### PR TITLE
Fix Android build, various fixes and added new features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,15 @@ else ifeq ($(platform), osx)
    fpic := -fPIC -mmacosx-version-min=10.6
    SHARED := -dynamiclib
    PLATFLAGS +=  -DRETRO -DLSB_FIRST -DALIGN_DWORD
+else ifeq ($(platform), android-armv7)
+   CC = arm-linux-androideabi-gcc
+   AR = @arm-linux-androideabi-ar
+   LD = @arm-linux-androideabi-g++ 
+   TARGET := $(TARGET_NAME)_libretro_android.so
+   fpic := -fPIC
+	LDFLAGS := -lz -lm
+   SHARED :=  -Wl,--fix-cortex-a8 -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
+   PLATFLAGS += -DANDROID -DRETRO -DAND -DLSB_FIRST -DALIGN_DWORD -DANDPORT -DA_ZIP
 else ifeq ($(platform), android)
    CC = arm-linux-androideabi-gcc
    AR = @arm-linux-androideabi-ar
@@ -110,6 +119,9 @@ $(TARGET): $(OBJECTS)
 	$(AR) rcs $@ $(OBJECTS) 
 
 else ifeq ($(platform), win)
+$(TARGET): $(OBJECTS)
+	$(CC) $(fpic) $(SHARED) $(INCDIRS) -o $@ $(OBJECTS) $(LDFLAGS)
+else ifeq ($(platform), android-armv7)
 $(TARGET): $(OBJECTS)
 	$(CC) $(fpic) $(SHARED) $(INCDIRS) -o $@ $(OBJECTS) $(LDFLAGS)
 else

--- a/README
+++ b/README
@@ -62,6 +62,7 @@ Recommended settings and information for Raspberry Pi 2:
   - use CPU type 68000 and kickstart 1.3 for stability
 	- set floppy speed to 1x speed to avoid sound stuttering when loading games
 	- 640x400 is suitable for widescreen gaming and fits perfectly for most games
+	- you can use the config settings gfx_width and gfx_height to specify resolution
 	- study the settings in the sample file "RickDangerous.uae"
 	- whdload does not work
 	- overall the core performs very well with adf files

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -33,7 +33,7 @@ int NPAGE=-1, KCOL=1, BKGCOLOR=0, MAXPAS=6;
 int SHIFTON=-1,MOUSEMODE=-1,NUMJOY=0,SHOWKEY=-1,PAS=2,STATUTON=-1;
 
 short signed int SNDBUF[1024*2];
-int snd_sampler = 44100 / 60;
+int snd_sampler = 44100 / 50;
 char RPATH[512];
 char DSKNAME[512];
 

--- a/sources/src/audio.c
+++ b/sources/src/audio.c
@@ -2044,7 +2044,6 @@ void led_filter_audio (void)
 
 void audio_vsync (void)
 {
-#if 0
 #if SOUNDSTUFF > 0
 	int max, min;
 	int vsync = isvsync ();
@@ -2075,7 +2074,6 @@ void audio_vsync (void)
 		extrasamples = 99;
 	if (extrasamples < -99)
 		extrasamples = -99;
-#endif
 #endif
 }
 

--- a/sources/src/gui-retro/sdlgui.h
+++ b/sources/src/gui-retro/sdlgui.h
@@ -16,8 +16,12 @@
 
 #include <stdbool.h>
 
+#ifdef ANDROID
+#define SDL_Delay GetTicks
+#else
 #define SDL_Delay GetTicks2
-
+#endif
+  
 enum
 {
   SGBOX,

--- a/sources/src/hardfile_unix.c
+++ b/sources/src/hardfile_unix.c
@@ -289,7 +289,7 @@ int hdf_open_target (struct hardfiledata *hfd, const char *pname)
 				write_log ("HDF '%s' re-opened in zfile-mode\n", name);
 				fclose (h);
 				hfd->handle->h = INVALID_HANDLE_VALUE;
-				hfd->handle->zf = zfile_fopen(name, /*hfd->readonly ? "rb" :*/ "r+b", ZFD_NORMAL);
+				hfd->handle->zf = zfile_fopen(name, /*hfd->readonly ? "rb" :*/ "rb", ZFD_NORMAL);
 				hfd->handle->zfile = 1;
 				if (!h)
 					goto end;

--- a/sources/src/sounddep/sound.c
+++ b/sources/src/sounddep/sound.c
@@ -45,7 +45,7 @@ unsigned long now_time;
 unsigned long stat_time;
 unsigned long stat_count;
 
-//static unsigned long scaled_sample_evtime;
+static unsigned long scaled_sample_evtime;
 /*
 void set_volume_sound_device (struct sound_data *sd, int volume, int mute)
 {
@@ -118,7 +118,7 @@ int init_sound (void)
 	return 1;
     }
 
-    int rate = 22500;
+    int rate = 44100;
     if (sound_initialized) {
 	return 1;
     }


### PR DESCRIPTION
List of fixes and new features:
- Fix android-armv7 build
- Set core to correct screen timing
- Enable perfect scrolling when running in 50Hz mode (the native Amiga refresh rate)
- Fix sound stuttering and enable 44100 hz samples
- Add "None" led option under core options
- Add config file options "gfx_width" and "gfx_height" which makes it possible for .uae config files to define the native screen resolution to use when launching
- Fix handling of compressed hdf files (hdz files)