### PR TITLE
Remove deprecated <sys/timeb.h>

### DIFF
--- a/sources/src/archivers/lha/header.c
+++ b/sources/src/archivers/lha/header.c
@@ -206,7 +206,18 @@ unix_to_generic_filename(char *name, int len)
 #endif
 
 #ifdef FTIME
-#include <sys/timeb.h>
+#include <sys/time.h>
+
+__BEGIN_DECLS
+
+struct timeb {
+    time_t          time;
+    unsigned short  millitm;
+    short           timezone;
+    short           dstflag;
+};
+
+extern int  ftime(struct timeb*  timebuf);
 #endif
 
 /*

--- a/sources/src/filesys_linux.c
+++ b/sources/src/filesys_linux.c
@@ -6,11 +6,20 @@
  * Copyright 2012-2013 Mustafa 'GnoStiC' Tufan
  */
 
-#ifndef __CELLOS_LV2__
-#include <sys/timeb.h>
-#endif
-#include <sys/timeb.h>
 #include "zfile.h"
+
+#include <sys/time.h>
+
+__BEGIN_DECLS
+
+struct timeb {
+    time_t          time;
+    unsigned short  millitm;
+    short           timezone;
+    short           dstflag;
+};
+
+extern int  ftime(struct timeb*  timebuf);
 
 typedef int BOOL;
 


### PR DESCRIPTION
<sys/timeb.h> has been deprecated since POSIX.1-2008 and since Android API 18.

This should fix build problems with the buildbot system.
