### PR TITLE
uae_sem_init(): Bad allocation size fix           (sem->sem = (sem_t*…

### DIFF
--- a/sources/src/threaddep/thread.c
+++ b/sources/src/threaddep/thread.c
@@ -193,7 +193,7 @@ int uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value)
 {
 	if (!sem || (sem && sem->sem))
 		return -1;
-	sem->sem = (sem_t*)calloc(0, sizeof(sem_t));
+	sem->sem = (sem_t*)calloc(1, sizeof(sem_t));
 	return sem_init (sem->sem, pshared, value);
 }
 


### PR DESCRIPTION
…)calloc(0, sizeof(sem_t)); -> sem->sem = (sem_t*)calloc(1, sizeof(sem_t));)

This issue generates the following valgrind event on my linux x86_64 system (and it crashes my arm thumb a7 linux setup too...):
==8668== Invalid write of size 8
==8668==    at 0x5E92AD9: sem_init@@GLIBC_2.2.5 (in /lib64/libpthread-2.24.so)
==8668==    by 0xBC9FF63: uae_sem_init (libretro-uae-20160530-r0-84287ade3b55eee1cf5315b9367b93fce5ec0795/sources/src/threaddep/thread.c:197)
...
==8668==  Address 0x14aca730 is 0 bytes after a block of size 0 alloc'd