### PR TITLE
Fix undefined symbol in debug build

### DIFF
--- a/gui-retro/zip.c
+++ b/gui-retro/zip.c
@@ -557,12 +557,12 @@ uint8_t *ZIP_ReadDisk(const char *pszFileName, const char *pszZipPath, long *pIm
 	}
 
 	switch(nDiskType) {
-	case ZIP_FILE_MSA:
+	/*case ZIP_FILE_MSA:*/
 		/* uncompress the MSA file */
-		pDiskBuffer = MSA_UnCompress(buf, (long *)&ImageSize);
+		/*pDiskBuffer = MSA_UnCompress(buf, (long *)&ImageSize);
 		free(buf);
 		buf = NULL;
-		break;
+		break;*/
 	case ZIP_FILE_DIM:
 		/* Skip DIM header */
 		ImageSize -= 32;


### PR DESCRIPTION
    $ ldd -r puae_libretro
    undefined symbol: MSA_UnCompress        (./puae_libretro.so)

ZIP_ReadDisk is not used and MSA detection is anyways commented out in line 351.