### PR TITLE
Fix build on linux

### DIFF
--- a/sources/src/archivers/lha/header.c
+++ b/sources/src/archivers/lha/header.c
@@ -208,8 +208,6 @@ unix_to_generic_filename(char *name, int len)
 #ifdef FTIME
 #include <sys/time.h>
 
-__BEGIN_DECLS
-
 struct timeb {
     time_t          time;
     unsigned short  millitm;

--- a/sources/src/filesys_linux.c
+++ b/sources/src/filesys_linux.c
@@ -11,10 +11,6 @@
 #include <sys/time.h>
 
 #ifdef FTIME
-#include <sys/time.h>
-
-__BEGIN_DECLS
-
 struct timeb {
     time_t          time;
     unsigned short  millitm;
@@ -22,7 +18,9 @@ struct timeb {
     short           dstflag;
 };
 
-extern int  ftime(struct timeb*  timebuf);
+extern int ftime(struct timeb*  timebuf);
+#else
+#include <sys/timeb.h>
 #endif
 
 


### PR DESCRIPTION
Since my fix of Windows build, libretro-puae could not build on Linux...

On linux we need to include <sys/timeb.h> when FTIME is not defined.
