### PR TITLE
Add IPF support through capsimg

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -25,6 +25,7 @@ SOURCES_C +=  $(EMU)/main.c \
 				  $(EMU)/inputrecord.c \
 				  $(EMU)/keymap/keymap.c\
 				  $(EMU)/diskutil.c \
+				  $(EMU)/caps/caps.c \
 				  $(EMU)/zfile.c \
 				  $(EMU)/zfile_archive.c \
 				  $(EMU)/cfgfile.c \
@@ -172,4 +173,4 @@ SOURCES_C += $(DEPS_DIR)/zlib/adler32.c \
 				 $(DEPS_DIR)/zlib/zutil.c
 endif
 
-CFLAGS += -DLIBRETRO_PUAE
+CFLAGS += -DLIBRETRO_PUAE -DCAPS


### PR DESCRIPTION
This compiles and links in the internal capsimg code. By default this tries to dlopen libcapsimage.so.2. Tested working with Frode Solheim's capsimg fork. I don't think there's any license issue as the capsimage code itself is external.