### PR TITLE
Minor changes

### DIFF
--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -406,7 +406,7 @@ void update_input(int disable_physical_cursor_keys)
             if(i > 0 && (i<4 || i>7) && i < 16) /* remappable retropad buttons (all apart from DPAD and B) */
             {
                 /* Skip the vkbd extra buttons if vkbd is visible */
-                if(SHOWKEY==1 && i==RETRO_DEVICE_ID_JOYPAD_A)
+                if(SHOWKEY==1 && (i==RETRO_DEVICE_ID_JOYPAD_A || i==RETRO_DEVICE_ID_JOYPAD_X))
                     continue;
 
                 if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && jbt[i]==0/* && i!=turbo_fire_button*/)
@@ -579,7 +579,7 @@ void update_input(int disable_physical_cursor_keys)
       virtual_kbd(bmp,vkx,vky);
 
       /* Position toggle */
-      i=RETRO_DEVICE_ID_JOYPAD_Y;
+      i=RETRO_DEVICE_ID_JOYPAD_X;
       if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[6]==0)
       {
          vkflag[6]=1;
@@ -591,7 +591,7 @@ void update_input(int disable_physical_cursor_keys)
          vkflag[6]=0;
       }
 
-      /* Transparenct toggle */
+      /* Transparency toggle */
       i=RETRO_DEVICE_ID_JOYPAD_A;
       if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[5]==0)
       {

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1841,8 +1841,8 @@ bool retro_load_game(const struct retro_game_info *info)
 					            printf("Disk (%d) inserted into drive DF%d: %s\n", dc->index+1, i, dc->files[dc->index]);
 					            fprintf(configfile, "floppy%d=%s\n", i, dc->files[i]);
 
-					            // By default only 2 drives are enabled, so floppyXtype needs to be set on the extra drives
-					            if(i > 1)
+					            // By default only DF0: is enabled, so floppyXtype needs to be set on the extra drives
+					            if(i > 0)
                                     fprintf(configfile, "floppy%dtype=%d\n", i, 0); // 0 = 3.5" DD
                             }
                             else

--- a/libretro/vkbd.c
+++ b/libretro/vkbd.c
@@ -64,6 +64,9 @@ void virtual_kbd(unsigned short int *pixels,int vx,int vy)
    };
    int alt_keys_len = sizeof(alt_keys)/sizeof(alt_keys[0]);
 
+   if(SHOWKEYTRANS==1)
+       BKG_COLOR_BORDER = RGB565(8, 8, 8);
+
    for(x=0;x<NPLGN;x++)
    {
       for(y=0;y<NLIGN;y++)

--- a/sources/src/cfgfile.c
+++ b/sources/src/cfgfile.c
@@ -4914,10 +4914,10 @@ void default_prefs (struct uae_prefs *p, int type)
 	p->custom_memory_sizes[1] = 0;
 	p->fastmem_autoconfig = true;
 
-	p->nr_floppies = 2;
+	p->nr_floppies = 1;
 	p->floppy_read_only = false;
 	p->floppyslots[0].dfxtype = DRV_35_DD;
-	p->floppyslots[1].dfxtype = DRV_35_DD;
+	p->floppyslots[1].dfxtype = DRV_NONE;
 	p->floppyslots[2].dfxtype = DRV_NONE;
 	p->floppyslots[3].dfxtype = DRV_NONE;
 	p->floppy_speed = 100;


### PR DESCRIPTION
Now I promise this is the last one for today, heh.

Reason for the floppy fix was that I launched Push Over and noticed it always clicks the extra drive during gameplay for absolutely no reason, as it does not even use it for the second disk. Sure I could disable the sound emulation completely, but..