### PR TITLE
Dynamic PAL/NTSC switching

### DIFF
--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -18,7 +18,7 @@
 extern cothread_t mainThread;
 extern cothread_t emuThread;
 
-void retro_update_geometry(bool);
+bool retro_update_av_info(bool, bool, bool);
 
 #define LOGI printf
 

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -1,5 +1,5 @@
-#ifndef LIBRETRO_HATARI_H
-#define LIBRETRO_HATARI_H
+#ifndef LIBRETRO_GLUE_H
+#define LIBRETRO_GLUE_H
 
 #include <stdint.h>
 #include <string.h>

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -18,6 +18,7 @@
 extern cothread_t mainThread;
 extern cothread_t emuThread;
 
+void retro_update_geometry(bool);
 
 #define LOGI printf
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -183,22 +183,6 @@ return (cpu_features_get_time_usec())/1000;
 
 } 
 
-void gui_poll_events(void)
-{
-   //NO SURE FIND BETTER WAY TO COME BACK IN MAIN THREAD IN HATARI GUI
-
-   Ktime = GetTicks();
-
-   if(Ktime - LastFPSTime >= 1000/50)
-   {
-      slowdown=0;
-      frame++; 
-      LastFPSTime = Ktime;		
-      co_switch(mainThread);
-      //retro_run();
-   }
-}
-
 void Print_Status(void)
 {
    if (!opt_enhanced_statusbar)

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -55,6 +55,7 @@ int touch=-1; // gui mouse btn
 int fmousex,fmousey; // emu mouse
 int slowdown=0;
 extern int pix_bytes;
+extern int fake_ntsc;
 
 int vkflag[7]={0,0,0,0,0,0,0};
 static int jbt[24]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
@@ -118,6 +119,7 @@ void emu_function(int function) {
          break;
       case EMU_RESET:
          uae_reset(0, 1); /* hardreset, keyboardreset */
+         fake_ntsc=false;
          break;
    }
 }

--- a/libretro/libretro-mapper.h
+++ b/libretro/libretro-mapper.h
@@ -1,5 +1,4 @@
 void Screen_SetFullUpdate(void);
-void gui_poll_events(void);
 
 #define RETRO_DEVICE_UAE_JOYSTICK         RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 0)
 #define RETRO_DEVICE_UAE_CD32PAD          RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 1)

--- a/sources/src/custom.c
+++ b/sources/src/custom.c
@@ -3222,7 +3222,7 @@ void compute_framesync (void)
 	);
 
 #ifdef __LIBRETRO__
-	retro_update_geometry(isntsc);
+	retro_update_av_info(1, 1, isntsc);
 #endif
 
 	config_changed = 1;

--- a/sources/src/custom.c
+++ b/sources/src/custom.c
@@ -75,6 +75,10 @@
 #include <features_cpu.h>
 #endif
 
+#ifdef __LIBRETRO__
+#include "libretro-glue.h"
+#endif
+
 /* internal prototypes */
 void uae_abort (const TCHAR *format,...);
 int is_bitplane_dma (int hpos);
@@ -3216,6 +3220,10 @@ void compute_framesync (void)
 		cr != NULL && cr->label != NULL ? cr->label : _T("<?>"),
 		currprefs.gfx_apmode[picasso_on ? 1 : 0].gfx_display, picasso_on, picasso_requested_on
 	);
+
+#ifdef __LIBRETRO__
+	retro_update_geometry(isntsc);
+#endif
 
 	config_changed = 1;
 }


### PR DESCRIPTION
Attempt at doing resolution and timing switching on the fly. It can be tested for example at Early Startup (hold LMB+RMB while booting A1200). Protracker also has a toggler.

If there is a way to achieve the same result without the desktop flashing, I'm all ears. I could not get the new timing to apply without using RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, and that causes the flash. Geometry alone updates nicely without the flash.

If nothing else helps then maybe a core option should be added to disable the Hz change but allow the geometry change.

This will fix the double statusbar issue with Dyna Blaster (if the statusbar is at the bottom), but because it uses a weird 60Hz PAL mode (but acts like normal NTSC on a real Amiga), and it keeps returning to PAL for a split second during loadings for zero reason, it needed some trickery.

Also found more unused GUI stuff for removal.
