### PR TITLE
Controller related updates

### DIFF
--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -40,7 +40,7 @@ void gettimeofday (struct timeval *tv, void *blah)
 unsigned short int bmp[1024*1024];
 unsigned short int savebmp[1024*1024];
 
-int NPAGE=-1,MAXPAS=8,PAS=4;
+int NPAGE=-1,PAS=4;
 int SHIFTON=-1,ALTON=-1;
 int MOUSEMODE=-1,SHOWKEY=-1,SHOWKEYPOS=-1,SHOWKEYTRANS=-1,STATUSON=-1,LEDON=-1;
 
@@ -50,6 +50,7 @@ int analog_left[2];
 int analog_right[2];
 extern int analog_deadzone;
 extern unsigned int analog_sensitivity;
+extern unsigned int opt_dpadmouse_speed;
 int fmousex,fmousey; // emu mouse
 int slowdown=0;
 extern int pix_bytes;
@@ -87,7 +88,8 @@ enum EMU_FUNCTIONS {
    EMU_VKBD = 0,
    EMU_STATUSBAR,
    EMU_MOUSE_TOGGLE,
-   EMU_MOUSE_SPEED,
+   EMU_MOUSE_SPEED_DOWN,
+   EMU_MOUSE_SPEED_UP,
    EMU_RESET,
    EMU_ASPECT_RATIO_TOGGLE,
    EMU_ZOOM_MODE_TOGGLE,
@@ -117,9 +119,25 @@ void emu_function(int function) {
       case EMU_MOUSE_TOGGLE:
          MOUSEMODE=-MOUSEMODE;
          break;
-      case EMU_MOUSE_SPEED:
-         PAS=PAS+2;
-         if(PAS>MAXPAS)PAS=2;
+      case EMU_MOUSE_SPEED_DOWN:
+         switch(PAS)
+         {
+            case 4:
+               PAS=8;
+               break;
+            case 6:
+               PAS=10;
+               break;
+            case 8:
+               PAS=4;
+               break;
+            case 10:
+               PAS=6;
+               break;
+         }
+         break;
+      case EMU_MOUSE_SPEED_UP:
+         PAS=opt_dpadmouse_speed;
          break;
       case EMU_RESET:
          uae_reset(0, 1); /* hardreset, keyboardreset */
@@ -627,7 +645,7 @@ void update_input(int disable_physical_cursor_keys)
                emu_function(EMU_MOUSE_TOGGLE);
                break;
             case 27:
-               emu_function(EMU_MOUSE_SPEED);
+               emu_function(EMU_MOUSE_SPEED_DOWN);
                break;
             case 28:
                emu_function(EMU_RESET);
@@ -652,6 +670,9 @@ void update_input(int disable_physical_cursor_keys)
                   retro_mouse_but0(1);
                   retro_mouse_but0(0);
                }
+               break;
+            case 27:
+               emu_function(EMU_MOUSE_SPEED_UP);
                break;
          }
       }
@@ -770,7 +791,7 @@ void update_input(int disable_physical_cursor_keys)
                 else if(mapper_keys[i] == mapper_keys[26]) /* Toggle mouse control */
                     emu_function(EMU_MOUSE_TOGGLE);
                 else if(mapper_keys[i] == mapper_keys[27]) /* Alter mouse speed */
-                    emu_function(EMU_MOUSE_SPEED);
+                    emu_function(EMU_MOUSE_SPEED_DOWN);
                 else if(mapper_keys[i] == mapper_keys[28]) /* Reset */
                     emu_function(EMU_RESET);
                 else if(mapper_keys[i] == mapper_keys[29]) /* Toggle aspect ratio */
@@ -799,7 +820,7 @@ void update_input(int disable_physical_cursor_keys)
                 else if(mapper_keys[i] == mapper_keys[26])
                     ; /* nop */
                 else if(mapper_keys[i] == mapper_keys[27])
-                    ; /* nop */
+                    emu_function(EMU_MOUSE_SPEED_UP);
                 else if(mapper_keys[i] == mapper_keys[28])
                     ; /* nop */
                 else if(mapper_keys[i] == mapper_keys[29])

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -50,8 +50,6 @@ int analog_left[2];
 int analog_right[2];
 extern int analog_deadzone;
 extern unsigned int analog_sensitivity;
-unsigned long MXjoy[4]={0}; // joyports
-int touch=-1; // gui mouse btn
 int fmousex,fmousey; // emu mouse
 int slowdown=0;
 extern int pix_bytes;
@@ -59,12 +57,10 @@ extern bool fake_ntsc;
 extern bool real_ntsc;
 
 int vkflag[7]={0,0,0,0,0,0,0};
+static int jflag[4][16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+static int kflag[2][1]={0};
 static int jbt[24]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 static int kbt[16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-
-//   RETRO                    B     Y     SLT   STA   UP    DWN   LEFT  RGT   A     X     L     R     L2    R2    L3    R3
-//   INDEX                    0     1     2     3     4     5     6     7     8     9     10    11    12    13    14    15
-static unsigned long vbt[16]={0x020,0x200,0x080,0x100,0x001,0x002,0x004,0x008,0x010,0x040,0x400,0x800};
 
 extern void reset_drawing(void);
 extern void retro_key_up(int);
@@ -72,7 +68,6 @@ extern void retro_key_down(int);
 extern void retro_mouse(int, int);
 extern void retro_mouse_but0(int);
 extern void retro_mouse_but1(int);
-extern void retro_joy(unsigned int, unsigned long);
 extern unsigned int uae_devices[4];
 extern int mapper_keys[31];
 extern int video_config;
@@ -257,7 +252,7 @@ void Screen_SetFullUpdate(void)
    reset_drawing();
 }
 
-void Process_Keyrah()
+void ProcessKeyrah()
 {
    /*** Port 2 ***/
 
@@ -271,7 +266,7 @@ void Process_Keyrah()
          setjoystickstate(0, 1, 1, 1);
    else
    if (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) &&
-       !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))
+       !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) )
          setjoystickstate(0, 1, 0, 1);
 
    /* Left / Right */
@@ -288,11 +283,17 @@ void Process_Keyrah()
          setjoystickstate(0, 0, 0, 1);
 
    /* Fire */
-   if ( input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP5))
+   if ( input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP5) && kflag[0][0]==0)
+   {
       setjoybuttonstate(0, 0, 1);
+      kflag[0][0]=1;
+   }
    else
-   if (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B))
+   if (!input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP5) && kflag[0][0]==1)
+   {
       setjoybuttonstate(0, 0, 0);
+      kflag[0][0]=0;
+   }
 
 
    /*** Port 1 ***/
@@ -323,14 +324,180 @@ void Process_Keyrah()
          setjoystickstate(1, 0, 0, 1);
 
    /* Fire */
-   if ( input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP0))
+   if ( input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP0) && kflag[1][0]==0)
+   {
       setjoybuttonstate(1, 0, 1);
+      kflag[1][0]=1;
+   }
    else
-   if (!input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B))
+   if (!input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP0) && kflag[1][0]==1)
+   {
       setjoybuttonstate(1, 0, 0);
+      kflag[1][0]=0;
+   }
 }
 
-void Process_key(int disable_physical_cursor_keys)
+int retro_button_to_uae_button(int i)
+{
+   int uae_button = -1;
+   switch(i)
+   {
+      case RETRO_DEVICE_ID_JOYPAD_B:
+         uae_button = 0;
+         break;
+      case RETRO_DEVICE_ID_JOYPAD_A:
+         uae_button = 1;
+         break;
+      case RETRO_DEVICE_ID_JOYPAD_Y:
+         uae_button = 2;
+         break;
+      case RETRO_DEVICE_ID_JOYPAD_X:
+         uae_button = 3;
+         break;
+      case RETRO_DEVICE_ID_JOYPAD_L:
+         uae_button = 4;
+         break;
+      case RETRO_DEVICE_ID_JOYPAD_R:
+         uae_button = 5;
+         break;
+      case RETRO_DEVICE_ID_JOYPAD_START:
+         uae_button = 6;
+         break;
+   }
+   return uae_button;
+}
+
+void ProcessController(int retro_port, int i)
+{
+   int uae_button = -1;
+
+   if(i>3 && i<8) // Directions, need to fight around presses on the same axis
+   {
+      if(i==RETRO_DEVICE_ID_JOYPAD_UP || i==RETRO_DEVICE_ID_JOYPAD_DOWN)
+      {
+         if(i==RETRO_DEVICE_ID_JOYPAD_UP && SHOWKEY==-1)
+         {
+            if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) )
+            {
+               setjoystickstate(retro_port, 1, -1, 1);
+               jflag[retro_port][i]=1;
+            }
+         }
+         else if(i==RETRO_DEVICE_ID_JOYPAD_DOWN && SHOWKEY==-1)
+         {
+            if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )
+            {
+               setjoystickstate(retro_port, 1, 1, 1);
+               jflag[retro_port][i]=1;
+            }
+         }
+
+         if(!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP)
+         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_UP]==1)
+         {
+            setjoystickstate(retro_port, 1, 0, 1);
+            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_UP]=0;
+         }
+         else if(!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN)
+         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_DOWN]==1)
+         {
+            setjoystickstate(retro_port, 1, 0, 1);
+            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_DOWN]=0;
+         }
+      }
+
+      if(i==RETRO_DEVICE_ID_JOYPAD_LEFT || i==RETRO_DEVICE_ID_JOYPAD_RIGHT)
+      {
+         if(i==RETRO_DEVICE_ID_JOYPAD_LEFT && SHOWKEY==-1)
+         {
+            if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) )
+            {
+               setjoystickstate(retro_port, 0, -1, 1);
+               jflag[retro_port][i]=1;
+            }
+         }
+         else if(i==RETRO_DEVICE_ID_JOYPAD_RIGHT && SHOWKEY==-1)
+         {
+            if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) )
+            {
+               setjoystickstate(retro_port, 0, 1, 1);
+               jflag[retro_port][i]=1;
+            }
+         }
+
+         if(!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT)
+         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_LEFT]==1)
+         {
+            setjoystickstate(retro_port, 0, 0, 1);
+            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_LEFT]=0;
+         }
+         if(!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
+         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_RIGHT]==1)
+         {
+            setjoystickstate(retro_port, 0, 0, 1);
+            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_RIGHT]=0;
+         }
+      }
+   }
+   else if(i != turbo_fire_button) // Buttons
+   {
+      uae_button = retro_button_to_uae_button(i);
+      if(uae_button != -1)
+      {
+         if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port][i]==0 && SHOWKEY==-1)
+         {
+            setjoybuttonstate(retro_port, uae_button, 1);
+            jflag[retro_port][i]=1;
+         }
+         else
+         if(!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port][i]==1)
+         {
+            setjoybuttonstate(retro_port, uae_button, 0);
+            jflag[retro_port][i]=0;
+         }
+      }
+   }
+}
+
+void ProcessTurbofire(int retro_port, int i)
+{
+   if(turbo_fire_button != -1 && i == turbo_fire_button)
+   {
+      if(input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button))
+      {
+         if(turbo_state[retro_port])
+         {
+            if((turbo_toggle[retro_port]) == (turbo_pulse))
+               turbo_toggle[retro_port] = 1;
+            else
+               turbo_toggle[retro_port]++;
+
+            if(turbo_toggle[retro_port] > (turbo_pulse / 2))
+               setjoybuttonstate(retro_port, 0, 0);
+            else
+               setjoybuttonstate(retro_port, 0, 1);
+         }
+         else
+         {
+            turbo_state[retro_port] = 1;
+            setjoybuttonstate(retro_port, 0, 1);
+         }
+      }
+      else if(!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button) && turbo_state[retro_port]==1)
+      {
+         turbo_state[retro_port] = 0;
+         turbo_toggle[retro_port] = 1;
+         setjoybuttonstate(retro_port, 0, 0);
+      }
+   }
+}
+
+
+void ProcessKey(int disable_physical_cursor_keys)
 {
    int i;
    for(i=0;i<320;i++)
@@ -417,6 +584,9 @@ void Process_key(int disable_physical_cursor_keys)
 
 void update_input(int disable_physical_cursor_keys)
 {
+// RETRO    B   Y   SLT STA UP  DWN LFT RGT A   X   L   R   L2  R2  L3  R3  LR  LL  LD  LU  RR  RL  RD  RU
+// INDEX    0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15  16  17  18  19  20  21  22  23
+
    int i, mk;
 
    static int oldi=-1;
@@ -490,7 +660,7 @@ void update_input(int disable_physical_cursor_keys)
    
 
    /* The check for kbt[i] here prevents the hotkey from generating key events */
-   /* SHOWKEY check is now in Process_key to allow certain keys while SHOWKEY */
+   /* SHOWKEY check is now in ProcessKey to allow certain keys while SHOWKEY */
    int processkey=1;
    for(i = 0; i < (sizeof(kbt)/sizeof(kbt[0])); i++) {
       if(kbt[i] == 1)
@@ -500,11 +670,11 @@ void update_input(int disable_physical_cursor_keys)
       }
    }
 
-   if (processkey) 
-      Process_key(disable_physical_cursor_keys);
+   if (processkey && disable_physical_cursor_keys != 2)
+      ProcessKey(disable_physical_cursor_keys);
 
    if (opt_keyrahkeypad)
-      Process_Keyrah();
+      ProcessKeyrah();
 
    /* RetroPad hotkeys */
    if (uae_devices[0] == RETRO_DEVICE_JOYPAD) {
@@ -784,29 +954,34 @@ void update_input(int disable_physical_cursor_keys)
 
 void retro_poll_event()
 {
-   /* if user plays with cursor keys, then prevent up/down/left/right from generating keyboard key presses */
-   if (
+   /* If RetroPad is controlled with keyboard keys, then prevent up/down/left/right/fire/fire2 from generating keyboard key presses */
+   if (uae_devices[0] == RETRO_DEVICE_JOYPAD && ALTON==-1 && 
+      (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) ||
+       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A)
+       )
+   )
+      update_input(2); /* Skip all keyboard input when fire/fire2 is pressed */
+   else if (
       (uae_devices[0] == RETRO_DEVICE_JOYPAD) && ALTON==-1 &&
       (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
        input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
        input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
+       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
+       )
    )
       update_input(1); /* Process all inputs but disable cursor keys */
    else
       update_input(0); /* Process all inputs */
 
-   //if(SHOWKEY==-1) /* retro joypad take control over keyboard joy */
+   if (ALTON==-1) /* retro joypad take control over keyboard joy */
    /* override keydown, but allow keyup, to prevent key sticking during keyboard use, if held down on opening keyboard */
    /* keyup allowing most likely not needed on actual keyboard presses even though they get stuck also */
-   if (ALTON==-1)
    {
       static int mbL=0,mbR=0;
-      int16_t mouse_x;
-      int16_t mouse_y;
-      int mouse_l;
-      int mouse_r;
-      int i;
+      int16_t mouse_x=0,mouse_y=0;
+      int mouse_l=0;
+      int mouse_r=0;
+      int i=0;
 
       int retro_port;
       for (retro_port = 0; retro_port <= 3; retro_port++)
@@ -814,151 +989,39 @@ void retro_poll_event()
          switch(uae_devices[retro_port])
          {
             case RETRO_DEVICE_JOYPAD:
-               // Joystick control (user 0 disabled if MOUSEMODE is on)
-               if(MOUSEMODE==-1 || retro_port != 0) {
-                  MXjoy[retro_port]=0;
-                  if(SHOWKEY==-1)
-                     for (i=0;i<23;i++)
-                     {
-                        if(i==0 || (i>3 && i<9)) // Dpad + B + A
-                        {
-                           // Need to fight around presses on the same axis
-                           if(i>3 && i<8)
-                           {
-                              if(i==RETRO_DEVICE_ID_JOYPAD_UP)
-                              {
-                                    if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) )
-                                       MXjoy[retro_port] |= vbt[i];
-                              }
-                              else if(i==RETRO_DEVICE_ID_JOYPAD_DOWN)
-                              {
-                                    if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )
-                                       MXjoy[retro_port] |= vbt[i];
-                              }
+               // RetroPad control (user 0 disabled if MOUSEMODE is on)
+               if(MOUSEMODE==1 && retro_port==0)
+                  break;
 
-                              if(i==RETRO_DEVICE_ID_JOYPAD_LEFT)
-                              {
-                                    if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) )
-                                       MXjoy[retro_port] |= vbt[i];
-                              }
-                              else if(i==RETRO_DEVICE_ID_JOYPAD_RIGHT)
-                              {
-                                    if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) )
-                                       MXjoy[retro_port] |= vbt[i];
-                              }
-                           }
-                           else if(i!=turbo_fire_button)
-                           {
-                                 if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) )
-                                    MXjoy[retro_port] |= vbt[i];
-                           }
-                        }
-
-                        /* Turbo fire */
-                        if(turbo_fire_button != -1 && i==turbo_fire_button) {
-                            if(input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button)) {
-                                if(turbo_state[retro_port]) {
-                                    if((turbo_toggle[retro_port]) == (turbo_pulse))
-                                        turbo_toggle[retro_port] = 1;
-                                    else
-                                        turbo_toggle[retro_port]++;
-
-                                    if(turbo_toggle[retro_port] > (turbo_pulse / 2))
-                                        setjoybuttonstate(retro_port, 0, 0);
-                                    else
-                                        setjoybuttonstate(retro_port, 0, 1);
-                                } else {
-                                    turbo_state[retro_port] = 1;
-                                    setjoybuttonstate(retro_port, 0, 1);
-                                }
-                            } else {
-                                turbo_state[retro_port] = 0;
-                                turbo_toggle[retro_port] = 1;
-                            }
-                        }
-                     }
-
-                  retro_joy(retro_port, MXjoy[retro_port]);
+               for (i=0;i<16;i++) // All buttons
+               {
+                  if(i==0 || (i>3 && i<9)) // DPAD + B + A
+                  {
+                     ProcessController(retro_port, i);
+                  }
+                  ProcessTurbofire(retro_port, i);
                }
                break;
 
             case RETRO_DEVICE_UAE_CD32PAD:
-               MXjoy[retro_port]=0;
-                  for (i=0;i<12;i++)
-                     if(i<2 || (i>2 && i<12)) // Skip select button
-                        // Need to fight around presses on the same axis
-                        if(i>3 && i<8)
-                        {
-                           if(i==RETRO_DEVICE_ID_JOYPAD_UP)
-                           {
-                              if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) )
-                                 MXjoy[retro_port] |= vbt[i];
-                           }
-                           else if(i==RETRO_DEVICE_ID_JOYPAD_DOWN)
-                           {
-                              if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )
-                                 MXjoy[retro_port] |= vbt[i];
-                           }
-
-                           if(i==RETRO_DEVICE_ID_JOYPAD_LEFT)
-                           {
-                              if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) )
-                                 MXjoy[retro_port] |= vbt[i];
-                           }
-                           else if(i==RETRO_DEVICE_ID_JOYPAD_RIGHT)
-                           {
-                              if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) )
-                                 MXjoy[retro_port] |= vbt[i];
-                           }
-                       }
-                       else
-                       {
-                           if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) )
-                           {
-                              MXjoy[retro_port] |= vbt[i];
-                           }
-                       }
-
-               retro_joy(retro_port, MXjoy[retro_port]);
+               for (i=0;i<16;i++) // All buttons
+               {
+                  if(i<2 || (i>2 && i<12)) // Only skip Select (2)
+                  {
+                     ProcessController(retro_port, i);
+                  }
+                  ProcessTurbofire(retro_port, i);
+               }
                break;
 
             case RETRO_DEVICE_UAE_JOYSTICK:
-               MXjoy[retro_port]=0;
-               if(SHOWKEY==-1)
-                  for (i=0;i<9;i++)
-                     if(i==0 || (i>3 && i<9))
-                        // Need to fight around presses on the same axis
-                        if(i>3 && i<8)
-                        {
-                           if(i==RETRO_DEVICE_ID_JOYPAD_UP)
-                           {
-                                 if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) )
-                                    MXjoy[retro_port] |= vbt[i];
-                           }
-                           else if(i==RETRO_DEVICE_ID_JOYPAD_DOWN)
-                           {
-                                 if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )
-                                    MXjoy[retro_port] |= vbt[i];
-                           }
-
-                           if(i==RETRO_DEVICE_ID_JOYPAD_LEFT)
-                           {
-                                 if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) )
-                                    MXjoy[retro_port] |= vbt[i];
-                           }
-                           else if(i==RETRO_DEVICE_ID_JOYPAD_RIGHT)
-                           {
-                                 if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) )
-                                    MXjoy[retro_port] |= vbt[i];
-                           }
-                        }
-                        else
-                        {
-                           if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) )
-                              MXjoy[retro_port] |= vbt[i];
-                        }
-
-               retro_joy(retro_port, MXjoy[retro_port]);
+               for (i=0;i<9;i++) // All buttons up to A
+               {
+                  if(i==0 || (i>3 && i<9)) // DPAD + B + A
+                  {
+                     ProcessController(retro_port, i);
+                  }
+               }
                break;
          }
       }
@@ -969,20 +1032,23 @@ void retro_poll_event()
          mouse_l=mouse_r=0;
          fmousex=fmousey=0;
 
-         if(MOUSEMODE==1 && uae_devices[0] == RETRO_DEVICE_JOYPAD) {
-            // Joypad buttons
+         // Joypad buttons
+         if(MOUSEMODE==1 && uae_devices[0] == RETRO_DEVICE_JOYPAD)
+         {
             mouse_l = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
             mouse_r = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
          }
 
-         if(!mouse_l && !mouse_r) {
-            // Mouse buttons
+         // Real mouse buttons
+         if(!mouse_l && !mouse_r)
+         {
             mouse_l = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
             mouse_r = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
          }
 
-         if(MOUSEMODE==1 && uae_devices[0] == RETRO_DEVICE_JOYPAD) {
-            // D-pad
+         // Joypad movement
+         if(MOUSEMODE==1 && uae_devices[0] == RETRO_DEVICE_JOYPAD)
+         {
             if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
                fmousex += PAS;
             if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))
@@ -993,50 +1059,56 @@ void retro_poll_event()
                fmousey -= PAS;
          }
 
+         // Left analog movement
          if(opt_analogmouse == 1 || opt_analogmouse == 3) 
-             if(!fmousex && !fmousey && (!mapper_keys[16] && !mapper_keys[17] && !mapper_keys[18] && !mapper_keys[19])) {
-                // Left Analog
-                analog_left[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X));
-                analog_left[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y));
+            // No keymappings and mousing at the same time
+            if(!fmousex && !fmousey && (!mapper_keys[16] && !mapper_keys[17] && !mapper_keys[18] && !mapper_keys[19]))
+            {
+               analog_left[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X));
+               analog_left[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y));
 
-                if(analog_left[0]<=-analog_deadzone)
-                   fmousex-=(-analog_left[0])/analog_sensitivity;
-                if(analog_left[0]>= analog_deadzone)
-                   fmousex+=( analog_left[0])/analog_sensitivity;
-                if(analog_left[1]<=-analog_deadzone)
-                   fmousey-=(-analog_left[1])/analog_sensitivity;
-                if(analog_left[1]>= analog_deadzone)
-                   fmousey+=( analog_left[1])/analog_sensitivity;
-         }
+               if(analog_left[0]<=-analog_deadzone)
+                  fmousex-=(-analog_left[0])/analog_sensitivity;
+               if(analog_left[0]>= analog_deadzone)
+                  fmousex+=( analog_left[0])/analog_sensitivity;
+               if(analog_left[1]<=-analog_deadzone)
+                  fmousey-=(-analog_left[1])/analog_sensitivity;
+               if(analog_left[1]>= analog_deadzone)
+                  fmousey+=( analog_left[1])/analog_sensitivity;
+            }
 
+         // Right analog movement
          if(opt_analogmouse == 2 || opt_analogmouse == 3)
-             // No keymappings and mousing at the same time
-             if(!fmousex && !fmousey && (!mapper_keys[20] && !mapper_keys[21] && !mapper_keys[22] && !mapper_keys[23])) {
-                // Right Analog
-                analog_right[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X));
-                analog_right[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y));
+            // No keymappings and mousing at the same time
+            if(!fmousex && !fmousey && (!mapper_keys[20] && !mapper_keys[21] && !mapper_keys[22] && !mapper_keys[23]))
+            {
+               analog_right[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X));
+               analog_right[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y));
 
-                if(analog_right[0]<=-analog_deadzone)
-                   fmousex-=(-analog_right[0])/analog_sensitivity;
-                if(analog_right[0]>= analog_deadzone)
-                   fmousex+=( analog_right[0])/analog_sensitivity;
-                if(analog_right[1]<=-analog_deadzone)
-                   fmousey-=(-analog_right[1])/analog_sensitivity;
-                if(analog_right[1]>= analog_deadzone)
-                   fmousey+=( analog_right[1])/analog_sensitivity;
-         }
+               if(analog_right[0]<=-analog_deadzone)
+                  fmousex-=(-analog_right[0])/analog_sensitivity;
+               if(analog_right[0]>= analog_deadzone)
+                  fmousex+=( analog_right[0])/analog_sensitivity;
+               if(analog_right[1]<=-analog_deadzone)
+                  fmousey-=(-analog_right[1])/analog_sensitivity;
+               if(analog_right[1]>= analog_deadzone)
+                  fmousey+=( analog_right[1])/analog_sensitivity;
+            }
 
-         if(!fmousex && !fmousey) {
-            // Real mouse
+         // Real mouse movement
+         if(!fmousex && !fmousey)
+         {
             mouse_x = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
             mouse_y = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
 
-            if(mouse_x || mouse_y) {
+            if(mouse_x || mouse_y)
+            {
                fmousex = mouse_x;
                fmousey = mouse_y;
             }
          }
 
+         // Mouse buttons to UAE
          if(mbL==0 && mouse_l)
          {
             mbL=1;
@@ -1059,6 +1131,7 @@ void retro_poll_event()
             mbR=0;
          }
 
+         // Mouse movement to UAE
          if(fmousex || fmousey)
             retro_mouse(fmousex, fmousey);
       }

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -217,6 +217,36 @@ return (cpu_features_get_time_usec())/1000;
 
 } 
 
+char* joystick_value_human(int val[16])
+{
+    static char str[4];
+    sprintf(str, "%3s", "   ");
+
+    if(val[RETRO_DEVICE_ID_JOYPAD_UP])
+        str[1] = '^';
+
+    if(val[RETRO_DEVICE_ID_JOYPAD_DOWN])
+        str[1] = 'v';
+
+    if(val[RETRO_DEVICE_ID_JOYPAD_LEFT])
+        str[0] = '<';
+
+    if(val[RETRO_DEVICE_ID_JOYPAD_RIGHT])
+        str[2] = '>';
+
+    if(val[RETRO_DEVICE_ID_JOYPAD_B])
+        str[1] = '1';
+
+    if(val[RETRO_DEVICE_ID_JOYPAD_A])
+        str[1] = '2';
+
+    if(val[RETRO_DEVICE_ID_JOYPAD_B] && val[RETRO_DEVICE_ID_JOYPAD_A])
+        str[1] = '3';
+
+    str[1] = (val[RETRO_DEVICE_ID_JOYPAD_B] || val[RETRO_DEVICE_ID_JOYPAD_A]) ? (str[1] | 0x80) : str[1];
+    return str;
+}
+
 void Print_Status(void)
 {
    if (!opt_enhanced_statusbar)
@@ -249,19 +279,56 @@ void Print_Status(void)
 
    BOX_Y=STAT_BASEY-BOX_PADDING;
 
+   char JOYPORT1[10];
+   sprintf(JOYPORT1, "J1%3s ", joystick_value_human(jflag[0]));
+   char JOYPORT2[10];
+   sprintf(JOYPORT2, "J2%3s ", joystick_value_human(jflag[1]));
+   char JOYPORT3[10];
+   sprintf(JOYPORT3, "J3%3s ", joystick_value_human(jflag[2]));
+   char JOYPORT4[10];
+   sprintf(JOYPORT4, "J4%3s ", joystick_value_human(jflag[3]));
+
+   char PASSTR[2];
+   switch(PAS) {
+      case 4:
+         PASSTR[0]='S';
+         break;
+      case 6:
+         PASSTR[0]='M';
+         break;
+      case 8:
+         PASSTR[0]='F';
+         break;
+      case 10:
+         PASSTR[0]='V';
+         break;
+   }
+
    if (pix_bytes == 4)
    {
       DrawFBoxBmp32((uint32_t *)bmp,0,BOX_Y,BOX_WIDTH,BOX_HEIGHT,RGB888(0,0,0));
-      Draw_text32((uint32_t *)bmp,STAT_DECX,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,((MOUSEMODE==-1) ? "Joystick" : "Mouse  "));
-      Draw_text32((uint32_t *)bmp,STAT_DECX+65,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,"MSpeed%d",PAS);
-      Draw_text32((uint32_t *)bmp,STAT_DECX+125,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,(SHIFTON>0 ? "CapsLock" : ""));
+
+      Draw_text32((uint32_t *)bmp,STAT_DECX+0,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT1);
+      Draw_text32((uint32_t *)bmp,STAT_DECX+40,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT2);
+      Draw_text32((uint32_t *)bmp,STAT_DECX+80,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT3);
+      Draw_text32((uint32_t *)bmp,STAT_DECX+120,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT4);
+
+      Draw_text32((uint32_t *)bmp,STAT_DECX+160,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,((MOUSEMODE==-1) ? "Joystick" : " Mouse "));
+      Draw_text32((uint32_t *)bmp,STAT_DECX+230,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,"MSpeed%s",PASSTR);
+      Draw_text32((uint32_t *)bmp,STAT_DECX+290,STAT_BASEY,0xffffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,(SHIFTON>0 ? "CapsLock" : ""));
    }
    else
    {
       DrawFBoxBmp(bmp,0,BOX_Y,BOX_WIDTH,BOX_HEIGHT,RGB565(0,0,0));
-      Draw_text(bmp,STAT_DECX,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,((MOUSEMODE==-1) ? "Joystick" : "Mouse  "));
-      Draw_text(bmp,STAT_DECX+65,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,"MSpeed%d",PAS);
-      Draw_text(bmp,STAT_DECX+125,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,(SHIFTON>0 ? "CapsLock" : ""));
+
+      Draw_text(bmp,STAT_DECX+0,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT1);
+      Draw_text(bmp,STAT_DECX+40,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT2);
+      Draw_text(bmp,STAT_DECX+80,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT3);
+      Draw_text(bmp,STAT_DECX+120,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,JOYPORT4);
+
+      Draw_text(bmp,STAT_DECX+160,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,((MOUSEMODE==-1) ? "Joystick" : " Mouse "));
+      Draw_text(bmp,STAT_DECX+230,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,20,"MSpeed%s",PASSTR);
+      Draw_text(bmp,STAT_DECX+290,STAT_BASEY,0xffff,0x0000,FONT_WIDTH,FONT_HEIGHT,40,(SHIFTON>0 ? "CapsLock" : ""));
    }
 }
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -39,6 +39,8 @@ bool opt_enhanced_statusbar = true;
 int opt_statusbar_position = 0;
 int opt_statusbar_position_old = 0;
 unsigned int opt_keyrahkeypad = 0;
+unsigned int opt_dpadmouse_speed = 4;
+extern int PAS;
 unsigned int opt_analogmouse = 0;
 int analog_deadzone = 6144;
 unsigned int analog_sensitivity = 2048;
@@ -617,7 +619,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "puae_analogmouse_deadzone",
-         "Analog deadzone",
+         "Analog mouse deadzone",
          "",
          {
             { "15", "15\%" },
@@ -634,7 +636,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "puae_analogmouse_sensitivity",
-         "Analog sensitivity",
+         "Analog mouse sensitivity",
          "",
          {
             { "1.0", "100\%" },
@@ -651,6 +653,19 @@ void retro_set_environment(retro_environment_t cb)
             { NULL, NULL },
          },
          "1.0"
+      },
+      {
+         "puae_dpadmouse_speed",
+         "D-Pad mouse speed",
+         "",
+         {
+            { "4", "Slow" },
+            { "6", "Medium" },
+            { "8", "Fast" },
+            { "10", "Very fast" },
+            { NULL, NULL },
+         },
+         "6"
       },
       {
          "puae_keyrah_keypad_mappings",
@@ -687,8 +702,8 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "puae_mapper_mouse_speed",
-         "Hotkey: Change mouse speed",
-         "Pressing a button mapped to this key alters the mouse speed",
+         "Hotkey: D-Pad mouse speed modifier",
+         "Pressing a button mapped to this key alters the mouse speed temporarily",
          {{ NULL, NULL }},
          "---"
       },
@@ -1429,6 +1444,15 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       analog_sensitivity = 2048 / atof(var.value);
+   }
+
+   var.key = "puae_dpadmouse_speed";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      opt_dpadmouse_speed = atoi(var.value);
+      PAS = opt_dpadmouse_speed;
    }
 
    var.key = "puae_keyrah_keypad_mappings";

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -29,8 +29,6 @@ extern unsigned int uae_devices[4];
 extern unsigned int inputdevice_finalized;
 extern int pix_bytes;
 
-#define TD_POSY 30
-
 #define LOG_MSG(...) 
 #define LOG_MSG2(...) 
 
@@ -51,7 +49,6 @@ void retro_audio_cb(short l, short r);
 
 int prefs_changed = 0;
 int vsync_enabled = 0;
-//int stat_count;
 int opt_scrw = 0;
 int opt_scrh = 0;
 unsigned long stat_value = 0;
@@ -65,7 +62,6 @@ int gui_init (void)
  * Handle target-specific cfgfile options
  */
 void target_save_options (struct zfile* f, struct uae_prefs *p)
-//void target_save_options (FILE *f, const struct uae_prefs *p)
 {
 }
 
@@ -78,188 +74,27 @@ void target_default_options (struct uae_prefs *p, int type)
 {
 }
 
-
+/* --- mouse input --- */
 void retro_mouse(int dx, int dy)
 {
-   changed_prefs.jports[0].id = JSEM_MICE;
-	setmousestate (0, 0, dx, 0);
+    changed_prefs.jports[0].id = JSEM_MICE;
+    setmousestate (0, 0, dx, 0);
     setmousestate (0, 1, dy, 0);
 }
 
 void retro_mouse_but0(int down)
 {
-   changed_prefs.jports[0].id = JSEM_MICE;
-	setmousebuttonstate (0, 0, down);
+    changed_prefs.jports[0].id = JSEM_MICE;
+    setmousebuttonstate (0, 0, down);
 }
 
 void retro_mouse_but1(int down)
 {
-   changed_prefs.jports[0].id = JSEM_MICE;
-	setmousebuttonstate (0, 1, down);
+    changed_prefs.jports[0].id = JSEM_MICE;
+    setmousebuttonstate (0, 1, down);
 }
-
-static unsigned int jflag[4][11]={0,0,0,0,0,0,0,0,0,0,0};
-
-void retro_joy(unsigned int port, unsigned long joy){
-// 0x001,0x002,0x004,0x008,0x010,0x020,0x040,0x200,0x400,0x800,0x100
-// UP    DWN   LFT   RGT   A  	 B     X     Y     L     R     STRT
-// 0     1     2     3     4     5     6     7     8     9     10
-// setjoybuttonstate(port, button, state)
-
-//if(joy!=0) printf("JOY: %d, PORT: %d\n", joy, port);
-
-	// B
-	if(joy&0x020){
-		if(jflag[port][4]==0){
-			setjoybuttonstate(port, 0, 1);
-			jflag[port][4]=1;
-		}
-	}else {
-		if(jflag[port][4]==1){
-			setjoybuttonstate(port, 0, 0);
-			jflag[port][4]=0;
-		}
-	}
-
-	// A
-	if(joy&0x010){
-		if(jflag[port][5]==0){
-			setjoybuttonstate(port, 1, 1);
-			jflag[port][5]=1;
-		}
-	}else {
-		if(jflag[port][5]==1){
-			setjoybuttonstate(port, 1, 0);
-			jflag[port][5]=0;
-		}
-	}
-
-	// Y
-	if(joy&0x200){
-		if(jflag[port][6]==0){
-			setjoybuttonstate(port, 2, 1);
-			jflag[port][6]=1;
-		}
-	}else {
-		if(jflag[port][6]==1){
-			setjoybuttonstate(port, 2, 0);
-			jflag[port][6]=0;
-		}
-	}
-
-	// X
-	if(joy&0x040){
-		if(jflag[port][7]==0){
-			setjoybuttonstate(port, 3, 1);
-			jflag[port][7]=1;
-		}
-	}else {
-		if(jflag[port][7]==1){
-			setjoybuttonstate(port, 3, 0);
-			jflag[port][7]=0;
-		}
-	}
-
-	// L
-	if(joy&0x400){
-		if(jflag[port][8]==0){
-			setjoybuttonstate(port, 4, 1);
-			jflag[port][8]=1;
-		}
-	}else {
-		if(jflag[port][8]==1){
-			setjoybuttonstate(port, 4, 0);
-			jflag[port][8]=0;
-		}
-	}
-
-	// R
-	if(joy&0x800){
-		if(jflag[port][9]==0){
-			setjoybuttonstate(port, 5, 1);
-			jflag[port][9]=1;
-		}
-	}else {
-		if(jflag[port][9]==1){
-			setjoybuttonstate(port, 5, 0);
-			jflag[port][9]=0;
-		}
-	}
-
-	// Start
-	if(joy&0x100){
-		if(jflag[port][10]==0){
-			setjoybuttonstate(port, 6, 1);
-			jflag[port][10]=1;
-		}
-	}else {
-		if(jflag[port][10]==1){
-			setjoybuttonstate(port, 6, 0);
-			jflag[port][10]=0;
-		}
-	}
-
-	// Up
-	if(joy&0x001){
-		if(jflag[port][0]==0){
-			setjoystickstate(port, 1, -1, 1);
-			jflag[port][0]=1;
-		}
-	}else {
-		if(jflag[port][0]==1){
-			setjoystickstate(port, 1, 0, 1);
-			jflag[port][0]=0;
-		}
-	}
-
-
-	// Down
-	if(joy&0x002){
-		if(jflag[port][1]==0){
-			setjoystickstate(port, 1, 1, 1);
-			jflag[port][1]=1;
-		}
-	}else {
-		if(jflag[port][1]==1){
-			setjoystickstate(port, 1, 0, 1);
-			jflag[port][1]=0;
-		}
-	}
-
-	// Left
-	if(joy&0x004){
-		if(jflag[port][2]==0){
-			setjoystickstate(port, 0, -1, 1);
-			jflag[port][2]=1;
-		}
-	}else {
-		if(jflag[port][2]==1){
-			setjoystickstate(port, 0, 0, 1);
-			jflag[port][2]=0;
-		}
-	}
-
-
-	// Right
-	if(joy&0x008){
-		if(jflag[port][3]==0){
-			setjoystickstate(port, 0, 1, 1);
-			jflag[port][3]=1;
-		}
-	}else {
-		if(jflag[port][3]==1){
-			setjoystickstate(port, 0, 0, 1);
-			jflag[port][3]=0;
-		}
-	}
-
-
-}
-
-/* cursor hiding */
 
 /* --- keyboard input --- */
-
 void retro_key_down(int key)
 {
 	inputdevice_do_keyboard (key, 1);
@@ -270,21 +105,19 @@ void retro_key_up(int key)
 	inputdevice_do_keyboard (key, 0);
 }
 
+
+
 int retro_renderSound(short* samples, int sampleCount)
 {
-   int i; 
+    int i;
 
-   if (sampleCount < 1)
-      return 0;
+    if (sampleCount < 1)
+        return 0;
 
-   for(i=0;i<sampleCount;i+=2)
-   {
-      retro_audio_cb( samples[i], samples[i+1]);
-   }
-}
-
-void ScreenUpdate ()
-{
+    for(i=0; i<sampleCount; i+=2)
+    {
+        retro_audio_cb(samples[i], samples[i+1]);
+    }
 }
 
 void retro_flush_screen (struct vidbuf_description *gfxinfo, int ystart, int yend)
@@ -297,20 +130,23 @@ void retro_flush_block (struct vidbuf_description *gfxinfo, int ystart, int yend
 {
 }
 
-void retro_flush_line (struct vidbuf_description *gfxinfo, int y) {
+void retro_flush_line (struct vidbuf_description *gfxinfo, int y)
+{
 }
 
-void retro_flush_clear_screen(struct vidbuf_description *gfxinfo) {
+void retro_flush_clear_screen(struct vidbuf_description *gfxinfo)
+{
 }
 
-
-int retro_lockscr(struct vidbuf_description *gfxinfo) {
-   return 1;
+int retro_lockscr(struct vidbuf_description *gfxinfo)
+{
+    return 1;
 }
 
-void retro_unlockscr(struct vidbuf_description *gfxinfo) {
-
+void retro_unlockscr(struct vidbuf_description *gfxinfo)
+{
 }
+
 
 
 int graphics_init(void) {
@@ -389,7 +225,8 @@ int mousehack_allowed (void)
     return 0;
 }
 
-int graphics_setup(void) {
+int graphics_setup(void)
+{
 	//32bit mode
 	//Rw, Gw, Bw,   Rs, Gs, Bs,   Aw, As, Avalue, swap
 	if (pix_bytes == 2)
@@ -400,35 +237,37 @@ int graphics_setup(void) {
 	return 1;
 }
 
-void graphics_leave(void) {
+void graphics_leave(void)
+{
 }
 
-
-void graphics_notify_state (int state) {
+void graphics_notify_state (int state)
+{
 }
 
-
-
-void gfx_save_options (FILE * f, const struct uae_prefs * p) {
+void gfx_save_options (FILE * f, const struct uae_prefs * p)
+{
 }
 
-int  gfx_parse_option (struct uae_prefs *p, const char *option, const char *value) {
-return 0;
+int gfx_parse_option (struct uae_prefs *p, const char *option, const char *value)
+{
+    return 0;
 }
 
-
-
-void gfx_default_options(struct uae_prefs *p) {
+void gfx_default_options(struct uae_prefs *p)
+{
 }
 
-void screenshot (int type,int f) {
-
+void screenshot (int type, int f)
+{
 }
 
-void toggle_fullscreen(int mode) {
+void toggle_fullscreen(int mode)
+{
 }
 
-int check_prefs_changed_gfx (void) {
+int check_prefs_changed_gfx (void)
+{
     if (prefs_changed)
         prefs_changed = 0;
     else
@@ -450,29 +289,14 @@ int check_prefs_changed_gfx (void) {
     return 0;
 }
 
-void clean_led_area(void) {
-/*
-    int size = 11 * opt_scrw * gfxvidinfo.pixbytes;
-    unsigned short int* addr;
-
-    addr = pixbuf;
-    addr+= (opt_scrh-11-TD_POSY)* opt_scrw;
-    memset(addr, 0, size);
-*/
-}
-
-
 
 /***************************************************************
   Joystick functions
 ****************************************************************/
 
-
 static int init_joysticks (void)
 {
-   LOG_MSG(("init_joysticks" ));
-
-   return 1;
+    return 1;
 }
 
 static void close_joysticks (void)
@@ -576,7 +400,6 @@ struct inputdevice_functions inputdevicefunc_joystick = {
 };
 
 int input_get_default_joystick (struct uae_input_device *uid, int num, int port, int af, int mode, bool gp)
-//void input_get_default_joystick (struct uae_input_device *uid)
 {
     if(uae_devices[0] == RETRO_DEVICE_UAE_CD32PAD)
     {
@@ -641,7 +464,6 @@ int input_get_default_joystick (struct uae_input_device *uid, int num, int port,
 /***************************************************************
   Mouse functions
 ****************************************************************/
-
 /*
  * Mouse inputdevice functions
  */
@@ -657,22 +479,22 @@ int input_get_default_joystick (struct uae_input_device *uid, int num, int port,
 
 static int init_mouse (void)
 {
-   return 1;
+    return 1;
 }
 
 static void close_mouse (void)
 {
-   return;
+    return;
 }
 
 static int acquire_mouse (int num, int flags)
 {
-   return 1;
+    return 1;
 }
 
 static void unacquire_mouse (int num)
 {
-   return;
+    return;
 }
 
 static int get_mouse_num (void)
@@ -727,7 +549,7 @@ static void read_mouse (void)
 
 static int get_mouse_flags (int num)
 {
-        return 0;
+    return 0;
 }
 
 struct inputdevice_functions inputdevicefunc_mouse = {
@@ -770,7 +592,6 @@ static int init_kb (void)
 
 static void close_kb (void)
 {
-	
 }
 
 static int acquire_kb (int num, int flags)
@@ -851,28 +672,30 @@ void setcapslockstate (int state)
     Misc fuctions
 *********************************************************************/
 
-int needmousehack(void) {
+int needmousehack(void)
+{
     return 0;
 }
 
-void toggle_mousegrab(void) {
+void toggle_mousegrab(void)
+{
 }
 
 /* handle pads in the "options" dialog */
-int handle_options_events() {
+int handle_options_events()
+{
 	return 0;
 }
 
-bool handle_events() {
- return 0;
-}
-
- void uae_pause (void)
+bool handle_events()
 {
-
+    return 0;
 }
- void uae_resume (void)
+
+void uae_pause (void)
 {
-	
 }
 
+void uae_resume (void)
+{
+}

--- a/sources/src/inputdevice.c
+++ b/sources/src/inputdevice.c
@@ -63,7 +63,7 @@ extern void master_sound_volume (int);
 extern void sound_mute (int);
 extern void sound_volume (int dir);
 extern uae_u32 uaerand (void);
-
+extern TCHAR *my_strdup_trim (const TCHAR *s);
 
 // 01 = host events
 // 02 = joystick
@@ -1609,7 +1609,7 @@ static void mousehack_helper (uae_u32 buttonmask)
 {
 #ifdef FILESYS /* Internal mousehack depends on filesys boot-rom */
 	int x, y;
-	float fdy, fdx, fmx, fmy;
+	int fdy, fdx, fmx, fmy;
 
 	if (currprefs.input_magic_mouse == 0 && currprefs.input_tablet < TABLET_MOUSEHACK)
 		return;
@@ -6715,7 +6715,7 @@ void setjoystickstate (int joy, int axis, int state, int max)
 	v1 = state;
 	v2 = id2->states[axis][MAX_INPUT_SUB_EVENT];
 
-	//write_log (_T("new=%d old=%d state=%d max=%d\n"), v1, v2, state, max);
+	//write_log (_T("new=%d old=%d axis=%d state=%d max=%d\n"), v1, v2, axis, state, max);
 
 	if (v1 < deadzone && v1 > -deadzone)
 		v1 = 0;


### PR DESCRIPTION
Had to bring some dynamite, because there was something wrong with the controls. Now it feels pretty much perfect. Please prove me wrong.

Changed the keyboard handling so the underlying keyboard key isn't pressed if using keyboard as RetroPad. For example in Turrican II the CTRL key pauses, and if CTRL key was the fire button, you're out of luck. And in Banshee the CTRL key also does the flip, so CTRL key as fire was no bueno. It can be overriden with the same Right Alt which overrides cursor keys without changing device type to keyboard.

Also changed the behavior of the D-Pad mouse speed toggler. Now it acts as a modifier which goes either faster or slower depending on the new core option starting point.

And again a little less compilation warnings.

And the bonus: Included joyport indicators to the statusbar, as seen in the VICE core.
