### PR TITLE
Assortment of minor goodies

### DIFF
--- a/README
+++ b/README
@@ -2,12 +2,11 @@
 
 
 
-based on P-UAE 2.6.1 https://github.com/GnoStiC/PUAE 
+based on P-UAE 2.6.1
 Git Commit: 0186c1b16f7181ffa02d73e6920d3180ce457c46
-
+Credits to Mustafa 'GnoStiC' TUFAN
 
 All credits to:
-
 Richard Drummond "http://www.rcdrummond.net/uae/"
 
 E-UAE is based on the work of dozens of contributors including Bernd
@@ -18,14 +17,7 @@ WinUAE), and many more.
 This RETRO port was based at start on PS3 version E-UAE 0.8.29-WIP4 release 8
 (so also credits to Ole.)
 
-For now we use the UEA core provide by P-UAE 2.6.1 :
-Git Commit: 0186c1b16f7181ffa02d73e6920d3180ce457c46
-https://github.com/GnoStiC/PUAE 
-
-Credits to Mustafa 'GnoStiC' TUFAN
-
-
-And of course for the RetroArch/Libretro team : "http://www.libretro.org/"
+And of course for the RetroArch/Libretro team: "http://www.libretro.org/"
 
 
 Default Control:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # P-UAE LIBRETRO
 
-Based on P-UAE 2.6.1 https://github.com/GnoStiC/PUAE 
-Git Commit: 0186c1b16f7181ffa02d73e6920d3180ce457c46
+Based on P-UAE 2.6.1, Git Commit: 0186c1b16f7181ffa02d73e6920d3180ce457c46, Credits to Mustafa 'GnoStiC' TUFAN
 
-All credits to:
-
-Richard Drummond "http://www.rcdrummond.net/uae/"
+All credits to: Richard Drummond "http://www.rcdrummond.net/uae/"
 
 E-UAE is based on the work of dozens of contributors including Bernd
 Schmidt (the original author and maintainer of UAE), Bernie Meyer (the
@@ -15,13 +12,7 @@ WinUAE), and many more.
 This RETRO port was  based at start on PS3 version E-UAE 0.8.29-WIP4 release 8
 (so also credits to Ole.)
 
-For now we use the UAE core provided by P-UAE 2.6.1:
-Git Commit: 0186c1b16f7181ffa02d73e6920d3180ce457c46
-https://github.com/GnoStiC/PUAE 
-
-Credits to Mustafa 'GnoStiC' TUFAN
-
-And of course for the RetroArch/Libretro team : "http://www.libretro.com/"
+And of course for the RetroArch/Libretro team: "http://www.libretro.com/"
 
 ## Default Controls
 
@@ -36,11 +27,12 @@ B   Button 1 / LMB
 You can pass a disk or a hard drive image as a rom.
 
 Supported formats are:
-- adf, dms, fdi, ipf, zip files for disk images
-- hdf, hdz for hard drive images
-- m3u for multiple disk images
+- **ADF**, **DMS**, **FDI**, **IPF** files for disk images
+- **HDF**, **HDZ** for hard drive images
+- **M3U** for multiple disk images
 
-When passing these files as parameter the core will generate a temporary uae configuration file in RetroArch saves directory and use it to automatically launch the game.
+When passing these files as a parameter the core will generate a temporary uae configuration file in RetroArch saves directory 
+and use it to launch the game.
 
 ### Configuration
 To generate the temporary uae configuration file the core will use the core options configured in RetroArch.
@@ -51,19 +43,19 @@ The following models are provided (hardcoded configuration):
 
 |Model|Description|
 |---|---|
-|A500|Amiga 500 with OCS chipset, 0.5MB of RAM and 0.5MB of slow memory expansion|
-|A500OG|Amiga 500 with OCS chipset, 0.5MB of RAM|
-|A500+|Amiga 500+ with ECS chipset, 1MB of RAM and 1MB of slow memory expansion|
-|A600|Amiga 600 with ECS chipset, 2MB of RAM and 8MB of fast memory expansion|
-|A1200|Amiga 1200 with AGA chipset, 2MB of RAM and 8MB of fast memory expansion|
-|A1200OG|Amiga 1200 with AGA chipset, 2MB of RAM|
+|A500|Amiga 500 with OCS chipset, 0.5MB Chip RAM + 0.5MB Slow RAM|
+|A500OG|Amiga 500 with OCS chipset, 0.5MB Chip RAM|
+|A500+|Amiga 500+ with ECS chipset, 1MB Chip RAM + 1MB Slow RAM|
+|A600|Amiga 600 with ECS chipset, 2MB Chip RAM + 8MB Fast RAM|
+|A1200|Amiga 1200 with AGA chipset, 2MB Chip RAM + 8MB Fast RAM|
+|A1200OG|Amiga 1200 with AGA chipset, 2MB Chip RAM|
 
 As the configuration file is only generated when launching a game you must restart RetroArch for the changes to take effects.
 
 ### Kickstarts roms
-To use disk and WHDLoad games with this core you'll need the following kickstart roms, rename them to the given name and copy the file to RetroArch system directory.
+To use disk and WHDLoad games with this core you'll need the following Kickstart roms, rename them to the given name and copy the file to RetroArch system directory.
 
-It is critical to use kickstarts with the right MD5, otherwise the core might not start.
+It is critical to use Kickstarts with the correct MD5, otherwise the core might not start.
 
 |Name|Description|System|MD5|
 |---|---|---|---|
@@ -98,56 +90,59 @@ Simpsons, The - Bart vs. The Space Mutants_Disk2.adf
 Path can be absolute or relative to the location of the M3U file.
 
 When a game ask for it, you can change the current disk in the RetroArch 'Disk Control' menu:
-- Eject the current disk with 'Disk Cycle Tray Status'.
-- Select the right disk index.
-- Insert the new disk with 'Disk Cycle Tray Status'.
+- Eject the current disk with 'Disk Cycle Tray Status'
+- Select the right disk index
+- Insert the new disk with 'Disk Cycle Tray Status'
 
-Note: ZIP support is provided by RetroArch and is done before passing the game to the core. So, when using a M3U file, the specified disk image must be uncompressed (adf, dms, fdi, ipf file formats).
+Note: ZIP support is provided by RetroArch and is done before passing the game to the core. So, when using a M3U file, the specified disk image must be uncompressed (ADF, DMS, FDI, IPF file formats).
 
-Append "(MD)" as in "MultiDrive" to the M3U filename to insert each disk in different drive for games that support multiple drives. Only possible if there are no more than 4 disks.
+Append "(MD)" as in "MultiDrive" to the M3U filename to insert each disk in a different drive for games that support multiple drives. Only possible if there are no more than 4 disks.
 
 ### WHDLoad
 To use WHDLoad games you'll need to have a prepared WHDLoad image named 'WHDLoad.hdf' in RetroArch system directory.
 
-In this WHDLoad image you must have the three kickstart roms (kick34005.A500, kick40063.A600, kick40068.A1200) in 'Dev/Kickstart' directory.
+In this WHDLoad image you must have the three Kickstart roms (kick34005.A500, kick40063.A600, kick40068.A1200) in 'Dev/Kickstart' directory.
 
 To do this, you can consult the excellent tutorial made by Allan Lindqvist (http://lindqvist.synology.me/wordpress/?page_id=182) just jump to the 'Create WHDLoad.hdf' section.
 
-The core only support HDD image files format (hdf and hdz) and slave file must be named 'game.Slave'. 
+The core only support HDD image files format (HDF and HDZ) and slave file must be named `game.slave`. 
 
-### Create a hdf file for a game 
-If you have a WHDLoad game in a zip or a directory, you will have to create an image file.
+### Create a HDF file for a game 
+If you have a WHDLoad game in a ZIP or a directory, you will have to create an image file.
 
 To do this you can use ADFOpus (http://adfopus.sourceforge.net/) or amitools (https://github.com/cnvogelg/amitools).
 
-Example, to create a hdf file from a zipped WHDLoad game :
-- Extract files from the zip to a directory.
-- Go to the directory where files were extracted.
-- Rename the main slave file (ending with '.Slave') to 'game.Slave' (certains games have many slave files, guess wich is the right one).
-- Pack the directory in a hdf file :
-	- Using ADFOpus (see [Allan Lindqvist's tutorial](http://lindqvist.synology.me/wordpress/?page_id=182)).
-	- Using amitools.
+Example, to create a HDF file from a zipped WHDLoad game:
+- Extract files from the ZIP to a directory
+- Go to the directory where files were extracted
+- Rename the main slave file (ending with '.slave') to 'game.slave' (certains games have many slave files, guess which is the right one)
+- Pack the directory in a HDF file:
+	- Using ADFOpus (see [Allan Lindqvist's tutorial](http://lindqvist.synology.me/wordpress/?page_id=182))
+	- Using amitools
 	
-The amitools command to use is :
+The amitools command to use is:
 ```
 xdftool -f <NAME_OF_HDF> pack <GAME_DIRECTORY> size=<SIZE_OF_HDF>
 ```
 
-Note the size of the HDF specified by SIZE_OF_HDF must be greater than size of the directory to store the additional filesystem informations (I use a 1.25 ratio).
+Note the size of the HDF specified by SIZE_OF_HDF must be greater than size of the directory to store the additional filesystem informations (f.ex a 1.25 ratio).
 
 ### Game that needs a specific Amiga model (AGA games for instance)
 If a game needs a specific Amiga model (AGA games for instance), you can specify which model to use.
 
-To do this just add these strings to your adf, hdf or m3u filename:
-- "(A500)" or "(OCS)" to use Amiga 500
-- "(A500OG)" or "(512K)" to use Amiga 500 without memory expansion
-- "(A500+)" or "(A500PLUS)" to use Amiga 500+
-- "(A600)" or "(ECS)" to use Amiga 600
-- "(A1200)" or "(AGA)" to use Amiga 1200
-- "(A1200OG)" or "(A1200NF)" to use Amiga 1200 without memory expansion
-- "(NTSC)" to use NTSC
-- "(PAL)" to use PAL
-- "(MD)" to insert each disk in different drive (Maximum 4 disks)
+To do this just add these strings to your ADF, HDF or M3U filename:
+
+|String|Result|
+|---|---|
+|(A500) or (OCS)|Amiga 500|
+|(A500OG) or (512K)|Amiga 500 without memory expansion|
+|(A500+) or (A500PLUS)|Amiga 500+|
+|(A600) or (ECS)|Amiga 600|
+|(A1200) or (AGA)|Amiga 1200|
+|(A1200OG) or (A1200NF)|Amiga 1200 without memory expansion|
+|(NTSC)|NTSC|
+|(PAL)|PAL|
+|(MD)|Insert each disk in a different drive (Maximum 4 disks)|
 
 Example: When launching "Alien Breed 2 (AGA).hdf" file the core will use an Amiga 1200 model.
 
@@ -167,7 +162,7 @@ A said in P-UAE configuration.txt:
 	display of 360 by 284 pixels.
 ```
 
-Three parameters control the output resolution of the core :
+Three parameters control the output resolution of the core:
 
 |Name|Values|Default|
 |---|---|---|
@@ -175,28 +170,29 @@ Three parameters control the output resolution of the core :
 |High resolution|false, true|true|
 |Crop overscan|false, true|false|
 
-With this settings all the standards resolutions of the amiga are available :
-- **360x284**: PAL Low resolution with overscan
-- **320x256**: PAL Low resolution cropped/clipped (without the "borders")
-- **360x240**: NTSC Low resolution with overscan
-- **320×200**: NTSC Low resolution cropped/clipped (without the "borders")
-- **720x568**: PAL High resolution with overscan
-- **640×512**: PAL High resolution cropped/clipped (without the "borders")
-- **720x480**: NTSC High resolution with overscan
-- **640×400**: NTSC High resolution cropped/clipped (without the "borders")
+With these settings all the standards resolutions of the amiga are available:
 
-When using a high resolution mode, rendering will be doubled horizontally and vertically for low res games. It's compatible with High res games and the Workbench but scaling shaders (ex: scalefx) will look ugly.
+- **720x568** PAL High resolution with overscan
+- **640×512** PAL High resolution cropped/clipped
+- **360x284** PAL Low resolution with overscan
+- **320x256** PAL Low resolution cropped/clipped
+- **720x480** NTSC High resolution with overscan
+- **640×400** NTSC High resolution cropped/clipped
+- **360x240** NTSC Low resolution with overscan
+- **320×200** NTSC Low resolution cropped/clipped
 
-When using a low resolution, scaling shaders (scalefx) looks greats but high res games and and the workbench are badly rendered (but still usable).
+When using a high resolution mode, rendering will be doubled horizontally and vertically. It's compatible with high resolution games and the Workbench but scaling shaders will look ugly.
+
+When using a low resolution mode, scaling shaders looks greats but high resolution games and the Workbench are badly rendered, but still usable.
 
 ## Using a configuration file for your games
-You can pass an '.uae' configuration file as a rom and the core will load the settings and start emulation without first showing the gui. 
+You can pass an '.uae' configuration file as a rom and the core will load the settings and start emulation. 
 
-Look at the sample configuration file "RickDangerous.uae" for help. You can use that sample as a starting point for making your own configuration files for each of your games.
+Look at the sample configuration file "RickDangerous.uae" for help. You can use that sample as a starting point for making your own configuration files.
 
-You can find the whole documentation in [configuration.txt](configuration.txt).
+You can find the whole documentation in [configuration.txt](configuration.txt). (Notice: many options are outdated and obsolete)
 
-Example 1: You want to mount four non-rdb .hdf files. You have one bootable 1000 MB file called `System.hdf` created with surfaces=1, and three non-bootable 2000 MB files called `WHDGamesA.hdf`, `WHDGamesB.hdf`, `WHDGamesC.hdf` created with surfaces=2. Your hdf files are located in the folder with absolute path `/emuroms/amiga/hdf/`. For that scenario, you should create a .uae text file with the following content:
+Example 1: You want to mount four non-RDB HDF files. You have one bootable 1000 MB file called `System.hdf` created with surfaces=1, and three non-bootable 2000 MB files called `WHDGamesA.hdf`, `WHDGamesB.hdf`, `WHDGamesC.hdf` created with surfaces=2. Your hdf files are located in the folder with absolute path `/emuroms/amiga/hdf/`. For that scenario, you should create a .uae text file with the following content:
 ```
 hardfile=read-write,32,1,2,512,/emuroms/amiga/hdf/System.hdf
 hardfile=read-write,32,2,2,512,/emuroms/amiga/hdf/WHDGamesA.hdf
@@ -205,7 +201,7 @@ hardfile=read-write,32,2,2,512,/emuroms/amiga/hdf/WHDGamesC.hdf
 ```
 You can then load your .uae file via Load Content.
 
-Note that for most hdf files, the model has to be set to A1200 in Quickmenu->Options. This requires a restart to take effect.
+Note that for most HDF files, the model has to be set to A1200 in Quickmenu->Options. This requires a restart to take effect.
 
-If you are using rdb hdf files, please use 0,0,0,0 instead of geometry numbers like 32,1,2,512. The geometry will then be read from the file. This only works for rdb hdf files.
+If you are using RDB HDF files, please use 0,0,0,0 instead of geometry numbers like 32,1,2,512. The geometry will then be read from the file. This only works for RDB HDF files.
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -544,7 +544,7 @@ void ProcessController(int retro_port, int i)
          if(i==RETRO_DEVICE_ID_JOYPAD_UP && SHOWKEY==-1)
          {
             if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
-            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) )
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))
             {
                setjoystickstate(retro_port, 1, -1, 1);
                jflag[retro_port][i]=1;
@@ -553,7 +553,7 @@ void ProcessController(int retro_port, int i)
          else if(i==RETRO_DEVICE_ID_JOYPAD_DOWN && SHOWKEY==-1)
          {
             if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
-            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))
             {
                setjoystickstate(retro_port, 1, 1, 1);
                jflag[retro_port][i]=1;
@@ -579,7 +579,7 @@ void ProcessController(int retro_port, int i)
          if(i==RETRO_DEVICE_ID_JOYPAD_LEFT && SHOWKEY==-1)
          {
             if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
-            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) )
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
             {
                setjoystickstate(retro_port, 0, -1, 1);
                jflag[retro_port][i]=1;
@@ -588,7 +588,7 @@ void ProcessController(int retro_port, int i)
          else if(i==RETRO_DEVICE_ID_JOYPAD_RIGHT && SHOWKEY==-1)
          {
             if( input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
-            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) )
+            && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))
             {
                setjoystickstate(retro_port, 0, 1, 1);
                jflag[retro_port][i]=1;
@@ -611,6 +611,10 @@ void ProcessController(int retro_port, int i)
    }
    else if(i != turbo_fire_button) // Buttons
    {
+      // Skip 2nd fire if keymapped
+      if(retro_port == 0 && i == RETRO_DEVICE_ID_JOYPAD_A && mapper_keys[RETRO_DEVICE_ID_JOYPAD_A] != 0)
+         return;
+
       uae_button = retro_button_to_uae_button(i);
       if(uae_button != -1)
       {
@@ -681,7 +685,7 @@ void ProcessKey(int disable_physical_cursor_keys)
       /* CapsLock */
       if(keyboard_translation[i]==AK_CAPSLOCK)
       {
-         if( key_state[i] && key_state2[i]==0 )
+         if(key_state[i] && key_state2[i]==0)
          {
             retro_key_down(keyboard_translation[i]);
             retro_key_up(keyboard_translation[i]);
@@ -689,19 +693,19 @@ void ProcessKey(int disable_physical_cursor_keys)
             Screen_SetFullUpdate();
             key_state2[i]=1;
          }
-         else if (!key_state[i] && key_state2[i]==1)
+         else if(!key_state[i] && key_state2[i]==1)
             key_state2[i]=0;
       }
       /* Special key (Right Alt) for overriding RetroPad cursor override */ 
       else if(keyboard_translation[i]==AK_RALT)
       {
-         if( key_state[i] && key_state2[i]==0 )
+         if(key_state[i] && key_state2[i]==0)
          {
             ALTON=1;
             retro_key_down(keyboard_translation[i]);
             key_state2[i]=1;
          }
-         else if (!key_state[i] && key_state2[i]==1)
+         else if(!key_state[i] && key_state2[i]==1)
          {
             ALTON=-1;
             retro_key_up(keyboard_translation[i]);
@@ -744,7 +748,7 @@ void ProcessKey(int disable_physical_cursor_keys)
             retro_key_down(keyboard_translation[i]);
             key_state2[i]=1;
          }
-         else if ( !key_state[i] && keyboard_translation[i]!=-1 && key_state2[i]==1 )
+         else if(!key_state[i] && keyboard_translation[i]!=-1 && key_state2[i]==1)
          {
             retro_key_up(keyboard_translation[i]);
             key_state2[i]=0;
@@ -815,7 +819,7 @@ void update_input(int disable_physical_cursor_keys)
          }
       }
       /* Key up */
-      else if (kbt[i]==1 && ! input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, mapper_keys[mk]) && mapper_keys[mk]!=0)
+      else if (kbt[i]==1 && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, mapper_keys[mk]) && mapper_keys[mk]!=0)
       {
          //printf("KEYUP: %d\n", mk);
          kbt[i]=0;
@@ -874,7 +878,7 @@ void update_input(int disable_physical_cursor_keys)
 
                 if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && jbt[i]==0 && i!=turbo_fire_button)
                     just_pressed = 1;
-                else if (jbt[i]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i))
+                else if (jbt[i]==1 && !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i))
                     just_released = 1;
             }
             else if (i >= 16) /* remappable retropad joystick directions */
@@ -1010,24 +1014,24 @@ void update_input(int disable_physical_cursor_keys)
    /* Virtual keyboard */
    if(SHOWKEY==1)
    {
-      if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) && vkflag[0]==0 )
+      if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) && vkflag[0]==0)
          vkflag[0]=1;
-      else if (vkflag[0]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )
+      else if (vkflag[0]==1 && !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))
          vkflag[0]=0;
 
-      if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) && vkflag[1]==0 )
+      if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) && vkflag[1]==0)
          vkflag[1]=1;
-      else if (vkflag[1]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) )
+      else if (vkflag[1]==1 && !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))
          vkflag[1]=0;
 
-      if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) && vkflag[2]==0 )
+      if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) && vkflag[2]==0)
          vkflag[2]=1;
-      else if (vkflag[2]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) )
+      else if (vkflag[2]==1 && !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))
          vkflag[2]=0;
 
-      if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) && vkflag[3]==0 )
+      if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) && vkflag[3]==0)
          vkflag[3]=1;
-      else if (vkflag[3]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) )
+      else if (vkflag[3]==1 && !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
          vkflag[3]=0;
 
       if (vkflag[0] || vkflag[1] || vkflag[2] || vkflag[3])
@@ -1075,33 +1079,33 @@ void update_input(int disable_physical_cursor_keys)
 
       /* Position toggle */
       i=RETRO_DEVICE_ID_JOYPAD_X;
-      if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[6]==0)
+      if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[6]==0)
       {
          vkflag[6]=1;
          SHOWKEYPOS=-SHOWKEYPOS;
          Screen_SetFullUpdate();
       }
-      else if( !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[6]==1)
+      else if(!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[6]==1)
       {
          vkflag[6]=0;
       }
 
       /* Transparency toggle */
       i=RETRO_DEVICE_ID_JOYPAD_A;
-      if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[5]==0)
+      if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[5]==0)
       {
          vkflag[5]=1;
          SHOWKEYTRANS=-SHOWKEYTRANS;
          Screen_SetFullUpdate();
       }
-      else if( !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[5]==1)
+      else if(!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[5]==1)
       {
          vkflag[5]=0;
       }
 
       /* Key press */
       i=RETRO_DEVICE_ID_JOYPAD_B;
-      if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[4]==0)
+      if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[4]==0)
       {
          vkflag[4]=1;
          i=check_vkey2(vkx,vky);
@@ -1134,7 +1138,7 @@ void update_input(int disable_physical_cursor_keys)
             }
          }
       }
-      else if( !input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i)  && vkflag[4]==1)
+      else if(!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[4]==1)
       {
          vkflag[4]=0;
       }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -19,7 +19,7 @@
 #define EMULATOR_MAX_HEIGHT 1024
 
 #define UAE_HZ_PAL 49.9201
-#define UAE_HZ_NTSC 59.8859
+#define UAE_HZ_NTSC 59.8251
 
 #if EMULATOR_DEF_WIDTH < 0 || EMULATOR_DEF_WIDTH > EMULATOR_MAX_WIDTH || EMULATOR_DEF_HEIGHT < 0 || EMULATOR_DEF_HEIGHT > EMULATOR_MAX_HEIGHT
 #error EMULATOR_DEF_WIDTH || EMULATOR_DEF_HEIGHT
@@ -122,7 +122,7 @@ const char *retro_content_directory;
 // Disk control context
 static dc_storage* dc;
 
-// Amiga default models
+// Amiga models
 // chipmem_size 1 = 0.5MB, 2 = 1MB, 4 = 2MB
 // bogomem_size 2 = 0.5MB, 4 = 1MB, 6 = 1.5MB, 7 = 1.8MB
 
@@ -169,8 +169,7 @@ chipset_compatible=A1200\n\
 chipset=aga\n"
 
 
-// Amiga default kickstarts
-
+// Amiga kickstarts
 #define A500_ROM    "kick34005.A500"
 #define A500KS2_ROM "kick37175.A500"
 #define A600_ROM    "kick40063.A600"
@@ -183,10 +182,11 @@ chipset=aga\n"
 
 #define PUAE_VIDEO_PAL_OV_LO 	PUAE_VIDEO_PAL
 #define PUAE_VIDEO_PAL_CR_LO 	PUAE_VIDEO_PAL|PUAE_VIDEO_CROP
-#define PUAE_VIDEO_NTSC_OV_LO 	PUAE_VIDEO_NTSC
-#define PUAE_VIDEO_NTSC_CR_LO 	PUAE_VIDEO_NTSC|PUAE_VIDEO_CROP
 #define PUAE_VIDEO_PAL_OV_HI 	PUAE_VIDEO_PAL|PUAE_VIDEO_HIRES
 #define PUAE_VIDEO_PAL_CR_HI 	PUAE_VIDEO_PAL|PUAE_VIDEO_CROP|PUAE_VIDEO_HIRES
+
+#define PUAE_VIDEO_NTSC_OV_LO 	PUAE_VIDEO_NTSC
+#define PUAE_VIDEO_NTSC_CR_LO 	PUAE_VIDEO_NTSC|PUAE_VIDEO_CROP
 #define PUAE_VIDEO_NTSC_OV_HI 	PUAE_VIDEO_NTSC|PUAE_VIDEO_HIRES
 #define PUAE_VIDEO_NTSC_CR_HI 	PUAE_VIDEO_NTSC|PUAE_VIDEO_CROP|PUAE_VIDEO_HIRES
 
@@ -247,7 +247,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "puae_video_standard",
          "Video standard",
-         "Needs restart",
+         "",
          {
             { "PAL", NULL },
             { "NTSC", NULL },
@@ -1053,6 +1053,13 @@ static void update_variables(void)
             strcat(uae_config, "ntsc=true\n");
             real_ntsc = true;
          }
+      else
+      {
+         if(strcmp(var.value, "PAL") == 0)
+            changed_prefs.ntscmode=0;
+         else
+            changed_prefs.ntscmode=1;
+      }
    }
 
    var.key = "puae_video_aspect";
@@ -1721,30 +1728,6 @@ static void update_variables(void)
    // - **640×400**: NTSC High resolution cropped/clipped (without the "borders")
    switch(video_config)
    {
-		case PUAE_VIDEO_PAL_OV_LO:
-			defaultw = 360;
-			defaulth = 284;
-			strcat(uae_config, "gfx_lores=true\n");
-			strcat(uae_config, "gfx_linemode=none\n");
-			break;
-		case PUAE_VIDEO_PAL_CR_LO:
-			defaultw = 320;
-			defaulth = 256;
-			strcat(uae_config, "gfx_lores=true\n");
-			strcat(uae_config, "gfx_linemode=none\n");
-			break;
-		case PUAE_VIDEO_NTSC_OV_LO:
-			defaultw = 360;
-			defaulth = 240;
-			strcat(uae_config, "gfx_lores=true\n");
-			strcat(uae_config, "gfx_linemode=none\n");
-			break;
-		case PUAE_VIDEO_NTSC_CR_LO:
-			defaultw = 320;
-			defaulth = 200;
-			strcat(uae_config, "gfx_lores=true\n");
-			strcat(uae_config, "gfx_linemode=none\n");
-			break;
 		case PUAE_VIDEO_PAL_OV_HI:
 			defaultw = 720;
 			defaulth = 568;
@@ -1757,9 +1740,22 @@ static void update_variables(void)
 			strcat(uae_config, "gfx_lores=false\n");
 			strcat(uae_config, "gfx_linemode=double\n");
 			break;
+		case PUAE_VIDEO_PAL_OV_LO:
+			defaultw = 360;
+			defaulth = 284;
+			strcat(uae_config, "gfx_lores=true\n");
+			strcat(uae_config, "gfx_linemode=none\n");
+			break;
+		case PUAE_VIDEO_PAL_CR_LO:
+			defaultw = 320;
+			defaulth = 256;
+			strcat(uae_config, "gfx_lores=true\n");
+			strcat(uae_config, "gfx_linemode=none\n");
+			break;
+
 		case PUAE_VIDEO_NTSC_OV_HI:
 			defaultw = 720;
-			defaulth = 480;
+			defaulth = 480 - 5; // UAE output correction
 			strcat(uae_config, "gfx_lores=false\n");
 			strcat(uae_config, "gfx_linemode=double\n");
 			break;
@@ -1768,6 +1764,18 @@ static void update_variables(void)
 			defaulth = 400;
 			strcat(uae_config, "gfx_lores=false\n");
 			strcat(uae_config, "gfx_linemode=double\n");
+			break;
+		case PUAE_VIDEO_NTSC_OV_LO:
+			defaultw = 360;
+			defaulth = 240 - 3; // As above
+			strcat(uae_config, "gfx_lores=true\n");
+			strcat(uae_config, "gfx_linemode=none\n");
+			break;
+		case PUAE_VIDEO_NTSC_CR_LO:
+			defaultw = 320;
+			defaulth = 200;
+			strcat(uae_config, "gfx_lores=true\n");
+			strcat(uae_config, "gfx_linemode=none\n");
 			break;
    }
 
@@ -2186,22 +2194,6 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
    /* Geometry dimensions */
    switch(video_config_geometry)
    {
-      case PUAE_VIDEO_PAL_OV_LO:
-         retrow = 360;
-         retroh = 284;
-         break;
-      case PUAE_VIDEO_PAL_CR_LO:
-         retrow = 320;
-         retroh = 256;
-         break;
-      case PUAE_VIDEO_NTSC_OV_LO:
-         retrow = 360;
-         retroh = 240;
-         break;
-      case PUAE_VIDEO_NTSC_CR_LO:
-         retrow = 320;
-         retroh = 200;
-         break;
       case PUAE_VIDEO_PAL_OV_HI:
          retrow = 720;
          retroh = 568;
@@ -2210,13 +2202,30 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
          retrow = 640;
          retroh = 512;
          break;
+      case PUAE_VIDEO_PAL_OV_LO:
+         retrow = 360;
+         retroh = 284;
+         break;
+      case PUAE_VIDEO_PAL_CR_LO:
+         retrow = 320;
+         retroh = 256;
+         break;
+
       case PUAE_VIDEO_NTSC_OV_HI:
          retrow = 720;
-         retroh = 480;
+         retroh = 480 - 5; // UAE does not actually output full 480 height in real NTSC mode, and statusbar will leave trails without the correction
          break;
       case PUAE_VIDEO_NTSC_CR_HI:
          retrow = 640;
          retroh = 400;
+         break;
+      case PUAE_VIDEO_NTSC_OV_LO:
+         retrow = 360;
+         retroh = 240 - 3; // As above
+         break;
+      case PUAE_VIDEO_NTSC_CR_LO:
+         retrow = 320;
+         retroh = 200;
          break;
    }
 


### PR DESCRIPTION
Prevented 2nd fire button from firing if RetroPad A is mapped to a key.

Made a minimal correction to uncropped NTSC geometry. Normally it is set at 480/240px, and that is where statusbar will be drawn, but UAE does not output NTSC quite that far, making the statusbar not clearing properly.

Also updated and corrected readme again (removed dead links and made reading easier).
