### PR TITLE
Improved zoom autocenter + analog stick mouse

### DIFF
--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -48,8 +48,8 @@ char RPATH[512];
 
 int analog_left[2];
 int analog_right[2];
-extern int analog_deadzone;
-extern unsigned int analog_sensitivity;
+extern unsigned int analog_deadzone;
+extern float analog_sensitivity;
 extern unsigned int opt_dpadmouse_speed;
 int fmousex,fmousey; // emu mouse
 int slowdown=0;
@@ -1291,14 +1291,13 @@ void retro_poll_event()
                analog_left[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X));
                analog_left[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y));
 
-               if (analog_left[0]<=-analog_deadzone)
-                  fmousex-=(-analog_left[0])/analog_sensitivity;
-               if (analog_left[0]>= analog_deadzone)
-                  fmousex+=( analog_left[0])/analog_sensitivity;
-               if (analog_left[1]<=-analog_deadzone)
-                  fmousey-=(-analog_left[1])/analog_sensitivity;
-               if (analog_left[1]>= analog_deadzone)
-                  fmousey+=( analog_left[1])/analog_sensitivity;
+               if (abs(analog_left[0]) <= analog_deadzone * 32768 / 100)
+                  analog_left[0] = 0;
+               if (abs(analog_left[1]) <= analog_deadzone * 32768 / 100)
+                  analog_left[1] = 0;
+
+               fmousex = analog_left[0] * (analog_sensitivity * analog_sensitivity * 0.7) / (32768 / 20);
+               fmousey = analog_left[1] * (analog_sensitivity * analog_sensitivity * 0.7) / (32768 / 20);
             }
 
          // Right analog movement
@@ -1309,14 +1308,13 @@ void retro_poll_event()
                analog_right[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X));
                analog_right[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y));
 
-               if (analog_right[0]<=-analog_deadzone)
-                  fmousex-=(-analog_right[0])/analog_sensitivity;
-               if (analog_right[0]>= analog_deadzone)
-                  fmousex+=( analog_right[0])/analog_sensitivity;
-               if (analog_right[1]<=-analog_deadzone)
-                  fmousey-=(-analog_right[1])/analog_sensitivity;
-               if (analog_right[1]>= analog_deadzone)
-                  fmousey+=( analog_right[1])/analog_sensitivity;
+               if (abs(analog_right[0]) <= analog_deadzone * 32768 / 100)
+                  analog_right[0] = 0;
+               if (abs(analog_right[1]) <= analog_deadzone * 32768 / 100)
+                  analog_right[1] = 0;
+
+               fmousex = analog_right[0] * (analog_sensitivity * analog_sensitivity * 0.7) / (32768 / 20);
+               fmousey = analog_right[1] * (analog_sensitivity * analog_sensitivity * 0.7) / (32768 / 20);
             }
 
          // Real mouse movement

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -44,8 +44,8 @@ unsigned int opt_keyrahkeypad = 0;
 unsigned int opt_dpadmouse_speed = 4;
 extern int PAS;
 unsigned int opt_analogmouse = 0;
-int analog_deadzone = 6144;
-unsigned int analog_sensitivity = 2048;
+unsigned int analog_deadzone = 15;
+float analog_sensitivity = 1.0;
 extern int turbo_fire_button;
 extern unsigned int turbo_pulse;
 int pix_bytes = 2;
@@ -1462,7 +1462,7 @@ static void update_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      analog_deadzone = 328 * atoi(var.value);
+      analog_deadzone = atoi(var.value);
    }
 
    var.key = "puae_analogmouse_sensitivity";
@@ -1470,7 +1470,7 @@ static void update_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      analog_sensitivity = 2048 / atof(var.value);
+      analog_sensitivity = atof(var.value);
    }
 
    var.key = "puae_dpadmouse_speed";


### PR DESCRIPTION
- Made zoom autocentering more reliable
- Removed the need for an ugly hack caused by PAL/NTSC difference in minfirstline
- Took influence from the Dosbox core for analog stick mouse control and tried to make it non-linear

Surprisingly even Cannon Fodder is pretty playable now with the stick.
