### PR TITLE
Minor usability and major compatibility fix

### DIFF
--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -1105,7 +1105,7 @@ void update_input(int disable_physical_cursor_keys)
 
       virtual_kbd(bmp,vkx,vky);
 
-      /* Position toggle */
+      /* Position toggle, RetroPad X */
       i=RETRO_DEVICE_ID_JOYPAD_X;
       if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[6]==0)
       {
@@ -1118,7 +1118,7 @@ void update_input(int disable_physical_cursor_keys)
          vkflag[6]=0;
       }
 
-      /* Transparency toggle */
+      /* Transparency toggle, RetroPad A */
       i=RETRO_DEVICE_ID_JOYPAD_A;
       if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[5]==0)
       {
@@ -1131,9 +1131,9 @@ void update_input(int disable_physical_cursor_keys)
          vkflag[5]=0;
       }
 
-      /* Key press */
+      /* Key press, RetroPad B or Keyboard Enter */
       i=RETRO_DEVICE_ID_JOYPAD_B;
-      if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[4]==0)
+      if((input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) || input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RETURN)) && vkflag[4]==0)
       {
          vkflag[4]=1;
          i=check_vkey2(vkx,vky);
@@ -1166,7 +1166,7 @@ void update_input(int disable_physical_cursor_keys)
             }
          }
       }
-      else if(!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && vkflag[4]==1)
+      else if((!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RETURN)) && vkflag[4]==1)
       {
          vkflag[4]=0;
       }

--- a/sources/src/cfgfile.c
+++ b/sources/src/cfgfile.c
@@ -4669,7 +4669,11 @@ void default_prefs (struct uae_prefs *p, int type)
 	 * to behave identically on all platforms if possible.
 	 * (TW says: maybe it is time to update default config..) */
 	p->illegal_mem = 0;
+#ifdef __LIBRETRO__
+	p->use_serial = 1;
+#else
 	p->use_serial = 0;
+#endif
 	p->serial_demand = 0;
 	p->serial_hwctsrts = 1;
 	p->serial_stopbits = 0;


### PR DESCRIPTION
- Pressing Enter works as a selector in the VKBD, mainly for the keyboard device type

- Enabled serial.device, otherwise Skidmarks start menu would lock up and nothing works


Closes #137 