### PR TITLE
Mouse support for both normal joyports

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -44,7 +44,6 @@ int opt_statusbar_position_offset = 0;
 int opt_statusbar_position_offset_lores = 0;
 unsigned int opt_keyrahkeypad = 0;
 unsigned int opt_dpadmouse_speed = 4;
-extern int dpadmouse_speed;
 unsigned int opt_analogmouse = 0;
 unsigned int opt_analogmouse_deadzone = 15;
 float opt_analogmouse_speed = 1.0;
@@ -655,7 +654,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "puae_analogmouse",
-         "Analog mouse",
+         "Analog stick mouse",
          "",
          {
             { "disabled", NULL },
@@ -668,7 +667,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "puae_analogmouse_deadzone",
-         "Analog mouse deadzone",
+         "Analog stick mouse deadzone",
          "",
          {
             { "15", "15\%" },
@@ -685,7 +684,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "puae_analogmouse_speed",
-         "Analog mouse speed",
+         "Analog stick mouse speed",
          "",
          {
             { "1.0", "100\%" },
@@ -715,6 +714,35 @@ void retro_set_environment(retro_environment_t cb)
             { NULL, NULL },
          },
          "6"
+      },
+      {
+         "puae_mouse_speed",
+         "Mouse speed",
+         "Affects mouse speed globally",
+         {
+            { "100", "100\%" },
+            { "110", "110\%" },
+            { "120", "120\%" },
+            { "130", "130\%" },
+            { "140", "140\%" },
+            { "150", "150\%" },
+            { "160", "160\%" },
+            { "170", "170\%" },
+            { "180", "180\%" },
+            { "190", "190\%" },
+            { "200", "200\%" },
+            { "10", "10\%" },
+            { "20", "20\%" },
+            { "30", "30\%" },
+            { "40", "40\%" },
+            { "50", "50\%" },
+            { "60", "60\%" },
+            { "70", "70\%" },
+            { "80", "80\%" },
+            { "90", "90\%" },
+            { NULL, NULL },
+         },
+         "100"
       },
       {
          "puae_keyrah_keypad_mappings",
@@ -1378,6 +1406,23 @@ static void update_variables(void)
          changed_prefs.dfxclickvolume=atoi(var.value);
    }
 
+   var.key = "puae_mouse_speed";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      strcat(uae_config, "input.mouse_speed=");
+      strcat(uae_config, var.value);
+      strcat(uae_config, "\n");
+
+      if(firstpass != 1)
+      {
+         int val;
+         val = atoi(var.value);
+         changed_prefs.input_mouse_speed=val;
+      }
+   }
+
    var.key = "puae_immediate_blits";
    var.value = NULL;
 
@@ -1584,7 +1629,6 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       opt_dpadmouse_speed = atoi(var.value);
-      dpadmouse_speed = opt_dpadmouse_speed;
    }
 
    var.key = "puae_keyrah_keypad_mappings";

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -18,6 +18,7 @@
 
 #include "inputdevice.h"
 void inputdevice_release_all_keys (void);
+extern int mouse_port[NORMAL_JPORTS];
 
 #include "drawing.h"
 #include "hotkeys.h"
@@ -75,23 +76,17 @@ void target_default_options (struct uae_prefs *p, int type)
 }
 
 /* --- mouse input --- */
-void retro_mouse(int dx, int dy)
+void retro_mouse(int port, int dx, int dy)
 {
-    changed_prefs.jports[0].id = JSEM_MICE;
-    setmousestate (0, 0, dx, 0);
-    setmousestate (0, 1, dy, 0);
+    mouse_port[port] = 1;
+    setmousestate(port, 0, dx, 0);
+    setmousestate(port, 1, dy, 0);
 }
 
-void retro_mouse_but0(int down)
+void retro_mouse_button(int port, int button, int down)
 {
-    changed_prefs.jports[0].id = JSEM_MICE;
-    setmousebuttonstate (0, 0, down);
-}
-
-void retro_mouse_but1(int down)
-{
-    changed_prefs.jports[0].id = JSEM_MICE;
-    setmousebuttonstate (0, 1, down);
+    mouse_port[port] = 1;
+    setmousebuttonstate(port, button, down);
 }
 
 /* --- keyboard input --- */
@@ -569,15 +564,22 @@ struct inputdevice_functions inputdevicefunc_mouse = {
 
 int input_get_default_mouse (struct uae_input_device *uid, int num, int port, int af, bool gp, bool wheel)
 {
-    /* Supports only one mouse */
     uid[0].eventid[ID_AXIS_OFFSET + 0][0]   = INPUTEVENT_MOUSE1_HORIZ;
     uid[0].eventid[ID_AXIS_OFFSET + 1][0]   = INPUTEVENT_MOUSE1_VERT;
     uid[0].eventid[ID_AXIS_OFFSET + 2][0]   = INPUTEVENT_MOUSE1_WHEEL;
     uid[0].eventid[ID_BUTTON_OFFSET + 0][0] = INPUTEVENT_JOY1_FIRE_BUTTON;
     uid[0].eventid[ID_BUTTON_OFFSET + 1][0] = INPUTEVENT_JOY1_2ND_BUTTON;
     uid[0].eventid[ID_BUTTON_OFFSET + 2][0] = INPUTEVENT_JOY1_3RD_BUTTON;
+
+    uid[1].eventid[ID_AXIS_OFFSET + 0][0]   = INPUTEVENT_MOUSE2_HORIZ;
+    uid[1].eventid[ID_AXIS_OFFSET + 1][0]   = INPUTEVENT_MOUSE2_VERT;
+    uid[1].eventid[ID_BUTTON_OFFSET + 0][0] = INPUTEVENT_JOY2_FIRE_BUTTON;
+    uid[1].eventid[ID_BUTTON_OFFSET + 1][0] = INPUTEVENT_JOY2_2ND_BUTTON;
+    uid[1].eventid[ID_BUTTON_OFFSET + 2][0] = INPUTEVENT_JOY2_3RD_BUTTON;
+
     uid[0].enabled = 1;
-	return 0;
+    uid[1].enabled = 1;
+    return 0;
 }
 
 /***************************************************************

--- a/sources/src/inputdevice.c
+++ b/sources/src/inputdevice.c
@@ -226,7 +226,11 @@ static int joydir[MAX_JPORTS];
 static int joydirpot[MAX_JPORTS][2];
 static uae_s16 mouse_frame_x[MAX_JPORTS], mouse_frame_y[MAX_JPORTS];
 
+#ifdef __LIBRETRO__
+int mouse_port[NORMAL_JPORTS];
+#else
 static int mouse_port[NORMAL_JPORTS];
+#endif
 static int cd32_shifter[NORMAL_JPORTS];
 #ifdef __LIBRETRO__
 int cd32_pad_enabled[NORMAL_JPORTS];


### PR DESCRIPTION
Note that this does not enable the use of 2 physical mice, but only RetroPad emulated.

And since the mouse and joystick ports are reversed in Amiga, as in the first mouse port is the second joystick, and the second mouse is the first joystick, this simply works just like RetroPad works now: Both ports can control the other port as mouse directly via analog sticks in joystick mode, and mouse mode forces D-Pad and the first 2 buttons to mouse.

Hotkey mouse buttons and mouse speed modifiers apply to the controller in question.

There is very little leg room to make this any simpler and clear-cut without creating another device type, which would skip joystick control completely. I don't think that is necessary.

Bonus: A global mouse speed core option which affects all mouse types

Closes #140 