### PR TITLE
Vertical positioning + Autozoom + 2nd fire improvements

### DIFF
--- a/sources/src/drawing.c
+++ b/sources/src/drawing.c
@@ -209,7 +209,11 @@ static int visible_top_start, visible_bottom_stop;
 static int hblank_left_start, hblank_right_stop;
 
 static int linetoscr_x_adjust_bytes;
+#ifdef __LIBRETRO__
+int thisframe_y_adjust;
+#else
 static int thisframe_y_adjust;
+#endif
 static int thisframe_y_adjust_real, max_ypos_thisframe, min_ypos_for_screen;
 static int extra_y_adjust;
 int thisframe_first_drawn_line, thisframe_last_drawn_line;
@@ -2992,6 +2996,7 @@ static void center_image (void)
 	if (visible_right_border > max_diwlastword)
 		visible_right_border = max_diwlastword;
 
+#ifndef __LIBRETRO__
 	thisframe_y_adjust = minfirstline;
 	if (currprefs.gfx_ycenter && thisframe_first_drawn_line >= 0 && !currprefs.gfx_filter_autoscale) {
 
@@ -3013,6 +3018,7 @@ static void center_image (void)
 		thisframe_y_adjust = maxvpos_nom - max_drawn_amiga_line;
 	if (thisframe_y_adjust < minfirstline)
 		thisframe_y_adjust = minfirstline;
+#endif
 
 	thisframe_y_adjust_real = thisframe_y_adjust << linedbl;
 	tmp = (maxvpos_nom - thisframe_y_adjust + 1) << linedbl;

--- a/sources/src/inputdevice.c
+++ b/sources/src/inputdevice.c
@@ -2175,7 +2175,11 @@ static void cap_check (void)
 					charge = 2;
 			}
 			// CD32 pad in 2-button mode: blue button is not floating
+#ifdef __LIBRETRO__
+			if (i == 1 && charge == 0)
+#else
 			if (cd32_pad_enabled[joy] && i == 1 && charge == 0)
+#endif
 				charge = 2;
 		
 			/* official Commodore mouse has pull-up resistors in button lines


### PR DESCRIPTION
- Vertical offset manipulation changed from minfirstline to thisframe_y_adjust
-- Fixes drawn line calculations = more reliable autozooms and autocenterings
-- Also fixes interlaced modes statusbar position shifting, like Wizkid

- Changed 2nd fire pull-up resistor behavior, fixing 2nd fire working only once on certain games, like Banshee

As always, testing and reports are more than welcome!
