### PR TITLE
Directory filesystem fixes

### DIFF
--- a/sources/src/filesys_linux.c
+++ b/sources/src/filesys_linux.c
@@ -29,6 +29,7 @@ extern int ftime(struct timeb*  timebuf);
 #endif
 
 typedef int BOOL;
+extern int log_filesys;
 
 #ifndef _WIN32
 
@@ -89,12 +90,12 @@ typedef struct {
 } LARGE_INTEGER;
 #endif
 
-#ifdef _WIN32
+/*#ifdef _WIN32
  #define S_IRGRP 00040
  #define S_IWGRP 00020
  #define S_IROTH 00004
  #define S_IWOTH 00002
-#endif
+#endif*/
 
 /* fsdb_mywin32 */
 bool my_stat (const TCHAR *name, struct mystat *statbuf)
@@ -645,31 +646,36 @@ int my_truncate (const TCHAR *name, uae_u64 len) {
 }
 
 uae_s64 my_fsize (struct my_openfile_s *mos) {
-	uae_s64 cur, filesize;
+    uae_s64 cur, filesize;
 
-	cur = my_lseek (mos->h, 0, SEEK_CUR);
-	filesize = my_lseek (mos->h, 0, SEEK_END);
-	my_lseek (mos->h, cur, SEEK_SET);
-	write_log (_T("FS: filesize <%d>\n"), filesize);
-	return filesize;
+#ifndef __LIBRETRO__
+    cur = my_lseek (mos->h, 0, SEEK_CUR);
+    filesize = my_lseek (mos->h, 0, SEEK_END);
+    my_lseek (mos->h, cur, SEEK_SET);
+#endif
+    if (log_filesys)
+        write_log (_T("FS: filesize <%d>\n"), filesize);
+    return filesize;
 }
 
 int my_read (struct my_openfile_s *mos, void *b, unsigned int size) {
     DWORD read = 0;
 #ifdef _WIN32
     ReadFile (mos->h, b, size, &read, NULL);
-	//ssize_t bytesRead = read(mos->h, b, size);
-	write_log (_T("read <%d> | FS: %x | size: %d | ERR: %s\n"), read, mos->h, size, strerror(errno));
+    //ssize_t bytesRead = read(mos->h, b, size);
+    if (log_filesys)
+        write_log (_T("read <%d> | FS: %x | size: %d | ERR: %s\n"), read, mos->h, size, strerror(errno));
 #endif
-	return read;
+    return read;
 }
 
 int my_write (struct my_openfile_s *mos, void *b, unsigned int size) {
     DWORD written = 0;
 #ifdef _WIN32
     WriteFile (mos->h, b, size, &written, NULL);
-	//ssize_t written = write (mos->h, b, size);
-	write_log (_T("wrote <%d> | FS: %x | ERR: %s\n"), written, mos->h, strerror(errno));
+    //ssize_t written = write (mos->h, b, size);
+    if (log_filesys)
+        write_log (_T("wrote <%d> | FS: %x | ERR: %s\n"), written, mos->h, strerror(errno));
 #endif
-	return written;
+    return written;
 }

--- a/sources/src/fsdb_unix.c
+++ b/sources/src/fsdb_unix.c
@@ -89,12 +89,16 @@ static int fsdb_name_invalid_2 (const TCHAR *n, int dir)
         if (_tcscmp (n, FSDB_FILE) == 0)
                 return -1;
 
+#ifndef __LIBRETRO__
         if (dir) {
+#endif
                 if (n[0] == '.' && l == 1)
                         return -1;
                 if (n[0] == '.' && n[1] == '.' && l == 2)
                         return -1;
+#ifndef __LIBRETRO__
         }
+#endif
 
         if (a >= 'a' && a <= 'z')
                 a -= 32;
@@ -156,7 +160,7 @@ int fsdb_fill_file_attrs (a_inode *base, a_inode *aino)
     aino->amigaos_mode = ((S_IXUSR & statbuf.st_mode ? 0 : A_FIBF_EXECUTE)
 			  | (S_IWUSR & statbuf.st_mode ? 0 : A_FIBF_WRITE)
 			  | (S_IRUSR & statbuf.st_mode ? 0 : A_FIBF_READ));
-#ifdef ANDROID
+#if defined (ANDROID) || defined (__LIBRETRO__)
     // Always give execute & read permission
     aino->amigaos_mode &= ~A_FIBF_EXECUTE;
     aino->amigaos_mode &= ~A_FIBF_READ;

--- a/sources/src/fsusage.c
+++ b/sources/src/fsusage.c
@@ -58,6 +58,20 @@ static long adjust_blocks (long blocks, int fromsize, int tosize)
 		return (blocks + (blocks < 0 ? -1 : 1)) / (tosize / fromsize);
 }
 
+#ifdef __LIBRETRO__
+static int get_fs_usage_fake (const TCHAR *path, const TCHAR *disk, struct fs_usage *fsp)
+{
+    fsp->fsu_blocks = 0x7fffff;
+    fsp->fsu_bavail = 0x3fffff;
+    return 0;
+}
+
+int get_fs_usage (const TCHAR *path, const TCHAR *disk, struct fs_usage *fsp)
+{
+    return get_fs_usage_fake(path, disk, fsp);
+}
+#else
+
 #if defined TARGET_AMIGAOS
 
 #include <dos/dos.h>
@@ -330,7 +344,7 @@ int get_fs_usage (const TCHAR *path, const TCHAR *disk, struct fs_usage *fsp)
 
 #endif /* STAT_STATVFS */
 
-#if defined(__PS3__) || defined(__LIBRETRO__)
+#if defined(__PS3__)
  return -1;
 #else
 #if !defined(STAT_STATFS2_FS_DATA) && !defined(STAT_READ_FILSYS) && !defined(ANDROID)
@@ -380,3 +394,5 @@ int
 
 #endif /* ! __BEOS__ */
 #endif /* ! TARGET_AMIGAOS */
+
+#endif /* __LIBRETRO__ */


### PR DESCRIPTION
Reading and writing with WHDLoads seems to be finally ok now. Only confirmed on Windows, so let's not update Readme just yet.

- Used/available size faked like in FS-UAE
- Protect flags on all files are +e, so executing works without Workbench and/or explicit flagging
- "." and ".." are for some reason seen as files and not directories, so enabled hiding them too
