### PR TITLE
Minor faults eliminated

### DIFF
--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -261,7 +261,7 @@ void Print_Status(void)
    else // Bottom
       STAT_BASEY=gfxvidinfo.outheight-opt_statusbar_position-BOX_HEIGHT+2;
 
-   BOX_WIDTH=retrow-146;
+   BOX_WIDTH=retrow-122;
    BOX_Y=STAT_BASEY-BOX_PADDING;
 
    // Joy port indicators

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -77,10 +77,10 @@ extern void retro_joystick(int, int, int);
 extern void retro_joystick_button(int, int, int);
 extern unsigned int uae_devices[4];
 extern int mapper_keys[32];
-extern int video_config;
-extern int video_config_aspect;
-extern int zoom_mode_id;
-static int opt_zoom_mode_id;
+extern unsigned int video_config;
+extern unsigned int video_config_aspect;
+extern unsigned int zoom_mode_id;
+extern unsigned int opt_zoom_mode_id;
 extern bool request_update_av_info;
 extern bool opt_enhanced_statusbar;
 extern int opt_statusbar_position;
@@ -137,11 +137,11 @@ void emu_function(int function)
       case EMU_ASPECT_RATIO_TOGGLE:
          if (real_ntsc)
             break;
-         if (video_config_aspect==0)
+         if (video_config_aspect == 0)
             video_config_aspect = (video_config & 0x02) ? 1 : 2;
-         else if (video_config_aspect==1)
+         else if (video_config_aspect == 1)
             video_config_aspect = 2;
-         else if (video_config_aspect==2)
+         else if (video_config_aspect == 2)
             video_config_aspect = 1;
          request_update_av_info = true;
          break;
@@ -149,15 +149,10 @@ void emu_function(int function)
          if (zoom_mode_id == 0 && opt_zoom_mode_id == 0)
             break;
          if (zoom_mode_id > 0)
-         {
-            opt_zoom_mode_id = zoom_mode_id;
             zoom_mode_id = 0;
-         }
-         else
-         {
+         else if (zoom_mode_id == 0)
             zoom_mode_id = opt_zoom_mode_id;
-            opt_zoom_mode_id = 0;
-         }
+
          request_update_av_info = true;
          break;
    }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2028,124 +2028,116 @@ extern void disk_eject (int num);
 
 static bool disk_set_eject_state(bool ejected)
 {
-	if (dc)
-	{
-		if (dc->eject_state == ejected)
-			return true;
-		else
-			dc->eject_state = ejected;
-		
-		if (dc->eject_state)
-		{
-			changed_prefs.floppyslots[0].df[0] = 0;
-			DISK_check_change();
-			disk_eject(0);
-		}
-		else
-		{
-			if (strlen(dc->files[dc->index]) > 0)
-			{
-				if (file_exists(dc->files[dc->index]))
-				{
-					if (currprefs.nr_floppies-1 < 0 )
-						currprefs.nr_floppies = 1;
+   if (dc)
+   {
+      if (dc->eject_state == ejected)
+         return true;
+      else
+         dc->eject_state = ejected;
 
-					//check whether drive is enabled
-					if (currprefs.floppyslots[0].dfxtype < 0)
-					{
-						changed_prefs.floppyslots[0].dfxtype = 0;
-						DISK_check_change();
-					}
-					changed_prefs = currprefs;
-					strcpy (changed_prefs.floppyslots[0].df,dc->files[dc->index]);
-					DISK_check_change();
-				}
-			}
-		}
-	}
-	return true;
+      if (dc->eject_state)
+      {
+         if (dc->files[dc->index] > 0)
+         {
+            changed_prefs.floppyslots[0].df[0] = 0;
+            DISK_check_change();
+            disk_eject(0);
+         }
+      }
+      else
+      {
+         if (dc->files[dc->index] > 0)
+         {
+            if (file_exists(dc->files[dc->index]))
+            {
+               strcpy (changed_prefs.floppyslots[0].df, dc->files[dc->index]);
+               DISK_check_change();
+            }
+         }
+      }
+   }
+   return true;
 }
 
 static bool disk_get_eject_state(void)
 {
-	if (dc)
-		return dc->eject_state;
-	
-	return true;
+   if (dc)
+      return dc->eject_state;
+
+   return true;
 }
 
 static unsigned disk_get_image_index(void)
 {
-	if (dc)
-		return dc->index;
-	
-	return 0;
+   if (dc)
+      return dc->index;
+
+   return 0;
 }
 
 static bool disk_set_image_index(unsigned index)
 {
-	// Insert disk
-	if (dc)
-	{
-		// Same disk...
-		// This can mess things in the emu
-		if (index == dc->index)
-			return true;
+   // Insert disk
+   if (dc)
+   {
+      // Same disk...
+      // This can mess things in the emu
+      if (index == dc->index)
+         return true;
 
-		if ((index < dc->count) && (dc->files[index]))
-		{
-			dc->index = index;
-			printf("Disk (%d) inserted into drive DF0: %s\n", dc->index+1, dc->files[dc->index]);
-			return true;
-		}
-	}
+      if ((index < dc->count) && (dc->files[index]))
+      {
+         dc->index = index;
+         fprintf(stdout, "[libretro-uae]: Disk (%d) inserted into drive DF0: '%s'\n", dc->index+1, dc->files[dc->index]);
+         return true;
+      }
+   }
 
-	return false;
+   return false;
 }
 
 static unsigned disk_get_num_images(void)
 {
-	if (dc)
-		return dc->count;
+   if (dc)
+      return dc->count;
 
-	return 0;
+   return 0;
 }
 
 static bool disk_replace_image_index(unsigned index, const struct retro_game_info *info)
 {
-	if (dc)
-	{
-		if (index >= dc->count)
-			return false;
+   if (dc)
+   {
+      if (index >= dc->count)
+         return false;
 
-		if (dc->files[index])
-		{
-			free(dc->files[index]);
-			dc->files[index] = NULL;
-		}
+      if (dc->files[index])
+      {
+         free(dc->files[index]);
+         dc->files[index] = NULL;
+      }
 
-		// TODO : Handling removing of a disk image when info = NULL
+      // TODO : Handling removing of a disk image when info = NULL
+      if (info != NULL)
+         dc->files[index] = strdup(info->path);
+   }
 
-		if (info != NULL)
-			dc->files[index] = strdup(info->path);
-	}
-
-    return false;
+   return false;
 }
 
 static bool disk_add_image_index(void)
 {
-	if (dc)
-	{
-		if (dc->count <= DC_MAX_SIZE)
-		{
-			dc->files[dc->count] = NULL;
-			dc->count++;
-			return true;
-		}
-	}
+   if (dc)
+   {
+      if (dc->count <= DC_MAX_SIZE)
+      {
+         dc->files[dc->count] = NULL;
+         dc->count++;
+         return true;
+      }
+   }
 
-    return false;
+   return false;
 }
 
 static struct retro_disk_control_callback disk_interface = {
@@ -2958,7 +2950,7 @@ bool retro_load_game(const struct retro_game_info *info)
                // Init first disk
                dc->index = 0;
                dc->eject_state = false;
-               fprintf(stdout, "[libretro-uae]: Disk (%d) inserted into drive DF0: %s\n", dc->index+1, dc->files[dc->index]);
+               fprintf(stdout, "[libretro-uae]: Disk (%d) inserted into drive DF0: '%s'\n", dc->index+1, dc->files[dc->index]);
                fprintf(configfile, "floppy0=%s\n", dc->files[0]);
 
                // Append rest of the disks to the config if m3u is a MultiDrive-m3u
@@ -2969,7 +2961,7 @@ bool retro_load_game(const struct retro_game_info *info)
                      dc->index = i;
                      if (i <= 3)
                      {
-                        fprintf(stdout, "[libretro-uae]: Disk (%d) inserted into drive DF%d: %s\n", dc->index+1, i, dc->files[dc->index]);
+                        fprintf(stdout, "[libretro-uae]: Disk (%d) inserted into drive DF%d: '%s'\n", dc->index+1, i, dc->files[dc->index]);
                         fprintf(configfile, "floppy%d=%s\n", i, dc->files[i]);
 
                         // By default only DF0: is enabled, so floppyXtype needs to be set on the extra drives

--- a/libretro/vkbd.c
+++ b/libretro/vkbd.c
@@ -7,9 +7,9 @@ extern int NPAGE;
 extern int SHOWKEYPOS;
 extern int SHOWKEYTRANS;
 extern int SHIFTON;
-extern int vkflag[7];
-extern int video_config_geometry;
 extern int pix_bytes;
+extern int vkflag[7];
+extern unsigned int video_config_geometry;
 
 void virtual_kbd(unsigned short int *pixels, int vx, int vy)
 {

--- a/sources/src/ar.c
+++ b/sources/src/ar.c
@@ -1644,7 +1644,9 @@ int action_replay_load (void)
 
 	armodel = 0;
 	action_replay_flag = ACTION_REPLAY_INACTIVE;
+#ifndef __LIBRETRO__
 	write_log_debug (_T("Entered action_replay_load ()\n"));
+#endif
 	/* Don't load a rom if one is already loaded. Use action_replay_unload () first. */
 	if (armemory_rom || hrtmemory) {
 		write_log (_T("action_replay_load () ROM already loaded.\n"));

--- a/sources/src/cfgfile.c
+++ b/sources/src/cfgfile.c
@@ -3748,7 +3748,9 @@ int cfgfile_load (struct uae_prefs *p, const TCHAR *filename, int *type, int ign
 	if (recursive > 1)
 		return 0;
 	recursive++;
+#ifndef __LIBRETRO__
 	write_log (_T("load config '%s':%d\n"), filename, type ? *type : -1);
+#endif
 	v = cfgfile_load_2 (p, filename, 1, type);
 	if (!v) {
 		write_log (_T("load failed\n"));

--- a/sources/src/main.c
+++ b/sources/src/main.c
@@ -1161,17 +1161,16 @@ void real_main (int argc, TCHAR **argv)
 	preinit_shm ();
 #endif
 
+#ifndef __LIBRETRO__
 	write_log (_T("Enumerating display devices.. \n"));
-#ifndef __LIBRETRO__
 	enumeratedisplays ();
-#endif
 	write_log (_T("Sorting devices and modes..\n"));
-#ifndef __LIBRETRO__
 	sortdisplays ();
-#endif
-//	write_log (_T("Display buffer mode = %d\n"), ddforceram);
-//	enumerate_sound_devices ();
+
+	write_log (_T("Display buffer mode = %d\n"), ddforceram);
+	enumerate_sound_devices ();
 	write_log (_T("done\n"));
+#endif
 
 	keyboard_settrans ();
 #ifdef CATWEASEL

--- a/sources/src/memory.c
+++ b/sources/src/memory.c
@@ -2554,10 +2554,6 @@ void memory_clear (void)
 	expansion_clear ();
 }
 
-#ifdef __LIBRETRO__
-int romnotfound=0;
-#endif
-
 void memory_reset (void)
 {
 	int bnk, bnk_end;
@@ -2601,7 +2597,9 @@ void memory_reset (void)
 #ifdef NATMEM_OFFSET
 		protect_roms (false);
 #endif
+#ifndef __LIBRETRO__
 		write_log (_T("ROM loader.. (%s)\n"), currprefs.romfile);
+#endif
 		kickstart_rom = 1;
 		a1000_handle_kickstart (0);
 		xfree (a1000_bootrom);
@@ -2624,9 +2622,6 @@ void memory_reset (void)
 			if (_tcslen (currprefs.romfile) > 0) {
 				write_log (_T("Failed to open '%s'\n"), currprefs.romfile);
 				notify_user (NUMSG_NOROM);
-#ifdef __LIBRETRO__
-				romnotfound=1;
-#endif
 			}
 			load_kickstart_replacement ();
 		} else {
@@ -2664,7 +2659,9 @@ void memory_reset (void)
 			}
 		}
 		patch_kick ();
+#ifndef __LIBRETRO__
 		write_log (_T("ROM loader end\n"));
+#endif
 #ifdef NATMEM_OFFSET
 		protect_roms (true);
 #endif
@@ -2862,7 +2859,9 @@ void memory_reset (void)
 	if (mem_hardreset) {
 		memory_clear ();
 	}
+#ifndef __LIBRETRO__
 	write_log (_T("memory init end\n"));
+#endif
 }
 
 

--- a/sources/src/statusline.c
+++ b/sources/src/statusline.c
@@ -120,18 +120,22 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             on_rgb = 0x00cc00;
             on_rgb2 = 0x006600;
             off_rgb = 0x003300;
-        if (!gui_data.drive_disabled[pled]) {
-            num1 = -1;
-            num2 = track / 10;
-            num3 = track % 10;
-            on = gui_data.drive_motor[pled];
-            if (gui_data.drive_writing[pled]) {
-                on_rgb = 0xcc0000;
-                on_rgb2 = 0x880000;
-            }
-            half = gui_data.drive_side ? 1 : -1;
-            if (gui_data.df[pled][0] == 0)
-                pen_rgb = ledcolor (0x00aaaaaa, rc, gc, bc, alpha);
+            if (!gui_data.drive_disabled[pled]) {
+                num1 = -1;
+                num2 = track / 10;
+                num3 = track % 10;
+                on = gui_data.drive_motor[pled];
+                if (gui_data.drive_writing[pled]) {
+                    on_rgb = 0xcc0000;
+                    on_rgb2 = 0x880000;
+                }
+                half = gui_data.drive_side ? 1 : -1;
+                if (gui_data.df[pled][0] == 0)
+                {
+                    pen_rgb = ledcolor (0x00aaaaaa, rc, gc, bc, alpha);
+                    num2 = -1;
+                    num3 = -1;
+                }
             }
             side = gui_data.drive_side;
         } else if (led == LED_POWER) {
@@ -155,15 +159,15 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
                 num2 = 10;
                 num3 = 12;
             }
-        } else if (led == LED_HD) {
-            pos = 5;
+        } else if (led == LED_HD && gui_data.hd >= 0) {
+            pos = 9;
             if (gui_data.hd >= 0) {
                 on = gui_data.hd;
                 on_rgb = on == 2 ? 0x333300 : 0xcccc00;
                 off_rgb = 0x333300;
                 num1 = -1;
-                num2 = 11;
-                num3 = 12;
+                num2 = -1;//11;
+                num3 = -1;//12;
             }
         } else if (led == LED_FPS) {
             pos = 10;


### PR DESCRIPTION
- Zoom toggling fixed to obey core option better
- No more crashing when ejecting a non-existing disk, thanks to an unwarranted strlen
- Statusline made shorter by replacing last floppy LED with hard disk LED when HD enabled
- Removed statusline floppy indicator track numbers when ejected and also HD text
- More readable and useful logging at startup and at runtime
