### PR TITLE
File support changes

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -148,4 +148,4 @@ SOURCES_C += $(DEPS_DIR)/zlib/adler32.c \
 				 $(DEPS_DIR)/zlib/zutil.c
 endif
 
-CFLAGS += -DLIBRETRO_PUAE -DCAPS
+CFLAGS += -DLIBRETRO_PUAE -DCAPS -DA_DMS

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ And of course for the RetroArch/Libretro team: "http://www.libretro.com/"
 You can pass a disk or a hard drive image as a rom.
 
 Supported formats are:
-- **ADF**, **DMS**, **FDI**, **IPF** files for disk images
+- **ADF**, **ADZ**, **IPF**, **DMS**, **FDI** files for disk images
 - **HDF**, **HDZ** for hard drive images
 - **M3U** for multiple disk images
 
@@ -104,7 +104,7 @@ When a game ask for it, you can change the current disk in the RetroArch 'Disk C
 - Select the right disk index
 - Insert the new disk with 'Disk Cycle Tray Status'
 
-Note: ZIP support is provided by RetroArch and is done before passing the game to the core. So, when using a M3U file, the specified disk image must be uncompressed (ADF, DMS, FDI, IPF file formats).
+Note: ZIP support is provided by RetroArch and is done before passing the game to the core. So, when using a M3U file, the specified disk image must be uncompressed (ADF, DMS, FDI, IPF file formats). ADZ (gzipped ADF) will work though.
 
 Append "(MD)" as in "MultiDrive" to the M3U filename to insert each disk in a different drive for games that support multiple drives. Only possible if there are no more than 4 disks.
 
@@ -140,7 +140,7 @@ Note the size of the HDF specified by SIZE_OF_HDF must be greater than size of t
 ### Game that needs a specific Amiga model (AGA games for instance)
 If a game needs a specific Amiga model (AGA games for instance), you can specify which model to use.
 
-To do this just add these strings to your ADF, HDF or M3U filename:
+To do this just add these strings to the filename:
 
 |String|Result|
 |---|---|
@@ -204,7 +204,7 @@ If you are using RDB HDF files, please use 0,0,0,0 instead of geometry numbers l
 - Parallel port four player joystick adapter is emulated with working two, three and four-player controls (sonninnos and rsn8887)
 - Multiple mice support using raw input driver on Windows (sonninnos)
 - Autozoom and autocentering options for large game display without borders or distortion (sonninnos)
-- Mappable hotkeys to bring up statusbar and on-screen keyboard (sonninos)
+- Mappable hotkeys to bring up statusbar and on-screen keyboard (sonninnos)
 - Analog stick mouse control (sonninnos and rsn8887)
 - On screen keyboard with easy joystick/dpad control (sonninnos and rsn8887)
 - Implement new core options with some small print explanations (sonninnos)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2317,7 +2317,7 @@ void retro_get_system_info(struct retro_system_info *info)
    info->library_version  = "2.6.1" GIT_VERSION;
    info->need_fullpath    = true;
    info->block_extract    = false;	
-   info->valid_extensions = "adf|dms|fdi|ipf|zip|hdf|hdz|uae|m3u";
+   info->valid_extensions = "adf|adz|dms|fdi|ipf|hdf|hdz|uae|m3u|zip";
 }
 
 bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
@@ -2783,10 +2783,10 @@ sortie:
 }
 
 #define ADF_FILE_EXT "adf"
+#define ADZ_FILE_EXT "adz"
 #define FDI_FILE_EXT "fdi"
 #define DMS_FILE_EXT "dms"
 #define IPF_FILE_EXT "ipf"
-#define ZIP_FILE_EXT "zip"
 #define HDF_FILE_EXT "hdf"
 #define HDZ_FILE_EXT "hdz"
 #define UAE_FILE_EXT "uae"
@@ -2804,14 +2804,14 @@ bool retro_load_game(const struct retro_game_info *info)
 			
 	  // If argument is a disk or hard drive image file
 	  if (  strendswith(full_path, ADF_FILE_EXT)
-         || strendswith(full_path, FDI_FILE_EXT)
-         || strendswith(full_path, DMS_FILE_EXT)
-         || strendswith(full_path, IPF_FILE_EXT)
-         || strendswith(full_path, ZIP_FILE_EXT)
-         || strendswith(full_path, HDF_FILE_EXT)
-         || strendswith(full_path, HDZ_FILE_EXT)
-         || strendswith(full_path, M3U_FILE_EXT))
-	  {
+	     || strendswith(full_path, ADZ_FILE_EXT)
+	     || strendswith(full_path, FDI_FILE_EXT)
+	     || strendswith(full_path, DMS_FILE_EXT)
+	     || strendswith(full_path, IPF_FILE_EXT)
+	     || strendswith(full_path, HDF_FILE_EXT)
+	     || strendswith(full_path, HDZ_FILE_EXT)
+	     || strendswith(full_path, M3U_FILE_EXT))
+      {
 	     path_join((char*)&RPATH, retro_save_directory, LIBRETRO_PUAE_CONF);
 	     fprintf(stdout, "[libretro-uae]: Generating temporary config file '%s'\n", (const char*)&RPATH);
 


### PR DESCRIPTION
- DMS support was not working at all despite being on the valid extension list
- Internal ZIP support is not working (and did not succeed in it), and a ZIP will never go that far in the first place, because RA does the unzipping, so changed it to ADZ (gzipped ADF) which does work

Also is there a real reason to keep the FDI format? I tried to search for a disk for testing but couldn't find one in a reasonable time.
