### PR TITLE
Automatic default modes for core options: model & filter type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The following models are provided (hardcoded configuration):
 |---|---|
 |A500|Amiga 500 with OCS chipset, 0.5MB Chip RAM + 0.5MB Slow RAM|
 |A500OG|Amiga 500 with OCS chipset, 0.5MB Chip RAM|
-|A500+|Amiga 500+ with ECS chipset, 1MB Chip RAM + 1MB Slow RAM|
+|A500+|Amiga 500+ with ECS chipset, 1MB Chip RAM|
 |A600|Amiga 600 with ECS chipset, 2MB Chip RAM + 8MB Fast RAM|
 |A1200|Amiga 1200 with AGA chipset, 2MB Chip RAM + 8MB Fast RAM|
 |A1200OG|Amiga 1200 with AGA chipset, 2MB Chip RAM|
@@ -140,23 +140,23 @@ Note the size of the HDF specified by SIZE_OF_HDF must be greater than size of t
 ### Game that needs a specific Amiga model (AGA games for instance)
 If a game needs a specific Amiga model (AGA games for instance), you can specify which model to use.
 
-To do this just add these strings to the filename:
+To do this just add the particular string to the filename:
 
 |String|Result|
 |---|---|
-|(A500) or (OCS)|Amiga 500|
-|(A500OG) or (512K)|Amiga 500 without memory expansion|
-|(A500+) or (A500PLUS)|Amiga 500+|
-|(A600) or (ECS)|Amiga 600|
-|(A1200) or (AGA)|Amiga 1200|
-|(A1200OG) or (A1200NF)|Amiga 1200 without memory expansion|
-|(NTSC)|NTSC|
-|(PAL)|PAL|
-|(MD)|Insert each disk in a different drive (Maximum 4 disks)|
+|**(A500)** or **OCS**|Amiga 500|
+|**(A500OG)** or **(512K)**|Amiga 500 without memory expansion|
+|**(A500+)** or **(A500PLUS)**|Amiga 500+|
+|**(A600)** or **ECS**|Amiga 600|
+|**(A1200)** or **AGA**|Amiga 1200|
+|**(A1200OG)** or **(A1200NF)**|Amiga 1200 without memory expansion|
+|**(NTSC)**|NTSC 60Hz|
+|**(PAL)**|PAL 50Hz|
+|**(MD)**|Insert each disk in a different drive (Maximum 4 disks)|
 
-Example: When launching "Alien Breed 2 (AGA).hdf" file the core will use an Amiga 1200 model.
+Example: When launching "Alien Breed 2 (AGA).hdf" file the core will use the Amiga 1200 model.
 
-If no special string is found the core will use the model configured in core options.
+If no special string is found the core will use the model configured in the core options. The model core option at 'Automatic' will select A500 when booting floppy disks and A600 when booting hard drives.
 
 ### Resolution and rendering
 These parameters control the output resolution of the core:

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -1175,7 +1175,7 @@ void update_input(int disable_physical_cursor_keys)
 void retro_poll_event()
 {
    /* If RetroPad is controlled with keyboard keys, then prevent RetroPad from generating keyboard key presses */
-   if (!opt_keyboard_pass_through && ALTON==-1 &&
+   if (!opt_keyboard_pass_through && ALTON==-1 && uae_devices[0] != RETRO_DEVICE_UAE_KEYBOARD &&
       (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) ||
        input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) ||
        input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) ||
@@ -1192,7 +1192,7 @@ void retro_poll_event()
    )
       update_input(2); /* Skip all keyboard input when RetroPad buttons are pressed */
 
-   else if (!opt_keyboard_pass_through && ALTON==-1 &&
+   else if (!opt_keyboard_pass_through && ALTON==-1 && uae_devices[0] != RETRO_DEVICE_UAE_KEYBOARD &&
       (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
        input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
        input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
@@ -1201,7 +1201,7 @@ void retro_poll_event()
    )
       update_input(1); /* Process all inputs but disable cursor keys */
 
-   else if (!opt_keyboard_pass_through && ALTON==-1 &&
+   else if (!opt_keyboard_pass_through && ALTON==-1 && uae_devices[1] != RETRO_DEVICE_UAE_KEYBOARD &&
       (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) ||
        input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) ||
        input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) ||
@@ -1252,7 +1252,7 @@ void retro_poll_event()
                   if (i==0 || (i>3 && i<9)) // DPAD + B + A
                   {
                      // Skip 2nd fire if keymapped
-                     if(retro_port==0 && i==RETRO_DEVICE_ID_JOYPAD_A && mapper_keys[RETRO_DEVICE_ID_JOYPAD_A]!=0)
+                     if (retro_port==0 && i==RETRO_DEVICE_ID_JOYPAD_A && mapper_keys[RETRO_DEVICE_ID_JOYPAD_A]!=0)
                         continue;
 
                      ProcessController(retro_port, i);
@@ -1309,13 +1309,13 @@ void retro_poll_event()
       }
 
       // Second mouse buttons only when enabled
-      if(opt_multimouse)
-          if (!uae_mouse_l[1] && !uae_mouse_r[1])
-          {
-             uae_mouse_l[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
-             uae_mouse_r[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
-             uae_mouse_m[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE);
-          }
+      if (opt_multimouse)
+         if (!uae_mouse_l[1] && !uae_mouse_r[1])
+         {
+            uae_mouse_l[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
+            uae_mouse_r[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
+            uae_mouse_m[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE);
+         }
 
       // Joypad movement only with digital mouse mode and virtual keyboard hidden
       if (MOUSEMODE==1 && SHOWKEY==-1 && (uae_devices[0] == RETRO_DEVICE_JOYPAD || uae_devices[1] == RETRO_DEVICE_JOYPAD))
@@ -1434,18 +1434,18 @@ void retro_poll_event()
       }
 
       // Second mouse movement only when enabled
-      if(opt_multimouse)
-          if (!uae_mouse_x[1] && !uae_mouse_y[1])
-          {
-             mouse_x[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
-             mouse_y[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
+      if (opt_multimouse)
+         if (!uae_mouse_x[1] && !uae_mouse_y[1])
+         {
+            mouse_x[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
+            mouse_y[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
 
-             if (mouse_x[1] || mouse_y[1])
-             {
-                uae_mouse_x[1] = mouse_x[1];
-                uae_mouse_y[1] = mouse_y[1];
-             }
-          }
+            if (mouse_x[1] || mouse_y[1])
+            {
+               uae_mouse_x[1] = mouse_x[1];
+               uae_mouse_y[1] = mouse_y[1];
+            }
+         }
 
       // Ports 1 & 2
       for (j = 0; j < 2; j++)


### PR DESCRIPTION
Since the default A500 is not HD bootable, the new default automatic mode makes juggling between floppies and hard drives more convenient. It selects A500 with floppies and A600 with hard drives, if there is no filename override tags.

Also made the new automatic sound filter type the default, because of course it should match the used model.

Removed the need for ()-chars with OCS, ECS & AGA tags, because AGA games tend to already have AGA in the title, so no need to make it `AGA (AGA)` or change it to `(AGA)`.

Altered A500+ model to be more realistic with only chip ram.

And the bonus is yet another tinkering with the keyboard pass-through.
