### PR TITLE
Fix linux-arm7neonhf build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 CORE_DIR  := .
 ROOT_DIR  := .
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
 	LDFLAGS += -lpthread


### PR DESCRIPTION
- [Buildbot](http://paste.libretro.com/176027) is using `platform=unix-armv7-hardfloat-neon` for linux-arm7neonhf build

- So now it matches platform which contains `unix` not strictly `unix`
