### PR TITLE
Video maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,16 @@ It is critical to use Kickstarts with the correct MD5, otherwise the core might 
 |kick37175.A500|Kickstart v2.04 (Rev. 37.175)|Amiga 500+|dc10d7bdd1b6f450773dfb558477c230|
 |kick40063.A600|Kickstart v3.1 (Rev. 40.063)|Amiga 600|e40a5dfb3d017ba8779faba30cbd1c8e|
 |kick40068.A1200|Kickstart v3.1 (Rev. 40.068)|Amiga 1200|646773759326fbac3b2311fd8c8793ee|
-|kick40060.CD32|Kickstart v3.1 (Rev. 40.060)|Amiga CD32|5f8924d013dd57a89cf349f4cdedc6b1|
+
+For CD32 you need either separate ROMs (Kickstart + extended ROM) or the combined ROM:
+
+|Name|Description|System|MD5|
+|---|---|---|---|
+|kick40060.CD32|CD32 (KS + extended) v3.1 (Rev. 40.060)|Amiga CD32|f2f241bf094168cfb9e7805dc2856433|
+| **OR** | | | |
+|kick40060.CD32|CD32 Kickstart v3.1 (Rev. 40.060)|Amiga CD32|5f8924d013dd57a89cf349f4cdedc6b1|
 |kick40060.CD32.ext|CD32 Extended ROM (Rev. 40.060)|Amiga CD32|bb72565701b1b6faece07d68ea5da639|
+
 
 ### Resolution and rendering
 These parameters control the output resolution of the core:
@@ -91,7 +99,7 @@ You can pass a disk image, a hard drive image, or a playlist file for disk image
 
 Supported formats are:
 - **ADF**, **ADZ**, **IPF**, **DMS**, **FDI** files for floppy disk images
-- **ISO**, **CUE**, **CCD**, **NRG**, files for CD images
+- **ISO**, **CUE**, **CCD**, **NRG** files for CD images
 - **HDF**, **HDZ** for hard drive images
 - **M3U** for multiple disk image playlist
 
@@ -152,7 +160,7 @@ Grab the new version from the repo: https://github.com/libretro/libretro-uae/tre
 - `WHDLoad.prefs` will be copied from the system directory, if it exists. It needs to be there for the core option overrides to work.
 - `WHDLoad.key` will be copied from the system directory if you have registered WHDLoad.
 - Supports a file named `custom` in the root of the game.hdf for passing specific WHDLoad parameters when the slave does not support the config screen or when it should be the default, for example `Custom1=1`. It always overrides `WHDLoad.prefs`.
-  - The Easiest way to create `custom` is to quit WHDLoad (default key Numpad*), type `echo custom1=1 >custom`, press enter and reboot the Amiga.
+  - The easiest way to create `custom` is to quit WHDLoad (default Numpad*), type `echo custom1=1 >custom`, press enter and reboot the Amiga.
 - Supports a file named `load` in the root of the game.hdf which overrides the whole launch command, aimed at non-WHDLoad installs.
 - 'Use WHDLoad.hdf' core option does not need to be disabled when launching a non-WHDLoad HDF which has its own startup-sequence.
 - NTSC parameter can be used with WHDLoad.

--- a/libretro/graph.c
+++ b/libretro/graph.c
@@ -95,8 +95,29 @@ void DrawHlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned
    for(i=x;i<x+dx;i++)
    {
       idx=i+y*retrow;
-      buffer[idx]=color;		
+      buffer[idx]=color;
    }
+}
+
+void DrawHlineBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color)
+{
+   int i,j,idx;
+
+   (void)j;
+
+   for(i=x;i<x+dx;i++)
+   {
+      idx=i+y*retrow;
+      buffer[idx]=color;
+   }
+}
+
+void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color)
+{
+   if (pix_bytes == 4)
+      DrawHlineBmp32((uint32_t *)buffer, x, y, dx, dy, (uint32_t)color);
+   else
+      DrawHlineBmp(buffer, x, y, dx, dy, color);
 }
 
 void DrawVlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color)

--- a/libretro/graph.h
+++ b/libretro/graph.h
@@ -14,7 +14,11 @@ extern void DrawBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, uns
 extern void DrawBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
 
 extern void DrawPointBmp(unsigned short *buffer, int x, int y, unsigned short color);
+
 extern void DrawHlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+extern void DrawHlineBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
+extern void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+
 extern void DrawVlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
 extern void DrawlineBmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color);
 

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -19,8 +19,10 @@ extern cothread_t mainThread;
 extern cothread_t emuThread;
 extern int retrow; 
 extern int retroh;
+extern int pix_bytes;
 extern int zoomed_height;
 extern bool retro_update_av_info(bool, bool, bool);
+extern void reset_drawing();
 
 #define LOGI printf
 
@@ -32,9 +34,7 @@ extern bool retro_update_av_info(bool, bool, bool);
 #define RGB888(r, g, b) (((r * 255 / 31) << (16)) | ((g * 255 / 31) << 8) | (b * 255 / 31))
 
 #define EMULATOR_DEF_WIDTH 720
-#define EMULATOR_DEF_HEIGHT 574
-#define EMULATOR_MAX_WIDTH 1024
-#define EMULATOR_MAX_HEIGHT 1024
+#define EMULATOR_DEF_HEIGHT 576
 
 #ifndef _WIN32
 #define TCHAR char /* from sysdeps.h */

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -37,8 +37,6 @@ void gettimeofday (struct timeval *tv, void *blah)
 #include <time.h>
 #endif
 
-unsigned short int retro_bmp[EMULATOR_DEF_WIDTH*EMULATOR_DEF_HEIGHT];
-
 // Mouse speed flags
 #define MOUSE_SPEED_SLOWER 1
 #define MOUSE_SPEED_FASTER 2
@@ -49,8 +47,6 @@ unsigned short int retro_bmp[EMULATOR_DEF_WIDTH*EMULATOR_DEF_HEIGHT];
 int NPAGE=-1;
 int SHIFTON=-1,ALTON=-1;
 int MOUSEMODE=-1,SHOWKEY=-1,SHOWKEYPOS=-1,SHOWKEYTRANS=-1,STATUSON=-1,LEDON=-1;
-
-char RPATH[512];
 
 unsigned int mouse_speed[2]={0};
 extern int pix_bytes;
@@ -66,6 +62,7 @@ static int mflag[2][16]={0};
 static int jbt[2][24]={0};
 static int kbt[16]={0};
 
+extern unsigned short int retro_bmp[(EMULATOR_DEF_WIDTH*EMULATOR_DEF_HEIGHT*2)];
 extern void reset_drawing(void);
 extern void retro_key_up(int);
 extern void retro_key_down(int);
@@ -118,12 +115,12 @@ void emu_function(int function)
    {
       case EMU_VKBD:
          SHOWKEY = -SHOWKEY;
-         Screen_SetFullUpdate();
+         reset_drawing();
          break;
       case EMU_STATUSBAR:
          STATUSON = -STATUSON;
          LEDON = -LEDON;
-         Screen_SetFullUpdate();
+         reset_drawing();
          break;
       case EMU_MOUSE_TOGGLE:
          MOUSEMODE = -MOUSEMODE;
@@ -421,11 +418,6 @@ void Print_Status(void)
       Draw_text(retro_bmp,STAT_DECX+80,STAT_BASEY,FONT_COLOR,0x0000,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT3);
       Draw_text(retro_bmp,STAT_DECX+120,STAT_BASEY,FONT_COLOR,0x0000,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT4);
    }
-}
-
-void Screen_SetFullUpdate(void)
-{
-   reset_drawing();
 }
 
 void ProcessKeyrah()
@@ -766,7 +758,7 @@ void ProcessKey(int disable_physical_cursor_keys)
             retro_key_down(keyboard_translation[i]);
             retro_key_up(keyboard_translation[i]);
             SHIFTON=-SHIFTON;
-            Screen_SetFullUpdate();
+            reset_drawing();
             key_state2[i]=1;
          }
          else if (!key_state[i] && key_state2[i]==1)
@@ -1133,7 +1125,7 @@ void update_input(int disable_physical_cursor_keys)
       {
          /* Movement needs screen refresh in transparent mode */
          if (SHOWKEYTRANS==1)
-            Screen_SetFullUpdate();
+            reset_drawing();
 
          long now = GetTicks();
          if (let_go_of_direction)
@@ -1176,7 +1168,7 @@ void update_input(int disable_physical_cursor_keys)
       {
          vkflag[6]=1;
          SHOWKEYPOS=-SHOWKEYPOS;
-         Screen_SetFullUpdate();
+         reset_drawing();
       }
       else if (vkflag[6]==1 && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
@@ -1189,7 +1181,7 @@ void update_input(int disable_physical_cursor_keys)
       {
          vkflag[5]=1;
          SHOWKEYTRANS=-SHOWKEYTRANS;
-         Screen_SetFullUpdate();
+         reset_drawing();
       }
       else if (vkflag[5]==1 && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
@@ -1213,7 +1205,7 @@ void update_input(int disable_physical_cursor_keys)
          {
             oldi=-1;
             NPAGE=-NPAGE;
-            Screen_SetFullUpdate();
+            reset_drawing();
          }
          else if (i < -10)
          {
@@ -1250,7 +1242,7 @@ void update_input(int disable_physical_cursor_keys)
                retro_key_down(i);
                retro_key_up(i);
                SHIFTON=-SHIFTON;
-               Screen_SetFullUpdate();
+               reset_drawing();
                oldi=-1;
             }
             else

--- a/libretro/libretro-mapper.h
+++ b/libretro/libretro-mapper.h
@@ -5,8 +5,6 @@ extern int SHOWKEY;
 extern int vkb_pos_x;
 extern int vkb_pos_y;
 
-void Screen_SetFullUpdate(void);
-
 #define RETRO_DEVICE_UAE_JOYSTICK         RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 0)
 #define RETRO_DEVICE_UAE_CD32PAD          RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 1)
 #define RETRO_DEVICE_UAE_KEYBOARD         RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_KEYBOARD, 0)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -19,12 +19,6 @@
 #include "blkdev.h"
 extern void check_changes(int unitnum);
 
-#define UAE_HZ_PAL 49.9201
-#define UAE_HZ_NTSC 59.8251
-
-#if EMULATOR_DEF_WIDTH < 0 || EMULATOR_DEF_WIDTH > EMULATOR_MAX_WIDTH || EMULATOR_DEF_HEIGHT < 0 || EMULATOR_DEF_HEIGHT > EMULATOR_MAX_HEIGHT
-#error EMULATOR_DEF_WIDTH || EMULATOR_DEF_HEIGHT
-#endif
 
 cothread_t mainThread;
 cothread_t emuThread;
@@ -70,12 +64,13 @@ extern uae_u8 *natmem_offset;
 extern uae_u32 natmem_size;
 #endif
 
-extern unsigned short int retro_bmp[EMULATOR_DEF_WIDTH*EMULATOR_DEF_HEIGHT];
+unsigned short int retro_bmp[(EMULATOR_DEF_WIDTH*EMULATOR_DEF_HEIGHT*2)];
+char RPATH[512];
+static int firstpass = 1;
 extern int SHIFTON;
 extern int STATUSON;
-extern char RPATH[512];
 extern void Print_Status(void);
-static int firstpass = 1;
+extern void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
 extern int prefs_changed;
 
 int opt_vertical_offset = 0;
@@ -208,6 +203,7 @@ floppy0type=-1\n"
 #define CD32_ROM                "kick40060.CD32"
 #define CD32_ROM_EXT            "kick40060.CD32.ext"
 
+// Amiga video
 #define PUAE_VIDEO_PAL          0x01
 #define PUAE_VIDEO_NTSC         0x02
 #define PUAE_VIDEO_HIRES        0x04
@@ -220,6 +216,12 @@ floppy0type=-1\n"
 #define PUAE_VIDEO_NTSC_LO      PUAE_VIDEO_NTSC
 #define PUAE_VIDEO_NTSC_HI      PUAE_VIDEO_NTSC|PUAE_VIDEO_HIRES
 #define PUAE_VIDEO_NTSC_HI_SL   PUAE_VIDEO_NTSC|PUAE_VIDEO_HIRES_SINGLE
+
+#define PUAE_VIDEO_HZ_PAL       49.9201
+#define PUAE_VIDEO_HZ_NTSC      59.8251
+#define PUAE_VIDEO_WIDTH        720
+#define PUAE_VIDEO_HEIGHT_PAL   576
+#define PUAE_VIDEO_HEIGHT_NTSC  480
 
 // Amiga files
 #define ADF_FILE_EXT "adf"
@@ -365,7 +367,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "puae_video_resolution",
          "Video Resolution",
-         "Restart required.",
+         "Changing will issue soft reset.",
          {
             { "lores", "Low" },
             { "hires_single", "High (Single line)" },
@@ -1231,22 +1233,45 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
+      int video_config_old = video_config;
+
       if (strcmp(var.value, "hires_double") == 0)
       {
          video_config |= PUAE_VIDEO_HIRES;
          video_config &= ~PUAE_VIDEO_HIRES_SINGLE;
+         max_diwlastword = 824;
+         if (!firstpass)
+         {
+            changed_prefs.gfx_resolution=RES_HIRES;
+            changed_prefs.gfx_vresolution=VRES_DOUBLE;
+         }
       }
       else if (strcmp(var.value, "hires_single") == 0)
       {
          video_config |= PUAE_VIDEO_HIRES_SINGLE;
          video_config &= ~PUAE_VIDEO_HIRES;
+         max_diwlastword = 824;
+         if (!firstpass)
+         {
+            changed_prefs.gfx_resolution=RES_HIRES;
+            changed_prefs.gfx_vresolution=VRES_NONDOUBLE;
+         }
       }
       else if (strcmp(var.value, "lores") == 0)
       {
          video_config &= ~PUAE_VIDEO_HIRES;
          video_config &= ~PUAE_VIDEO_HIRES_SINGLE;
-         max_diwlastword = max_diwlastword / 2;
+         max_diwlastword = 412;
+         if (!firstpass)
+         {
+            changed_prefs.gfx_resolution=RES_LORES;
+            changed_prefs.gfx_vresolution=VRES_NONDOUBLE;
+         }
       }
+
+      /* Resolution change requires Amiga reset */
+      if (!firstpass && video_config != video_config_old)
+         uae_reset(0, 0);
    }
 
    var.key = "puae_statusbar";
@@ -1276,7 +1301,7 @@ static void update_variables(void)
 
       /* Screen refresh required */
       if (opt_statusbar_position_old != opt_statusbar_position || !opt_enhanced_statusbar)
-         Screen_SetFullUpdate();
+         reset_drawing();
 
       opt_statusbar_position_old = opt_statusbar_position;
    }
@@ -2085,39 +2110,39 @@ static void update_variables(void)
    switch (video_config)
    {
 		case PUAE_VIDEO_PAL_HI:
-			defaultw = 720;
-			defaulth = 574;
+			defaultw = PUAE_VIDEO_WIDTH;
+			defaulth = PUAE_VIDEO_HEIGHT_PAL;
 			strcat(uae_config, "gfx_lores=false\n");
 			strcat(uae_config, "gfx_linemode=double\n");
 			break;
 		case PUAE_VIDEO_PAL_HI_SL:
-			defaultw = 720;
-			defaulth = 287;
+			defaultw = PUAE_VIDEO_WIDTH;
+			defaulth = PUAE_VIDEO_HEIGHT_PAL / 2;
 			strcat(uae_config, "gfx_lores=false\n");
 			strcat(uae_config, "gfx_linemode=none\n");
 			break;
 		case PUAE_VIDEO_PAL_LO:
-			defaultw = 360;
-			defaulth = 287;
+			defaultw = PUAE_VIDEO_WIDTH / 2;
+			defaulth = PUAE_VIDEO_HEIGHT_PAL / 2;
 			strcat(uae_config, "gfx_lores=true\n");
 			strcat(uae_config, "gfx_linemode=none\n");
 			break;
 
 		case PUAE_VIDEO_NTSC_HI:
-			defaultw = 720;
-			defaulth = 480;
+			defaultw = PUAE_VIDEO_WIDTH;
+			defaulth = PUAE_VIDEO_HEIGHT_NTSC;
 			strcat(uae_config, "gfx_lores=false\n");
 			strcat(uae_config, "gfx_linemode=double\n");
 			break;
 		case PUAE_VIDEO_NTSC_HI_SL:
-			defaultw = 720;
-			defaulth = 240;
+			defaultw = PUAE_VIDEO_WIDTH;
+			defaulth = PUAE_VIDEO_HEIGHT_NTSC / 2;
 			strcat(uae_config, "gfx_lores=false\n");
 			strcat(uae_config, "gfx_linemode=none\n");
 			break;
 		case PUAE_VIDEO_NTSC_LO:
-			defaultw = 360;
-			defaulth = 240;
+			defaultw = PUAE_VIDEO_WIDTH / 2;
+			defaulth = PUAE_VIDEO_HEIGHT_NTSC / 2;
 			strcat(uae_config, "gfx_lores=true\n");
 			strcat(uae_config, "gfx_linemode=none\n");
 			break;
@@ -2417,8 +2442,6 @@ void retro_init(void)
 
 void retro_deinit(void)
 {	
-   leave_program();
-
    if (emuThread)
       co_delete(emuThread);
    emuThread = 0;
@@ -2563,29 +2586,29 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
    switch (video_config_geometry)
    {
       case PUAE_VIDEO_PAL_HI:
-         retrow = 720;
-         retroh = 574;
+         retrow = PUAE_VIDEO_WIDTH;
+         retroh = PUAE_VIDEO_HEIGHT_PAL;
          break;
       case PUAE_VIDEO_PAL_HI_SL:
-         retrow = 720;
-         retroh = 287;
+         retrow = PUAE_VIDEO_WIDTH;
+         retroh = PUAE_VIDEO_HEIGHT_PAL / 2;
          break;
       case PUAE_VIDEO_PAL_LO:
-         retrow = 360;
-         retroh = 287;
+         retrow = PUAE_VIDEO_WIDTH / 2;
+         retroh = PUAE_VIDEO_HEIGHT_PAL / 2;
          break;
 
       case PUAE_VIDEO_NTSC_HI:
-         retrow = 720;
-         retroh = 480;
+         retrow = PUAE_VIDEO_WIDTH;
+         retroh = PUAE_VIDEO_HEIGHT_NTSC;
          break;
       case PUAE_VIDEO_NTSC_HI_SL:
-         retrow = 720;
-         retroh = 240;
+         retrow = PUAE_VIDEO_WIDTH;
+         retroh = PUAE_VIDEO_HEIGHT_NTSC / 2;
          break;
       case PUAE_VIDEO_NTSC_LO:
-         retrow = 360;
-         retroh = 240;
+         retrow = PUAE_VIDEO_WIDTH / 2;
+         retroh = PUAE_VIDEO_HEIGHT_NTSC / 2;
          break;
    }
 
@@ -2649,7 +2672,6 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
    }
 
    /* Apply zoom mode if necessary */
-   zoomed_height = retroh;
    switch (zoom_mode_id)
    {
       case 1:
@@ -2696,7 +2718,7 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
          break;
       case 8:
          if (thisframe_first_drawn_line != thisframe_last_drawn_line
-         && thisframe_first_drawn_line > 0 && thisframe_last_drawn_line > 0
+          && thisframe_first_drawn_line > 0 && thisframe_last_drawn_line > 0
          )
          {
             zoomed_height = thisframe_last_drawn_line - thisframe_first_drawn_line + 1;
@@ -2709,6 +2731,9 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
             zoomed_height = (zoomed_height < 200) ? 200 : zoomed_height;
          break;
       default:
+         zoomed_height = retroh;
+         if (fake_ntsc)
+            zoomed_height = 460;
          break;
    }
 
@@ -2732,19 +2757,23 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
       if (opt_statusbar_position >= 0 && (retroh - zoomed_height - opt_statusbar_position_offset) > opt_statusbar_position)
          opt_statusbar_position = retroh - zoomed_height - opt_statusbar_position_offset;
 
+      /* Exception for Dyna Blaster */
+      if (fake_ntsc)
+         opt_statusbar_position -= (retroh - defaulth);
+
       //fprintf(stdout, "ztatusbar:%3d old:%3d offset:%3d, retroh:%d defaulth:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, retroh, defaulth);
    }
 
    /* If zoom mode should be centered automagically */
-   if (opt_vertical_offset_auto && zoom_mode_id != 0 && firstpass != 1)
+   if (opt_vertical_offset_auto && (zoom_mode_id != 0 || zoomed_height != retroh) && firstpass != 1)
    {
       int zoomed_height_normal = (video_config & PUAE_VIDEO_HIRES) ? zoomed_height / 2 : zoomed_height;
       int thisframe_y_adjust_new = minfirstline;
 
       /* Need proper values for calculations */
       if (thisframe_first_drawn_line != thisframe_last_drawn_line
-      && thisframe_first_drawn_line > 0 && thisframe_last_drawn_line > 0 
-      && thisframe_first_drawn_line < 150 && thisframe_last_drawn_line > 150
+       && thisframe_first_drawn_line > 0 && thisframe_last_drawn_line > 0
+       && (thisframe_first_drawn_line < 150 || thisframe_last_drawn_line > 150)
       )
          thisframe_y_adjust_new = (thisframe_last_drawn_line - thisframe_first_drawn_line - zoomed_height_normal) / 2 + thisframe_first_drawn_line; // Smart
          //thisframe_y_adjust_new = thisframe_first_drawn_line + ((thisframe_last_drawn_line - thisframe_first_drawn_line) - zoomed_height_normal) / 2; // Simple
@@ -2752,6 +2781,8 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
       /* Sensible limits */
       thisframe_y_adjust_new = (thisframe_y_adjust_new < 0) ? 0 : thisframe_y_adjust_new;
       thisframe_y_adjust_new = (thisframe_y_adjust_new > (minfirstline + 50)) ? (minfirstline + 50) : thisframe_y_adjust_new;
+      if (thisframe_first_drawn_line == -1 && thisframe_last_drawn_line == -1)
+          thisframe_y_adjust_new = thisframe_y_adjust_old;
 
       /* Change value only if altered */
       if (thisframe_y_adjust != thisframe_y_adjust_new)
@@ -2771,13 +2802,15 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
 
       /* Need proper values for calculations */
       if (min_diwstart != max_diwstop
-      && min_diwstart > 0 && max_diwstop > 0
-      && min_diwstart < 200 && max_diwstop > 600
+       && min_diwstart > 0 && max_diwstop > 0
+       && min_diwstart < 220 && max_diwstop > 600
       )
       {
          visible_left_border_new = (max_diwstop - min_diwstart - retrow) / 2 + min_diwstart; // Smart
          //visible_left_border_new = max_diwstop - retrow - (max_diwstop - min_diwstart - retrow) / 2; // Simple
       }
+      else if (min_diwstart == 30000 && max_diwstop == 0)
+         visible_left_border_new = visible_left_border;
 
       /* Change value only if altered */
       if (visible_left_border != visible_left_border_new)
@@ -2818,8 +2851,8 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    static struct retro_game_geometry geom;
    geom.base_width=retrow;
    geom.base_height=retroh;
-   geom.max_width=EMULATOR_MAX_WIDTH;
-   geom.max_height=EMULATOR_MAX_HEIGHT;
+   geom.max_width=EMULATOR_DEF_WIDTH;
+   geom.max_height=EMULATOR_DEF_HEIGHT;
 
    if (retro_get_region() == RETRO_REGION_NTSC)
       geom.aspect_ratio=(float)retrow/(float)retroh * 44.0/52.0;
@@ -2831,7 +2864,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 
    info->geometry = geom;
    info->timing.sample_rate = 44100.0;
-   info->timing.fps = (retro_get_region() == RETRO_REGION_NTSC) ? UAE_HZ_NTSC : UAE_HZ_PAL;
+   info->timing.fps = (retro_get_region() == RETRO_REGION_NTSC) ? PUAE_VIDEO_HZ_NTSC : PUAE_VIDEO_HZ_PAL;
 }
 
 void retro_set_audio_sample(retro_audio_sample_t cb)
@@ -2862,7 +2895,7 @@ void retro_reset(void)
 
 void retro_audio_cb(short l, short r)
 {
-   audio_cb(l,r);
+   audio_cb(l, r);
 }
 
 void retro_run(void)
@@ -2877,9 +2910,17 @@ void retro_run(void)
    {
       if (thisframe_first_drawn_line != thisframe_first_drawn_line_old || thisframe_last_drawn_line != thisframe_last_drawn_line_old)
       {
-         thisframe_first_drawn_line_old = thisframe_first_drawn_line;
-         thisframe_last_drawn_line_old = thisframe_last_drawn_line;
-         request_update_av_info = true;
+         // Prevent interlace stuttering by requiring a change of at least 2 lines
+         if (abs(thisframe_first_drawn_line_old - thisframe_first_drawn_line) > 1)
+         {
+            thisframe_first_drawn_line_old = thisframe_first_drawn_line;
+            request_update_av_info = true;
+         }
+         if (abs(thisframe_last_drawn_line_old - thisframe_last_drawn_line) > 1)
+         {
+            thisframe_last_drawn_line_old = thisframe_last_drawn_line;
+            request_update_av_info = true;
+         }
       }
       // Timer required for unserialize recovery
       else if (thisframe_first_drawn_line == thisframe_first_drawn_line_old)
@@ -2952,6 +2993,19 @@ void retro_run(void)
       virtual_kbd(retro_bmp, vkb_pos_x, vkb_pos_y);
    if (STATUSON == 1)
       Print_Status();
+   // Maximum 288p/576p PAL shenanigans:
+   // Mask the last line(s), since UAE does not refresh the last line, and even its own OSD will leave trails
+   else if (video_config & PUAE_VIDEO_PAL)
+   {
+      if (video_config & PUAE_VIDEO_HIRES)
+      {
+         DrawHline(retro_bmp, 0, 574, retrow, 0, 0);
+         DrawHline(retro_bmp, 0, 575, retrow, 0, 0);
+      }
+      else
+         DrawHline(retro_bmp, 0, 287, retrow, 0, 0);
+   }
+
    video_cb(retro_bmp, retrow, zoomed_height, retrow << (pix_bytes / 2));
 }
 
@@ -3509,13 +3563,12 @@ bool retro_load_game(const struct retro_game_info *info)
 
    retrow = defaultw;
    retroh = defaulth;
-   memset(retro_bmp, 0, sizeof(retro_bmp));
-   Screen_SetFullUpdate();
    return true;
 }
 
 void retro_unload_game(void)
 {
+   leave_program();
 }
 
 unsigned retro_get_region(void)

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -45,7 +45,7 @@ unsigned short int clut[] = {
 
 unsigned short int* pixbuf = NULL;
 
-extern unsigned short int retro_bmp[EMULATOR_DEF_WIDTH*EMULATOR_DEF_HEIGHT];
+extern unsigned short int retro_bmp[(EMULATOR_DEF_WIDTH*EMULATOR_DEF_HEIGHT*2)];
 void retro_audio_cb(short l, short r);
 
 int prefs_changed = 0;
@@ -189,8 +189,8 @@ int graphics_init(void) {
 	//	currprefs.gfx_lores = 1;
 	//}
 	//vsync_enabled = currprefs.gfx_vsync;
-	LOG_MSG2("screen w=%i", currprefs.gfx_size_win.width);
-	LOG_MSG2("screen h=%i", currprefs.gfx_size_win.height);
+	//LOG_MSG2("screen w=%i", currprefs.gfx_size_win.width);
+	//LOG_MSG2("screen h=%i", currprefs.gfx_size_win.height);
 
 #ifdef ENABLE_LOG_SCREEN
 	pixbuf = (unsigned int*) malloc(currprefs.gfx_size_win.width * 576 * pix_bytes);
@@ -208,7 +208,7 @@ int graphics_init(void) {
 	gfxvidinfo.height_allocated = currprefs.gfx_size_win.height;
 	gfxvidinfo.maxblocklines = 1000;
 	gfxvidinfo.pixbytes = pix_bytes;
-	gfxvidinfo.rowbytes = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes ;
+	gfxvidinfo.rowbytes = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes;
 	gfxvidinfo.bufmem = (unsigned char*)pixbuf;
 	gfxvidinfo.emergmem = 0;
 	gfxvidinfo.linemem = 0;
@@ -294,16 +294,21 @@ int check_prefs_changed_gfx (void)
     changed_prefs.gfx_size_win.width = defaultw;
     changed_prefs.gfx_size_win.height = defaulth;
 
-    currprefs.gfx_size_win.width    = changed_prefs.gfx_size_win.width;
-    currprefs.gfx_size_win.height   = changed_prefs.gfx_size_win.height;
-    currprefs.gfx_xcenter           = changed_prefs.gfx_xcenter;
-    currprefs.gfx_ycenter           = changed_prefs.gfx_ycenter;
+    if (currprefs.gfx_size_win.width   != changed_prefs.gfx_size_win.width)
+        currprefs.gfx_size_win.width    = changed_prefs.gfx_size_win.width;
+    if (currprefs.gfx_size_win.height  != changed_prefs.gfx_size_win.height)
+        currprefs.gfx_size_win.height   = changed_prefs.gfx_size_win.height;
+    if (currprefs.gfx_resolution       != changed_prefs.gfx_resolution)
+        currprefs.gfx_resolution        = changed_prefs.gfx_resolution;
+    if (currprefs.gfx_vresolution      != changed_prefs.gfx_vresolution)
+        currprefs.gfx_vresolution       = changed_prefs.gfx_vresolution;
 
     gfxvidinfo.width_allocated      = currprefs.gfx_size_win.width;
     gfxvidinfo.height_allocated     = currprefs.gfx_size_win.height;
+    gfxvidinfo.rowbytes             = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes;
 
     reset_drawing();
-    //printf("check_prefs_changed_gfx: %d:%d, xcenter:%d ycenter:%d\n", changed_prefs.gfx_size_win.width, changed_prefs.gfx_size_win.height, changed_prefs.gfx_xcenter, changed_prefs.gfx_ycenter);
+    //printf("check_prefs_changed_gfx: %d:%d, res:%d vres:%d\n", changed_prefs.gfx_size_win.width, changed_prefs.gfx_size_win.height, changed_prefs.gfx_resolution, changed_prefs.gfx_vresolution);
     return 0;
 }
 

--- a/sources/src/include/drawing.h
+++ b/sources/src/include/drawing.h
@@ -4,6 +4,9 @@
  * Copyright 1996-1998 Bernd Schmidt
  */
 
+#ifndef UAE_DRAWING_H
+#define UAE_DRAWING_H
+
 #define SMART_UPDATE 1
 
 #ifdef SUPPORT_PENGUINS
@@ -304,3 +307,5 @@ STATIC_INLINE void toggle_inhibit_frame (int bit)
 {
 	inhibit_frame ^= 1 << bit;
 }
+
+#endif /* UAE_DRAWING_H */


### PR DESCRIPTION
New features:
- Video resolution core option no longer requires core restart, but only a soft reboot
- PAL resolution changed to full 576p/288p
  - A minor last line drawing thing preventing the use before is now dealt with

Issues solved:
- Many interlaced screens got zoom calculations off the rails and so zoom shaked horribly, like CD32 boot screen and Turrican Anthology Compilaton start menu
- Fire & Ice CD32 not triggering zoom correctly and not centered horizontally
- Crashing with 24-bit hires double line mode

Bonus:
- Combined CD32 KS + extended ROM file support option with the same name
  - CD32 extended ROM only searched if KS ROM size is 512KB, combined will be 1MB
- Cleanups
