### PR TITLE
Add support for auto-generated save disks in M3U playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,29 @@ Note: ZIP support is provided by RetroArch and is done before passing the game t
 
 Append "(MD)" as in "MultiDrive" to the M3U filename to insert each disk in a different drive for games that support multiple drives. Only possible if there are no more than 4 disks.
 
+For games that require a dedicated save disk, one may be generated automatically by entering the following line in an M3U file: `#SAVEDISK:VolumeName`. `VolumeName` is optional and may be omitted. For example, this will create a blank, unlabelled disk image at disk index 5:
+
+Secret of Monkey Island.m3u
+```
+Secret of Monkey Island_Disk 1.adf
+Secret of Monkey Island_Disk 2.adf
+Secret of Monkey Island_Disk 3.adf
+Secret of Monkey Island_Disk 4.adf
+#SAVEDISK:
+```
+
+Some games require save disks to have a specific label - for example, `It Came from the Desert` will only save to a disk named `DSAVE`:
+
+It Came from the Desert.m3u
+```
+It Came from the Desert_Disk 1.adf
+It Came from the Desert_Disk 2.adf
+It Came from the Desert_Disk 3.adf
+#SAVEDISK:DSAVE
+```
+
+Although one save disk is normally sufficient, an arbitrary number of `#SAVEDISK:VolumeName` lines may be included. Save disks are located in the frontend's save directory, with the following name: `[M3U_FILE_NAME].save[DISK_INDEX].adf`.
+
 ## WHDLoad
 To use WHDLoad games you'll need to have a prepared WHDLoad image named 'WHDLoad.hdf' in RetroArch system directory.
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -3363,7 +3363,7 @@ bool retro_load_game(const struct retro_game_info *info)
                if (strendswith(full_path, M3U_FILE_EXT))
                {
                   // Parse the m3u file
-                  dc_parse_m3u(dc, full_path);
+                  dc_parse_m3u(dc, full_path, retro_save_directory);
 
                   // Some debugging
                   fprintf(stdout, "[libretro-uae]: M3U file parsed, %d file(s) found\n", dc->count);

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -35,7 +35,7 @@ struct dc_storage{
 
 typedef struct dc_storage dc_storage;
 dc_storage* dc_create(void);
-void dc_parse_m3u(dc_storage* dc, const char* m3u_file);
+void dc_parse_m3u(dc_storage* dc, const char* m3u_file, const char* save_dir);
 bool dc_add_file(dc_storage* dc, const char* filename);
 void dc_free(dc_storage* dc);
 


### PR DESCRIPTION
This PR adds the ability to automatically generate one or more blank save disks when creating an M3U playlist.

- On any line of the M3U file, the following my be entered: `#SAVEDISK:VolumeName`

- `VolumeName` is the disk label - this is optional, and may be omitted to create an unlabelled disk image (only certain games require save disks to have specific labels)

- Save disks are created in the user's save directory, with the following name: `[M3U_FILE_NAME].save[DISK_INDEX].adf`

@sonninnos I realise you are the maestro when it comes to this core - please let me know if you object to anything I've done here!