### PR TITLE
Fix disk_replace_image_index() return value

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2461,6 +2461,8 @@ static bool disk_replace_image_index(unsigned index, const struct retro_game_inf
             // Image label
             fill_short_pathname_representation(image_label, info->path, sizeof(image_label));
             dc->labels[index] = strdup(image_label);
+
+            return true;
          }
       }
    }


### PR DESCRIPTION
While updating RetroArch's disk control interface code (https://github.com/libretro/RetroArch/pull/10045) I noticed that the `disk_replace_image_index()` function of this core breaks spec by always returning `false` - this will make 'append disk image' operations fail.

This trivial PR just makes `disk_replace_image_index()` return `true` when successful.