### PR TITLE
Band-aid for missing volname&filesysdir

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -834,7 +834,7 @@ void retro_set_environment(retro_environment_t cb)
             { "disabled", NULL },
             { NULL, NULL },
          },
-         "enabled"
+         "disabled"
       },
       {
          "puae_use_whdload_prefs",

--- a/sources/src/filesys.c
+++ b/sources/src/filesys.c
@@ -8276,8 +8276,13 @@ uae_u8 *save_filesys (int num, int *len)
 	else
 		save_path (ui->rootdir, SAVESTATE_PATH);
 	save_string (ui->devname);
+#ifdef __LIBRETRO__
+	save_string (ui->volname ? ui->volname : ui->devname);
+	save_path (ui->filesysdir ? ui->filesysdir : "./", SAVESTATE_PATH);
+#else
 	save_string (ui->volname);
 	save_path (ui->filesysdir, SAVESTATE_PATH);
+#endif
 	save_u8 (ui->bootpri);
 	save_u8 (ui->readonly);
 	save_u32 (ui->startup);


### PR DESCRIPTION
For some reason HDF volname is always null when doing savestates, and some platforms do not like it.

Debugging/brainstorm credits to @realnc 

Also changed default WHDSaves.hdf to disabled to use raw files.

Closes #219 