### PR TITLE
68020 fix for 'cpu_model'

### DIFF
--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -86,7 +86,7 @@ fastmem_size=8\n\
 "
 
 #define A1200_CONFIG "\
-cpu_model=68ec020\n\
+cpu_model=68020\n\
 chipset=aga\n\
 chipset_compatible=A1200\n\
 chipmem_size=4\n\
@@ -94,7 +94,7 @@ fastmem_size=8\n\
 "
 
 #define A1200OG_CONFIG "\
-cpu_model=68ec020\n\
+cpu_model=68020\n\
 chipset=aga\n\
 chipset_compatible=A1200\n\
 chipmem_size=4\n\
@@ -102,7 +102,7 @@ fastmem_size=0\n\
 "
 
 #define CD32_CONFIG "\
-cpu_model=68ec020\n\
+cpu_model=68020\n\
 chipset=aga\n\
 chipset_compatible=CD32\n\
 chipmem_size=4\n\
@@ -111,7 +111,7 @@ floppy0type=-1\n\
 "
 
 #define CD32FR_CONFIG "\
-cpu_model=68ec020\n\
+cpu_model=68020\n\
 chipset=aga\n\
 chipset_compatible=CD32\n\
 chipmem_size=4\n\


### PR DESCRIPTION
Sorry for the hassle, you merged ~30sec too soon, heh.

`68ec020` did not resolve to the correct value using `cpu_model` instead of old fashioned `cpu_type`. I changed it because `cpu_type` would not pick up `68030`.

Please merge ASAP, because otherwise A1200 & CD32 remain broken!
