### PR TITLE
Visual upgrades & CPU adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ These parameters control the output resolution of the core:
 
 |Name|Values|Default|
 |---|---|---|
-|Video Resolution|Low, High (SL), High (DL), Super-High (SL), Super-High (DL)|High (DL)|
+|Video Resolution|Low, High (SL), High (DL), Super-High (SL), Super-High (DL), Automatic (SL), Automatic (DL)|Automatic (DL)|
 |Video Standard|PAL, NTSC|PAL|
 |Aspect Ratio|PAL, NTSC, Automatic|Automatic|
 
@@ -101,24 +101,28 @@ With these settings all the standard resolutions are available:
 |PAL Resolution|Description|
 |---|---|
 |**360x288**|Lores|
-|**720x288**|Hires single line|
-|**720x576**|Hires double line|
-|**1440x288**|SuperHires single line|
-|**1440x576**|SuperHires double line|
+|**720x288**|Hires Single Line|
+|**720x576**|Hires Double Line|
+|**1440x288**|SuperHires Single Line|
+|**1440x576**|SuperHires Double Line|
 
 |NTSC Resolution|Description|
 |---|---|
 |**360x240**|Lores|
-|**720x240**|Hires single line|
-|**720x480**|Hires double line|
-|**1440x240**|SuperHires single line|
-|**1440x480**|SuperHires double line|
+|**720x240**|Hires Single Line|
+|**720x480**|Hires Double Line|
+|**1440x240**|SuperHires Single Line|
+|**1440x480**|SuperHires Double Line|
 
 When using low resolution mode, rendering will be halved horizontally. Scaling shaders looks great but high resolution games and Workbench are badly rendered.
 
 When using high resolution double line mode, rendering will be doubled vertically. It is compatible with high resolution games and Workbench, but scaling shaders will look ugly.
 
 When using high resolution single line mode, rendering is presented as is. It delivers the best of both worlds, and looks great with high resolution games, Workbench and shaders.
+
+Automatic resolution defaults to Hires and selects SuperHires when needed (practically only in Workbench and Super Skidmarks).
+
+Double Line handles deinterlacing, which will halve the framerate, and thus is best suited for still images.
 
 ## Games that need a specific model
 You can force a specific model if a game needs one (AGA games for instance).
@@ -157,7 +161,7 @@ Supported formats are:
 - **M3U** for multiple disk image playlist
 
 When passing these files as a parameter the core will generate a temporary uae configuration file in RetroArch saves directory 
-and use it to launch the game.
+and use it to launch the content.
 
 ### Floppy drive sound
 For external floppy drive sounds to work, copy the files from https://github.com/libretro/libretro-uae/tree/master/sources/uae_data into a subdirectory called `uae_data` in your RetroArch system directory.
@@ -174,7 +178,7 @@ Compatible CAPSIMG libraries for Android can be found at https://github.com/rsn8
 Please be aware that there are 32-bits and 64-bits versions of the library. Choose the one corresponding to your RetroArch executable.
 
 ### M3U support
-When you have a multi disk game, you can use a M3U file to specify each disk of the game and change them from the RetroArch Disk control interface.
+When you have a multi disk game, you can use a M3U file to specify each disk of the game and change them from the RetroArch Disk Control interface.
 
 A M3U file is a simple text file with one disk per line (see https://en.wikipedia.org/wiki/M3U).
 
@@ -335,6 +339,18 @@ hardfile=read-write,32,2,2,512,/emuroms/amiga/hdf/WHDGamesA.hdf
 hardfile=read-write,32,2,2,512,/emuroms/amiga/hdf/WHDGamesB.hdf
 hardfile=read-write,32,2,2,512,/emuroms/amiga/hdf/WHDGamesC.hdf
 ```
+
+Example 2: You want to mount a directory full of extracted data as a hard drive:
+```
+filesystem2=rw,DH0:data:/emuroms/amiga/,0
+```
+
+Windows tip:
+- If paths are enclosed with quotes, Windows needs double blackslashes: `filesystem2=rw,DH0:data:"c:\\emuroms\\amiga",0`.
+
+Linux tip:
+- Leave the ending slash to the path to make sure UAE sees it as a directory.
+
 You can then load your .uae file via Load Content.
 
 Note that for most HDF files, the model has to be set to A1200 in Quickmenu->Options. This requires a restart to take effect.

--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ These parameters control the output resolution of the core:
 
 |Name|Values|Default|
 |---|---|---|
-|Video Resolution|Low, High (SL), High (DL), Super-High (SL), Super-High (DL), Automatic (SL), Automatic (DL)|Automatic (DL)|
-|Video Standard|PAL, NTSC|PAL|
+|Video Standard|PAL 50Hz, NTSC 60Hz|PAL 50Hz|
+|Video Resolution|Low, High, Super-High, Automatic|Automatic|
+|Video Line Mode|Single Line, Double Line, Automatic|Automatic|
 |Aspect Ratio|PAL, NTSC, Automatic|Automatic|
 
 With these settings all the standard resolutions are available:
 
-|PAL Resolution|Description|
+|PAL 50Hz Resolution|Description|
 |---|---|
 |**360x288**|Lores|
 |**720x288**|Hires Single Line|
@@ -106,7 +107,7 @@ With these settings all the standard resolutions are available:
 |**1440x288**|SuperHires Single Line|
 |**1440x576**|SuperHires Double Line|
 
-|NTSC Resolution|Description|
+|NTSC 60Hz Resolution|Description|
 |---|---|
 |**360x240**|Lores|
 |**720x240**|Hires Single Line|
@@ -120,9 +121,12 @@ When using high resolution double line mode, rendering will be doubled verticall
 
 When using high resolution single line mode, rendering is presented as is. It delivers the best of both worlds, and looks great with high resolution games, Workbench and shaders.
 
-Automatic resolution defaults to Hires and selects SuperHires when needed (practically only in Workbench and Super Skidmarks).
+Single Line does bob deinterlacing, which will keep full framerate, but interlaced images will not look correct.
 
-Double Line handles deinterlacing, which will halve the framerate, and thus is best suited for still images.
+Double Line does weave deinterlacing, which will halve the framerate, and thus movement will be jerky.
+
+- Automatic Resolution defaults to Hires and selects SuperHires when needed (practically only in Workbench and Super Skidmarks).
+- Automatic Line Mode defaults to Single Line and selects Double Line on interlaced screens.
 
 ## Games that need a specific model
 You can force a specific model if a game needs one (AGA games for instance).

--- a/libretro/graph.c
+++ b/libretro/graph.c
@@ -414,7 +414,7 @@ void Draw_text(unsigned short *buffer, int x, int y,
    unsigned char c;
    char s[2] = {0};
    int charwidth = 6;
-   if (max > 4)
+   if (max > 10)
       charwidth = 7;
    int cmax;
    cmax = strlen(text);
@@ -461,7 +461,7 @@ void Draw_text32(uint32_t *buffer, int x, int y,
    unsigned char c;
    char s[2] = {0};
    int charwidth = 6;
-   if (max > 4)
+   if (max > 10)
       charwidth = 7;
    int cmax;
    cmax = strlen(text);

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -18,7 +18,7 @@ extern int retroh;
 extern int pix_bytes;
 extern int zoomed_height;
 extern int imagename_timer;
-extern bool retro_update_av_info(bool, bool, bool);
+extern bool retro_update_av_info(bool, bool);
 extern void reset_drawing();
 
 extern int vkey_pressed;

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -386,10 +386,11 @@ void Print_Status(void)
    int FONT_COLOR   = 0;
    FONT_COLOR       = FONT_COLOR_DEFAULT;
    int FONT_SLOT    = 0;
-   FONT_SLOT        = 40 * FONT_WIDTH;
+   FONT_SLOT        = 34 * FONT_WIDTH;
 
-   int STAT_DECX    = 4;
+   int STAT_X       = 2;
    int STAT_BASEY   = 0;
+   int TEXT_LENGTH  = (video_config & PUAE_VIDEO_DOUBLELINE) ? 88 : 37;
 
    // Statusbar location
    if (opt_statusbar_position < 0) // Top
@@ -409,6 +410,51 @@ void Print_Status(void)
          BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 2) * 5) - 2;
       else
          BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 4) * 5) - 2;
+   }
+
+   // Video resolution
+   int STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*4);
+   char RESOLUTION[10] = {0};
+   snprintf(RESOLUTION, sizeof(RESOLUTION), "%4dx%3d", retrow, zoomed_height);
+
+   // Model & memory
+   int STAT_X_MODEL  = STAT_X+(FONT_SLOT*5)+(FONT_WIDTH*52);
+   int STAT_X_MEMORY = STAT_X+(FONT_SLOT*5)+(FONT_WIDTH*25);
+   char MODEL[10] = {0};
+   char MEMORY[5] = {0};
+   float mem_size = 0;
+   mem_size = (float)(currprefs.chipmem_size / 0x80000) / 2;
+   mem_size += (float)(currprefs.bogomem_size / 0x40000) / 4;
+   mem_size += (float)(currprefs.fastmem_size / 0x100000);
+   snprintf(MEMORY, sizeof(MEMORY), "%2.0fM", floor(mem_size));
+   switch (currprefs.cs_compatible)
+   {
+      case CP_A500:
+         snprintf(MODEL, sizeof(MODEL), "%s", " A500");
+         break;
+      case CP_A500P:
+         snprintf(MODEL, sizeof(MODEL), "%s", "A500+");
+         break;
+      case CP_A600:
+         snprintf(MODEL, sizeof(MODEL), "%s", " A600");
+         break;
+      case CP_A1200:
+         snprintf(MODEL, sizeof(MODEL), "%s", "A1200");
+         break;
+      case CP_A4000:
+         snprintf(MODEL, sizeof(MODEL), "%s", "A4000");
+         break;
+      case CP_CD32:
+         snprintf(MODEL, sizeof(MODEL), "%s", " CD32");
+         break;
+   }
+
+   // Double line positions
+   if (video_config & PUAE_VIDEO_DOUBLELINE)
+   {
+      STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*14)+(FONT_WIDTH*29);
+      STAT_X_MODEL      = STAT_X+(FONT_SLOT*15)+(FONT_WIDTH*72);
+      STAT_X_MEMORY     = STAT_X+(FONT_SLOT*15)+(FONT_WIDTH*48);
    }
 
    // Joy port indicators
@@ -482,22 +528,26 @@ void Print_Status(void)
 
       if (imagename_timer > 0)
       {
-          Draw_text32((uint32_t *)retro_bmp,STAT_DECX+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,100,statusbar_text);
+          Draw_text32((uint32_t *)retro_bmp,STAT_X+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,TEXT_LENGTH,statusbar_text);
           return;
       }
 
       if (JOYPORT1_COLORIZE)
          FONT_COLOR = joystick_color(jflag[0]);
-      Draw_text32((uint32_t *)retro_bmp,STAT_DECX+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT1);
+      Draw_text32((uint32_t *)retro_bmp,STAT_X+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT1);
       if (JOYPORT1_COLORIZE)
          FONT_COLOR = FONT_COLOR_DEFAULT;
       if (JOYPORT2_COLORIZE)
          FONT_COLOR = joystick_color(jflag[1]);
-      Draw_text32((uint32_t *)retro_bmp,STAT_DECX+(FONT_SLOT),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT2);
+      Draw_text32((uint32_t *)retro_bmp,STAT_X+(FONT_SLOT),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT2);
       if (JOYPORT2_COLORIZE)
          FONT_COLOR = FONT_COLOR_DEFAULT;
-      Draw_text32((uint32_t *)retro_bmp,STAT_DECX+(FONT_SLOT*2),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT3);
-      Draw_text32((uint32_t *)retro_bmp,STAT_DECX+(FONT_SLOT*3),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT4);
+      Draw_text32((uint32_t *)retro_bmp,STAT_X+(FONT_SLOT*2),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT3);
+      Draw_text32((uint32_t *)retro_bmp,STAT_X+(FONT_SLOT*3),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT4);
+
+      Draw_text32((uint32_t *)retro_bmp,STAT_X_RESOLUTION,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,RESOLUTION);
+      Draw_text32((uint32_t *)retro_bmp,STAT_X_MEMORY,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,MEMORY);
+      Draw_text32((uint32_t *)retro_bmp,STAT_X_MODEL,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,MODEL);
    }
    else
    {
@@ -505,22 +555,26 @@ void Print_Status(void)
 
       if (imagename_timer > 0)
       {
-          Draw_text(retro_bmp,STAT_DECX+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,100,statusbar_text);
+          Draw_text(retro_bmp,STAT_X+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,TEXT_LENGTH,statusbar_text);
           return;
       }
 
       if (JOYPORT1_COLORIZE)
          FONT_COLOR = joystick_color(jflag[0]);
-      Draw_text(retro_bmp,STAT_DECX+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT1);
+      Draw_text(retro_bmp,STAT_X+0,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT1);
       if (JOYPORT1_COLORIZE)
          FONT_COLOR = FONT_COLOR_DEFAULT;
       if (JOYPORT2_COLORIZE)
          FONT_COLOR = joystick_color(jflag[1]);
-      Draw_text(retro_bmp,STAT_DECX+(FONT_SLOT),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT2);
+      Draw_text(retro_bmp,STAT_X+(FONT_SLOT),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT2);
       if (JOYPORT2_COLORIZE)
          FONT_COLOR = FONT_COLOR_DEFAULT;
-      Draw_text(retro_bmp,STAT_DECX+(FONT_SLOT*2),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT3);
-      Draw_text(retro_bmp,STAT_DECX+(FONT_SLOT*3),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT4);
+      Draw_text(retro_bmp,STAT_X+(FONT_SLOT*2),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT3);
+      Draw_text(retro_bmp,STAT_X+(FONT_SLOT*3),STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,JOYPORT4);
+
+      Draw_text(retro_bmp,STAT_X_RESOLUTION,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,RESOLUTION);
+      Draw_text(retro_bmp,STAT_X_MEMORY,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,MEMORY);
+      Draw_text(retro_bmp,STAT_X_MODEL,STAT_BASEY,FONT_COLOR,0,255,FONT_WIDTH,FONT_HEIGHT,10,MODEL);
    }
 }
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -419,7 +419,7 @@ void Print_Status(void)
 
    // Model & memory
    int STAT_X_MODEL  = STAT_X+(FONT_SLOT*5)+(FONT_WIDTH*52);
-   int STAT_X_MEMORY = STAT_X+(FONT_SLOT*5)+(FONT_WIDTH*25);
+   int STAT_X_MEMORY = STAT_X+(FONT_SLOT*5)+(FONT_WIDTH*24);
    char MODEL[10] = {0};
    char MEMORY[5] = {0};
    float mem_size = 0;
@@ -452,7 +452,7 @@ void Print_Status(void)
    // Double line positions
    if (video_config & PUAE_VIDEO_DOUBLELINE)
    {
-      STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*14)+(FONT_WIDTH*29);
+      STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*14)+(FONT_WIDTH*28);
       STAT_X_MODEL      = STAT_X+(FONT_SLOT*15)+(FONT_WIDTH*72);
       STAT_X_MEMORY     = STAT_X+(FONT_SLOT*15)+(FONT_WIDTH*48);
    }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -27,7 +27,10 @@
 #include "blkdev.h"
 extern void check_changes(int unitnum);
 extern int frame_redraw_necessary;
-
+extern int bplcon0;
+extern int diwlastword_total;
+extern int diwfirstword_total;
+extern int interlace_seen;
 extern int m68k_go(int may_quit, int resume);
 
 int defaultw = EMULATOR_DEF_WIDTH;
@@ -36,10 +39,12 @@ int retrow = 0;
 int retroh = 0;
 char key_state[512];
 char key_state2[512];
+
 unsigned int opt_mapping_options_display;
 unsigned int opt_video_options_display;
 unsigned int opt_audio_options_display;
 char opt_model[10];
+bool opt_video_resolution_auto = false;
 bool opt_use_whdload_hdf = true;
 bool opt_use_whdsaves_hdf = true;
 unsigned int opt_use_whdload_prefs = 0;
@@ -57,8 +62,28 @@ unsigned int opt_dpadmouse_speed = 4;
 unsigned int opt_analogmouse = 0;
 unsigned int opt_analogmouse_deadzone = 15;
 float opt_analogmouse_speed = 1.0;
+
+#if defined(NATMEM_OFFSET)
+extern uae_u8 *natmem_offset;
+extern uae_u32 natmem_size;
+#endif
+
+static char RPATH[512] = {0};
+static char full_path[512] = {0};
+static char *uae_argv[] = { "puae", RPATH };
+static int firstpass = 1;
+static int restart_pending = 0;
+
+unsigned short int retro_bmp[RETRO_BMP_SIZE];
+extern int SHIFTON;
+extern int STATUSON;
+extern void Print_Status(void);
+extern void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+extern int prefs_changed;
+
 extern int turbo_fire_button;
 extern unsigned int turbo_pulse;
+unsigned int inputdevice_finalized = 0;
 int pix_bytes = 2;
 static bool pix_bytes_initialized = false;
 bool filter_type_update = true;
@@ -72,31 +97,13 @@ unsigned int zoom_mode_id = 0;
 unsigned int opt_zoom_mode_id = 0;
 int zoomed_height;
 
-#if defined(NATMEM_OFFSET)
-extern uae_u8 *natmem_offset;
-extern uae_u32 natmem_size;
-#endif
-
-unsigned short int retro_bmp[RETRO_BMP_SIZE];
-static char RPATH[512] = {0};
-static char full_path[512] = {0};
-static int firstpass = 1;
-static int restart_pending = 0;
-extern int SHIFTON;
-extern int STATUSON;
-extern void Print_Status(void);
-extern void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-extern int prefs_changed;
-
-static char *uae_argv[] = { "puae", RPATH };
-
 int opt_vertical_offset = 0;
 bool opt_vertical_offset_auto = true;
 extern int minfirstline;
 extern int retro_thisframe_first_drawn_line;
-static int thisframe_first_drawn_line_old = -1;
+static int retro_thisframe_first_drawn_line_old = -1;
 extern int retro_thisframe_last_drawn_line;
-static int thisframe_last_drawn_line_old = -1;
+static int retro_thisframe_last_drawn_line_old = -1;
 extern int thisframe_y_adjust;
 static int thisframe_y_adjust_old = 0;
 static int thisframe_y_adjust_update_frame_timer = 3;
@@ -106,9 +113,9 @@ bool opt_horizontal_offset_auto = true;
 static int retro_max_diwlastword_hires = 824;
 static int retro_max_diwlastword = 824;
 extern int retro_min_diwstart;
-static int min_diwstart_old = -1;
+static int retro_min_diwstart_old = -1;
 extern int retro_max_diwstop;
-static int max_diwstop_old = -1;
+static int retro_max_diwstop_old = -1;
 extern int visible_left_border;
 static int visible_left_border_old = 0;
 static int visible_left_border_update_frame_timer = 3;
@@ -118,7 +125,6 @@ unsigned int video_config_old = 0;
 unsigned int video_config_aspect = 0;
 unsigned int video_config_geometry = 0;
 unsigned int video_config_allow_hz_change = 0;
-unsigned int inputdevice_finalized = 0;
 
 #include "libretro-keyboard.i"
 int keyId(const char *val)
@@ -290,20 +296,6 @@ void retro_set_environment(retro_environment_t cb)
          "disabled"
       },
       {
-         "puae_video_resolution",
-         "Video Resolution",
-         "Width:\n- 360px Low\n- 720px High\n- 1440px Super-High",
-         {
-            { "lores", "Low" },
-            { "hires_single", "High (Single line)" },
-            { "hires_double", "High (Double line)" },
-            { "superhires_single", "Super-High (Single line)" },
-            { "superhires_double", "Super-High (Double line)" },
-            { NULL, NULL },
-         },
-         "hires_double"
-      },
-      {
          "puae_video_allow_hz_change",
          "Allow PAL/NTSC Hz Change",
          "",
@@ -315,12 +307,28 @@ void retro_set_environment(retro_environment_t cb)
          "enabled"
       },
       {
+         "puae_video_resolution",
+         "Video Resolution",
+         "Output width:\n- Automatic defaults to High and switches to Super-High when needed.\n- Double Line deinterlaces interlaced images.",
+         {
+            { "lores", "Low 360px" },
+            { "hires_single", "High 720px - Single Line" },
+            { "hires_double", "High 720px - Double Line" },
+            { "superhires_single", "Super-High 1440px - Single Line" },
+            { "superhires_double", "Super-High 1440px - Double Line" },
+            { "automatic_single", "Automatic - Single Line" },
+            { "automatic_double", "Automatic - Double Line" },
+            { NULL, NULL },
+         },
+         "automatic_double"
+      },
+      {
          "puae_video_standard",
          "Video Standard",
-         "Height (Single line/Double line):\n- 288px/576px PAL\n- 240px/480px NTSC",
+         "Output height:\n- Single Line / Double Line.",
          {
-            { "PAL", NULL },
-            { "NTSC", NULL },
+            { "PAL", "PAL - 288px / 576px" },
+            { "NTSC", "NTSC - 240px / 480px" },
             { NULL, NULL },
          },
          "PAL"
@@ -328,7 +336,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "puae_video_aspect",
          "Aspect Ratio",
-         "",
+         "PAR:\n- PAL 1/1 = 1.000\n- NTSC 44/52 = 0.846",
          {
             { "auto", "Automatic" },
             { "PAL", NULL },
@@ -340,7 +348,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "puae_zoom_mode",
          "Zoom Mode",
-         "Requirements in RetroArch settings:\nAspect Ratio: Core provided,\nInteger Scale: Off.",
+         "Requirements in RetroArch settings:\n- Aspect Ratio: Core provided,\n- Integer Scale: Off.",
          {
             { "none", "disabled" },
             { "minimum", "Minimum" },
@@ -1266,8 +1274,18 @@ static void update_variables(void)
    {
       int video_config_prev = video_config;
       video_config = video_config_region;
+      opt_video_resolution_auto = false;
 
-      if (strcmp(var.value, "hires_double") == 0)
+      if (strcmp(var.value, "lores") == 0)
+      {
+         retro_max_diwlastword = retro_max_diwlastword_hires / 2;
+         if (!firstpass)
+         {
+            changed_prefs.gfx_resolution=RES_LORES;
+            changed_prefs.gfx_vresolution=VRES_NONDOUBLE;
+         }
+      }
+      else if (strcmp(var.value, "hires_double") == 0)
       {
          video_config |= PUAE_VIDEO_HIRES;
          video_config |= PUAE_VIDEO_DOUBLELINE;
@@ -1292,7 +1310,6 @@ static void update_variables(void)
       {
          video_config |= PUAE_VIDEO_SUPERHIRES;
          video_config |= PUAE_VIDEO_DOUBLELINE;
-
          retro_max_diwlastword = retro_max_diwlastword_hires * 2;
          if (!firstpass)
          {
@@ -1303,7 +1320,6 @@ static void update_variables(void)
       else if (strcmp(var.value, "superhires_single") == 0)
       {
          video_config |= PUAE_VIDEO_SUPERHIRES;
-
          retro_max_diwlastword = retro_max_diwlastword_hires * 2;
          if (!firstpass)
          {
@@ -1311,19 +1327,63 @@ static void update_variables(void)
             changed_prefs.gfx_vresolution=VRES_NONDOUBLE;
          }
       }
-      else if (strcmp(var.value, "lores") == 0)
+      else if (strcmp(var.value, "automatic_double") == 0)
       {
-         retro_max_diwlastword = retro_max_diwlastword_hires / 2;
-         if (!firstpass)
+         opt_video_resolution_auto = true;
+         video_config |= PUAE_VIDEO_DOUBLELINE;
+         if (video_config_prev & PUAE_VIDEO_SUPERHIRES)
          {
-            changed_prefs.gfx_resolution=RES_LORES;
-            changed_prefs.gfx_vresolution=VRES_NONDOUBLE;
+            video_config |= PUAE_VIDEO_SUPERHIRES;
+            retro_max_diwlastword = retro_max_diwlastword_hires * 2;
+
+            if (!firstpass)
+            {
+               changed_prefs.gfx_resolution=RES_SUPERHIRES;
+               changed_prefs.gfx_vresolution=VRES_DOUBLE;
+            }
+         }
+         else
+         {
+            video_config |= PUAE_VIDEO_HIRES;
+            retro_max_diwlastword = retro_max_diwlastword_hires;
+
+            if (!firstpass)
+            {
+               changed_prefs.gfx_resolution=RES_HIRES;
+               changed_prefs.gfx_vresolution=VRES_DOUBLE;
+            }
+         }
+      }
+      else if (strcmp(var.value, "automatic_single") == 0)
+      {
+         opt_video_resolution_auto = true;
+         if (video_config_prev & PUAE_VIDEO_SUPERHIRES)
+         {
+            video_config |= PUAE_VIDEO_SUPERHIRES;
+            retro_max_diwlastword = retro_max_diwlastword_hires * 2;
+
+            if (!firstpass)
+            {
+               changed_prefs.gfx_resolution=RES_SUPERHIRES;
+               changed_prefs.gfx_vresolution=VRES_NONDOUBLE;
+            }
+         }
+         else
+         {
+            video_config |= PUAE_VIDEO_HIRES;
+            retro_max_diwlastword = retro_max_diwlastword_hires;
+
+            if (!firstpass)
+            {
+               changed_prefs.gfx_resolution=RES_HIRES;
+               changed_prefs.gfx_vresolution=VRES_NONDOUBLE;
+            }
          }
       }
 
       /* Resolution change needs init_custom() to be done after reset_drawing() is done */
       if (!firstpass && video_config != video_config_prev)
-         request_init_custom_timer = 2;
+         request_init_custom_timer = 3;
    }
 
    var.key = "puae_statusbar";
@@ -1344,12 +1404,6 @@ static void update_variables(void)
          opt_statusbar_minimal = true;
       else
          opt_statusbar_minimal = false;
-
-      /* Screen refresh required
-       * (redundant - will be forced by av_info
-       *  geometry update) */
-      if (opt_statusbar_position_old != opt_statusbar_position || !opt_statusbar_enhanced)
-         request_reset_drawing = true;
 
       opt_statusbar_position_old = opt_statusbar_position;
    }
@@ -2728,13 +2782,13 @@ float retro_get_aspect_ratio(int w, int h)
    return ar;
 }
 
-bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
+bool retro_update_av_info(bool change_timing, bool isntsc)
 {
    bool av_log = false;
    request_update_av_info = false;
    float hz = currprefs.chipset_refreshrate;
    if (av_log)
-      fprintf(stdout, "[libretro-uae]: Trying to update AV geometry:%d timing:%d, to: ntsc:%d hz:%0.4f, from video_config:%d, video_aspect:%d\n", change_geometry, change_timing, isntsc, hz, video_config, video_config_aspect);
+      fprintf(stdout, "[libretro-uae]: Trying to update AV timing:%d to: ntsc:%d hz:%0.4f, from video_config:%d, video_aspect:%d\n", change_timing, isntsc, hz, video_config, video_config_aspect);
 
    /* Change PAL/NTSC with a twist, thanks to Dyna Blaster
 
@@ -2877,6 +2931,10 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
          break;
    }
 
+   /* Exception for Dyna Blaster */
+   if (fake_ntsc)
+      retroh = (video_config & PUAE_VIDEO_DOUBLELINE) ? 476 : 238;
+
    /* When the actual dimensions change and not just the view */
    if (change_timing)
    {
@@ -2885,53 +2943,64 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
    }
 
    static struct retro_system_av_info new_av_info;
-   new_av_info.geometry.base_width = retrow;
-   new_av_info.geometry.base_height = retroh;
-   new_av_info.geometry.aspect_ratio = retro_get_aspect_ratio(retrow, retroh);
+   retro_get_system_av_info(&new_av_info);
 
    /* Disable Hz change if not allowed */
    if (!video_config_allow_hz_change)
-      change_timing = 0;
+      change_timing = false;
 
-   /* Logging */
-   if (av_log)
+   /* Timing or geometry update */
+   if (change_timing)
    {
-      if (change_geometry && change_timing) {
-         fprintf(stdout, "[libretro-uae]: Update av_info: %dx%d %0.4fHz, video_config:%d\n", retrow, retroh, hz, video_config_geometry);
-      } else if (change_geometry && !change_timing) {
-         fprintf(stdout, "[libretro-uae]: Update geometry: %dx%d, video_config:%d\n", retrow, retroh, video_config_geometry);
-      } else if (!change_geometry && change_timing) {
-         fprintf(stdout, "[libretro-uae]: Update timing: %0.4fHz, video_config:%d\n", hz, video_config_geometry);
+      new_av_info.timing.fps = hz;
+      environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_av_info);
+   }
+   else
+      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
+
+   /* Ensure statusbar stays visible at the bottom */
+   opt_statusbar_position_offset = 0;
+   opt_statusbar_position = opt_statusbar_position_old;
+   if (!change_timing)
+      if (retroh < defaulth)
+         if (opt_statusbar_position >= 0 && (defaulth - retroh) >= opt_statusbar_position)
+            opt_statusbar_position = defaulth - retroh;
+
+   /* Aspect offset for zoom mode */
+   opt_statusbar_position_offset = opt_statusbar_position_old - opt_statusbar_position;
+
+   /* Compensate for the PAL last line  */
+   if (video_config_geometry & PUAE_VIDEO_PAL && retroh == defaulth && opt_statusbar_position == 0)
+   {
+      if (interlace_seen)
+      {
+         if (video_config_geometry & PUAE_VIDEO_DOUBLELINE)
+         {
+            opt_statusbar_position += 2;
+            opt_statusbar_position_offset += 2;
+         }
+         else
+         {
+            opt_statusbar_position += 1;
+            opt_statusbar_position_offset += 1;
+         }
+      }
+      else
+      {
+         if (video_config_geometry & PUAE_VIDEO_DOUBLELINE)
+         {
+            opt_statusbar_position += 1;
+            opt_statusbar_position_offset += 1;
+         }
+         else
+         {
+            opt_statusbar_position += 0;
+            opt_statusbar_position_offset += 0;
+         }
       }
    }
 
-   if (change_timing) {
-      struct retro_system_av_info new_timing;
-      retro_get_system_av_info(&new_timing);
-      new_timing.timing.fps = hz;
-      environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_timing);
-   }
-
-   if (change_geometry) {
-      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
-
-      /* Ensure statusbar stays visible at the bottom */
-      opt_statusbar_position_offset = 0;
-      opt_statusbar_position = opt_statusbar_position_old;
-      if (!change_timing)
-         if (retroh < defaulth)
-            if (opt_statusbar_position >= 0 && (defaulth - retroh) > opt_statusbar_position)
-               opt_statusbar_position = defaulth - retroh;
-
-      /* Aspect offset for zoom mode */
-      opt_statusbar_position_offset = opt_statusbar_position_old - opt_statusbar_position;
-
-      /* Compensate for the last line in PAL HIRES */
-      if (video_config_geometry & PUAE_VIDEO_PAL && video_config_geometry & PUAE_VIDEO_DOUBLELINE && retroh == defaulth && opt_statusbar_position >= 0)
-         opt_statusbar_position += 1;
-
-      //fprintf(stdout, "statusbar:%3d old:%3d offset:%3d, retroh:%d defaulth:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, retroh, defaulth);
-   }
+   //fprintf(stdout, "statusbar:%3d old:%3d offset:%3d, defaulth:%d retroh:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, defaulth, retroh);
 
    /* Apply zoom mode if necessary */
    switch (zoom_mode_id)
@@ -2994,8 +3063,6 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
          break;
       default:
          zoomed_height = retroh;
-         if (fake_ntsc)
-            zoomed_height = 460;
          break;
    }
 
@@ -3009,18 +3076,14 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
       environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
 
       /* Ensure statusbar stays visible at the bottom */
-      if (opt_statusbar_position >= 0 && (retroh - zoomed_height - opt_statusbar_position_offset) > opt_statusbar_position)
+      if (opt_statusbar_position >= 0 && (retroh - zoomed_height - opt_statusbar_position_offset) >= opt_statusbar_position)
          opt_statusbar_position = retroh - zoomed_height - opt_statusbar_position_offset;
 
-      /* Exception for Dyna Blaster */
-      if (fake_ntsc)
-         opt_statusbar_position -= (retroh - defaulth);
-
-      //fprintf(stdout, "ztatusbar:%3d old:%3d offset:%3d, retroh:%d defaulth:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, retroh, defaulth);
+      //fprintf(stdout, "ztatusbar:%3d old:%3d offset:%3d, defaulth:%d retroz:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, defaulth, zoomed_height);
    }
 
    /* If zoom mode should be vertically centered automagically */
-   if (opt_vertical_offset_auto && (zoom_mode_id != 0 || zoomed_height != retroh) && !firstpass)
+   if (opt_vertical_offset_auto && (zoom_mode_id != 0 || zoomed_height != retroh))
    {
       int zoomed_height_normal = (video_config & PUAE_VIDEO_DOUBLELINE) ? zoomed_height / 2 : zoomed_height;
       int thisframe_y_adjust_new = minfirstline;
@@ -3052,7 +3115,7 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
       thisframe_y_adjust = minfirstline + opt_vertical_offset;
 
    /* Horizontal centering */
-   if (opt_horizontal_offset_auto && !firstpass)
+   if (opt_horizontal_offset_auto)
    {
       int visible_left_border_new = retro_max_diwlastword - retrow;
       int diw_multiplier = 1;
@@ -3085,9 +3148,17 @@ bool retro_update_av_info(bool change_geometry, bool change_timing, bool isntsc)
       visible_left_border_old = visible_left_border;
    }
 
-   /* No need to check changed gfx at startup */
-   if (!firstpass)
-      prefs_changed = 1; // Triggers check_prefs_changed_gfx() in vsync_handle_check()
+   /* Logging */
+   if (av_log)
+   {
+      if (change_timing)
+         fprintf(stdout, "[libretro-uae]: Update av_info: %dx%d %0.4fHz, zoomed_height:%d, video_config:%d\n", retrow, retroh, hz, zoomed_height, video_config_geometry);
+      else
+         fprintf(stdout, "[libretro-uae]: Update geometry: %dx%d zoomed_height:%d, video_config:%d\n", retrow, retroh, zoomed_height, video_config_geometry);
+   }
+
+   /* Triggers check_prefs_changed_gfx() in vsync_handle_check() */
+   prefs_changed = 1;
 
    /* Changing any drawing/offset parameters requires
     * a drawing reset - it is safest to just do this
@@ -3965,13 +4036,8 @@ void retro_reset(void)
    uae_restart(1, (const char*)&RPATH); /* 1=nogui */
 }
 
-void retro_run(void)
+void update_audiovideo(void)
 {
-   // Core options
-   bool updated = false;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
-      update_variables();
-
    // Statusbar disk display timer
    if (imagename_timer > 0)
       imagename_timer--;
@@ -3987,32 +4053,73 @@ void retro_run(void)
       config_changed = 0;
    }
 
+   // Automatic video resolution
+   if (opt_video_resolution_auto && request_init_custom_timer == 0)
+   {
+      int current_resolution = GET_RES_DENISE (bplcon0);
+      //printf("BPLCON0: %d, %d, %d %d\n", bplcon0, current_resolution, diwfirstword_total, diwlastword_total);
+      if (current_resolution == 1 && bplcon0 == 0xC201 && ((diwfirstword_total == 210 && diwlastword_total && 786) || (diwfirstword_total == 420 && diwlastword_total && 1572))) // Super Skidmarks exception
+         current_resolution = 2;
+      else if (current_resolution == 0 && bplcon0 == 0 && ((diwfirstword_total == 114 && diwlastword_total && 818) || (diwfirstword_total == 228 && diwlastword_total && 1636))) // Super Stardust exception
+         current_resolution = 2;
+      else if (current_resolution == 0)
+         current_resolution = 1;
+
+      switch (current_resolution)
+      {
+         case 1:
+            if (!(video_config & PUAE_VIDEO_HIRES))
+            {
+               changed_prefs.gfx_resolution = RES_HIRES;
+               video_config |= PUAE_VIDEO_HIRES;
+               video_config &= ~PUAE_VIDEO_SUPERHIRES;
+               defaultw = retrow = PUAE_VIDEO_WIDTH;
+               retro_max_diwlastword = retro_max_diwlastword_hires;
+               request_init_custom_timer = 3;
+            }
+            break;
+         case 2:
+            if (!(video_config & PUAE_VIDEO_SUPERHIRES))
+            {
+               changed_prefs.gfx_resolution = RES_SUPERHIRES;
+               video_config |= PUAE_VIDEO_SUPERHIRES;
+               video_config &= ~PUAE_VIDEO_HIRES;
+               defaultw = retrow = PUAE_VIDEO_WIDTH * 2;
+               retro_max_diwlastword = retro_max_diwlastword_hires * 2;
+               request_init_custom_timer = 3;
+            }
+            break;
+      }
+
+      // Horizontal centering calculation needs to be forced due to retro_max_diwlastword change, which is crucial for visible_left_border
+      if (request_init_custom_timer > 0)
+      {
+         retro_min_diwstart_old = -1;
+         retro_max_diwstop_old = -1;
+         thisframe_y_adjust = minfirstline;
+         visible_left_border = retro_max_diwlastword - retrow;
+      }
+   }
+
    // Automatic vertical offset
    if (opt_vertical_offset_auto && zoom_mode_id != 0)
    {
-      if ((retro_thisframe_first_drawn_line != thisframe_first_drawn_line_old) ||
-          (retro_thisframe_last_drawn_line != thisframe_last_drawn_line_old))
+      if (((retro_thisframe_first_drawn_line != retro_thisframe_first_drawn_line_old)
+         ||(retro_thisframe_last_drawn_line  != retro_thisframe_last_drawn_line_old))
+         && retro_thisframe_first_drawn_line != -1
+         && retro_thisframe_last_drawn_line  != -1
+      )
       {
          // Prevent interlace stuttering by requiring a change of at least 2 lines
-         if (abs(thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1)
+         if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1)
          {
-            thisframe_first_drawn_line_old = retro_thisframe_first_drawn_line;
+            retro_thisframe_first_drawn_line_old = retro_thisframe_first_drawn_line;
             request_update_av_info = true;
          }
-         if (abs(thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
+         if (abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
          {
-            thisframe_last_drawn_line_old = retro_thisframe_last_drawn_line;
+            retro_thisframe_last_drawn_line_old = retro_thisframe_last_drawn_line;
             request_update_av_info = true;
-         }
-      }
-      // Timer required for unserialize recovery
-      else if (retro_thisframe_first_drawn_line == thisframe_first_drawn_line_old)
-      {
-         if (thisframe_y_adjust_update_frame_timer > 0)
-         {
-            thisframe_y_adjust_update_frame_timer--;
-            if (thisframe_y_adjust_update_frame_timer == 0)
-               request_update_av_info = true;
          }
       }
    }
@@ -4033,11 +4140,11 @@ void retro_run(void)
    // Automatic horizontal offset
    if (opt_horizontal_offset_auto)
    {
-      if ((retro_min_diwstart != min_diwstart_old) ||
-          (retro_max_diwstop != max_diwstop_old))
+      if ((retro_min_diwstart != retro_min_diwstart_old) ||
+          (retro_max_diwstop != retro_max_diwstop_old))
       {
-         min_diwstart_old = retro_min_diwstart;
-         max_diwstop_old = retro_max_diwstop;
+         retro_min_diwstart_old = retro_min_diwstart;
+         retro_max_diwstop_old = retro_max_diwstop;
          request_update_av_info = true;
       }
    }
@@ -4054,13 +4161,27 @@ void retro_run(void)
          }
       }
    }
+}
 
-   // AV info change is requested
-   if (request_update_av_info)
-      retro_update_av_info(1, 0, 0);
+void retro_run(void)
+{
+   // Core options
+   bool updated = false;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
+      update_variables();
 
-   // Poll inputs
-   retro_poll_event();
+   if (!firstpass)
+   {
+      // Handle statusbar text, audio filter type & video geometry + resolution
+      update_audiovideo();
+
+      // AV info change is requested
+      if (request_update_av_info)
+         retro_update_av_info(false, false);
+
+      // Poll inputs
+      retro_poll_event();
+   }
 
    // If any drawing parameters/offsets have been modified,
    // must call reset_drawing() to ensure that the changes
@@ -4079,6 +4200,8 @@ void retro_run(void)
    // Dynamic resolution changing requires a frame breather after reset_drawing()
    if (request_init_custom_timer > 0)
    {
+      if (request_init_custom_timer == 2)
+         request_reset_drawing = true;
       request_init_custom_timer--;
       if (request_init_custom_timer == 0)
          init_custom ();
@@ -4112,7 +4235,7 @@ void retro_run(void)
    if (SHOWKEY == 1)
    {
       // Virtual keyboard requires a graceful redraw, blunt reset_drawing() interferes with zoom
-      frame_redraw_necessary=2;
+      frame_redraw_necessary = 2;
       virtual_kbd(retro_bmp, vkey_pos_x, vkey_pos_y);
    }
    // Maximum 288p/576p PAL shenanigans:
@@ -4121,11 +4244,23 @@ void retro_run(void)
    {
       if (video_config & PUAE_VIDEO_DOUBLELINE)
       {
-         DrawHline(retro_bmp, 0, 574, retrow, 0, 0);
-         DrawHline(retro_bmp, 0, 575, retrow, 0, 0);
+         if (interlace_seen)
+         {
+            DrawHline(retro_bmp, 0, 572, retrow, 0, 0);
+            DrawHline(retro_bmp, 0, 573, retrow, 0, 0);
+            DrawHline(retro_bmp, 0, 574, retrow, 0, 0);
+            DrawHline(retro_bmp, 0, 575, retrow, 0, 0);
+         }
+         else
+         {
+            DrawHline(retro_bmp, 0, 574, retrow, 0, 0);
+            DrawHline(retro_bmp, 0, 575, retrow, 0, 0);
+         }
       }
       else
+      {
          DrawHline(retro_bmp, 0, 287, retrow, 0, 0);
+      }
    }
    video_cb(retro_bmp, retrow, zoomed_height, retrow << (pix_bytes / 2));
 }
@@ -4232,7 +4367,6 @@ bool retro_unserialize(const void *data_, size_t size)
 {
    if (!firstpass)
    {
-      thisframe_y_adjust_update_frame_timer = 3;
       FILE *file = fopen(savestate_fname, "wb");
       if (file)
       {

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -318,8 +318,8 @@ int check_prefs_changed_gfx (void)
     else
         return 0;
 
-    changed_prefs.gfx_size_win.width = defaultw;
-    changed_prefs.gfx_size_win.height = defaulth;
+    changed_prefs.gfx_size_win.width    = defaultw;
+    changed_prefs.gfx_size_win.height   = defaulth;
 
     if (currprefs.gfx_size_win.width   != changed_prefs.gfx_size_win.width)
         currprefs.gfx_size_win.width    = changed_prefs.gfx_size_win.width;
@@ -330,13 +330,12 @@ int check_prefs_changed_gfx (void)
     if (currprefs.gfx_vresolution      != changed_prefs.gfx_vresolution)
         currprefs.gfx_vresolution       = changed_prefs.gfx_vresolution;
 
-    gfxvidinfo.width_allocated      = currprefs.gfx_size_win.width;
-    gfxvidinfo.height_allocated     = currprefs.gfx_size_win.height;
-    gfxvidinfo.rowbytes             = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes;
+    gfxvidinfo.width_allocated          = currprefs.gfx_size_win.width;
+    gfxvidinfo.height_allocated         = currprefs.gfx_size_win.height;
+    gfxvidinfo.rowbytes                 = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes;
 
-    reset_drawing();
     //printf("check_prefs_changed_gfx: %d:%d, res:%d vres:%d\n", changed_prefs.gfx_size_win.width, changed_prefs.gfx_size_win.height, changed_prefs.gfx_resolution, changed_prefs.gfx_vresolution);
-    return 0;
+    return 1;
 }
 
 
@@ -377,7 +376,6 @@ static int get_joystick_num (void)
 
 static TCHAR *get_joystick_friendlyname (int joy)
 {
-
     switch (joy)
     {
         case 0:

--- a/sources/src/newcpu.c
+++ b/sources/src/newcpu.c
@@ -1203,14 +1203,44 @@ static void update_68k_cycles (void)
 			cycles_mult = (unsigned long)(CYCLES_DIV * 1000 / (1000 + currprefs.m68k_speed_throttle));
 		} else if (currprefs.m68k_speed_throttle > 0) {
 			cycles_mult = (unsigned long)(CYCLES_DIV * 1000 / (1000 + currprefs.m68k_speed_throttle));
+		}
 	}
+#ifdef __LIBRETRO__
+	if (currprefs.m68k_speed == 0) {
+		if (currprefs.cpu_model >= 68040) {
+			if (!cycles_mult)
+				cycles_mult = CYCLES_DIV / 8;
+			else
+				cycles_mult /= 8;
+			cycles_mult /= 2;
+		} else if (currprefs.cpu_model >= 68030) {
+			if (!cycles_mult)
+				cycles_mult = CYCLES_DIV / 4;
+			else
+				cycles_mult /= 4;
+		} else if (currprefs.cpu_model >= 68020) {
+			if (!cycles_mult)
+				cycles_mult = CYCLES_DIV / 4;
+			else
+				cycles_mult /= 4;
+			cycles_mult *= 3;
+		}
 	}
-	if (currprefs.m68k_speed == 0 && currprefs.cpu_model >= 68020) {
-		if (!cycles_mult)
-			cycles_mult = CYCLES_DIV / 4;
-		else
-			cycles_mult /= 4;
+#else
+	if (currprefs.m68k_speed == 0) {
+		if (currprefs.cpu_model >= 68040) {
+			if (!cycles_mult)
+				cycles_mult = CYCLES_DIV / 8;
+			else
+				cycles_mult /= 8;
+		} else if (currprefs.cpu_model >= 68020) {
+			if (!cycles_mult)
+				cycles_mult = CYCLES_DIV / 4;
+			else
+				cycles_mult /= 4;
+		}
 	}
+#endif
 
 	currprefs.cpu_clock_multiplier = changed_prefs.cpu_clock_multiplier;
 	currprefs.cpu_frequency = changed_prefs.cpu_frequency;
@@ -1226,14 +1256,33 @@ static void update_68k_cycles (void)
 	} else if (currprefs.cpu_frequency) {
 		cpucycleunit = CYCLE_UNIT * baseclock / currprefs.cpu_frequency;
 	} else if (currprefs.cpu_cycle_exact && currprefs.cpu_clock_multiplier == 0) {
-		if (currprefs.cpu_model >= 68030) {
+#ifdef __LIBRETRO__
+		if (currprefs.cpu_model >= 68040) {
+			cpucycleunit = CYCLE_UNIT / 28;
+		} else if (currprefs.cpu_model >= 68030) {
+			cpucycleunit = CYCLE_UNIT / 5;
+		} else if (currprefs.cpu_model == 68020) {
+			cpucycleunit = CYCLE_UNIT / 4;
+		} else {
+			cpucycleunit = CYCLE_UNIT / 2;
+		}
+#else
+		if (currprefs.cpu_model >= 68040) {
+			cpucycleunit = CYCLE_UNIT / 16;
+		} if (currprefs.cpu_model == 68030) {
 			cpucycleunit = CYCLE_UNIT / 8;
 		} else if (currprefs.cpu_model == 68020) {
 			cpucycleunit = CYCLE_UNIT / 4;
 		} else {
 			cpucycleunit = CYCLE_UNIT / 2;
 		}
+#endif
 	}
+#ifdef __LIBRETRO__
+	if (currprefs.cpu_model == 68020) {
+		cpucycleunit *= 2;
+	}
+#endif
 	if (cpucycleunit < 1)
 		cpucycleunit = 1;
 	if (currprefs.cpu_cycle_exact)


### PR DESCRIPTION
- Added more useful information (resolution, memory, model) to the statusbar
  Closes #235 

- Fixed double line deinterlacing

So instead of this:
![retroarch_2020_02_16_23_02_12_755](https://user-images.githubusercontent.com/45124675/74691978-df14c200-51ed-11ea-8e23-0dd0362e0fd1.png)

We get this:
![retroarch_2020_02_16_23_01_57_594](https://user-images.githubusercontent.com/45124675/74691990-e5a33980-51ed-11ea-9751-ac17519c6e6a.png)

And instead of this unreadable mess:
![retroarch_2020_02_16_16_01_53_370](https://user-images.githubusercontent.com/45124675/74691999-f489ec00-51ed-11ea-907a-63a879eabafc.png)

We get this:
![retroarch_2020_02_16_16_01_59_183](https://user-images.githubusercontent.com/45124675/74692007-fb186380-51ed-11ea-8bc6-90c708010662.png)

(Yes the before-screenshots are Single Line, but currently Double Line does the same bob deinterlacing, so didn't bother to remove the fix and compile again just for the screenshot)

And of course the complimentary WB shot:
![retroarch_2020_02_16_13_02_38_297](https://user-images.githubusercontent.com/45124675/74692126-83970400-51ee-11ea-940a-c9756301c6c5.png)

Same as a raw RA screenshot with aspect ratio correction:
![A1200-200216-130449-aspect](https://user-images.githubusercontent.com/45124675/74692800-8d6e3680-51f1-11ea-837c-78ee2d9d7a61.png)



- Separated Resolution and Line Mode core options

- New default Video Resolution: Automatic
  - Defaults to Hires and switches to SuperHires when resolution is sensed
    - Only WB tells the resolution cleanly, so had to resort to hackery to get Super Skidmarks to register
- New default Video Line Mode: Automatic
  - Defaults to Single and switches to Double when interlacing is sensed

Bonus:
- Adjusted 68020 and higher CPU speeds to more match Sysinfo on all CPU compatibility modes
  - Fixes some games with fluctuating screen refresh, like Brutal Sports Football & Flood
  - Surprisingly gives a performance boost for doing less unnecessary work (No need to drop frame delay in Soccer Kid AGA anymore)
  - Please test and search for any negative side effects, as I haven't found one yet!