### PR TITLE
Use memory-based save states

### DIFF
--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -13,6 +13,8 @@
 #include <windows.h>
 #endif
 
+#include "zfile.h"
+
 extern int retrow;
 extern int retroh;
 extern int pix_bytes;
@@ -32,6 +34,8 @@ extern int retro_min_diwstart;
 extern int retro_max_diwstop;
 
 extern char retro_system_directory[512];
+
+extern struct zfile *retro_deserialize_file;
 
 #ifndef _WIN32
 #define TCHAR char /* from sysdeps.h */

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -36,6 +36,7 @@ extern int pix_bytes;
 extern int defaultw;
 extern int defaulth;
 
+extern int libretro_runloop_active;
 extern int libretro_frame_end;
 
 unsigned short int clut[] = {
@@ -145,7 +146,7 @@ void retro_key_up(int key)
 /* retro */
 void retro_renderSound(short* samples, int sampleCount)
 {
-    if (sampleCount < 1)
+    if ((sampleCount < 1) || !libretro_runloop_active)
         return;
 #if 0
     for(int i=0; i<sampleCount; i+=2)

--- a/sources/src/drawing.c
+++ b/sources/src/drawing.c
@@ -3605,6 +3605,7 @@ void vsync_handle_redraw (int long_frame, int lof_changed, uae_u16 bplcon0p, uae
 #endif
 
 		if (quit_program < 0) {
+#ifndef __LIBRETRO__
 #ifdef SAVESTATE
 			if (!savestate_state) {
 				if (currprefs.quitstatefile[0]) {
@@ -3612,6 +3613,7 @@ void vsync_handle_redraw (int long_frame, int lof_changed, uae_u16 bplcon0p, uae
 					save_state (currprefs.quitstatefile, _T(""));
 				}
 			}
+#endif
 #endif
 			quit_program = -quit_program;
 			set_inhibit_frame (IHF_QUIT_PROGRAM);

--- a/sources/src/include/savestate.h
+++ b/sources/src/include/savestate.h
@@ -211,8 +211,13 @@ extern uae_u8 *restore_hrtmon (uae_u8 *);
 extern uae_u8 *save_hrtmon (int *, uae_u8 *);
 
 extern void savestate_initsave (const TCHAR *filename, int docompress, int nodialogs, bool save);
+#ifdef __LIBRETRO__
+extern struct zfile *save_state (const TCHAR *description);
+void restore_state (void);
+#else
 extern int save_state (const TCHAR *filename, const TCHAR *description);
 extern void restore_state (const TCHAR *filename);
+#endif
 extern bool savestate_restore_finish (void);
 extern void savestate_restore_final (void);
 extern void savestate_memorysave (void);
@@ -239,7 +244,9 @@ STATIC_INLINE bool isrestore (void)
 	return savestate_state == STATE_RESTORE || savestate_state == STATE_REWIND;
 }
 
+#ifndef __LIBRETRO__
 extern void savestate_quick (int slot, int save);
+#endif
 
 extern void savestate_capture (int);
 extern void savestate_free (void);

--- a/sources/src/include/uae.h
+++ b/sources/src/include/uae.h
@@ -50,6 +50,7 @@ extern uae_u32 getlocaltime (void);
 
 extern int quit_program;
 #ifdef __LIBRETRO__
+extern int libretro_runloop_active;
 extern int libretro_frame_end;
 #endif
 extern bool console_emulation;

--- a/sources/src/inputdevice.c
+++ b/sources/src/inputdevice.c
@@ -2874,6 +2874,7 @@ void inputdevice_handle_inputcode (void)
 		uae_reset (1, 1);
 		break;
 #ifdef SAVESTATE
+#ifndef __LIBRETRO__
 	case AKS_STATESAVEQUICK:
 	case AKS_STATESAVEQUICK1:
 	case AKS_STATESAVEQUICK2:
@@ -2898,6 +2899,7 @@ void inputdevice_handle_inputcode (void)
 	case AKS_STATERESTOREQUICK9:
 		savestate_quick ((code - AKS_STATERESTOREQUICK) / 2, 0);
 		break;
+#endif
 #endif
 	case AKS_TOGGLEDEFAULTSCREEN:
 		toggle_fullscreen (-1);

--- a/sources/src/inputrecord.c
+++ b/sources/src/inputrecord.c
@@ -494,8 +494,10 @@ bool inprec_prepare_record (const TCHAR *statefilename)
 			_tcscpy (state, changed_prefs.inprecfile);
 		}
 		_tcscat (state, _T(".uss"));
+#ifndef __LIBRETRO__
 		savestate_initsave (state, 1, 1, true); 
 		save_state (state, _T("input recording test"));
+#endif
 		mode = 2;
 	}
 	input_record = INPREC_RECORD_NORMAL;

--- a/sources/src/newcpu.c
+++ b/sources/src/newcpu.c
@@ -4959,7 +4959,11 @@ void m68k_go (int may_quit)
 			if (savestate_state == STATE_DORESTORE)
 				savestate_state = STATE_RESTORE;
 			if (savestate_state == STATE_RESTORE)
+#ifdef __LIBRETRO__
+				restore_state ();
+#else
 				restore_state (savestate_fname);
+#endif
 			else if (savestate_state == STATE_REWIND)
 				savestate_rewind ();
 #endif


### PR DESCRIPTION
At present, the core implements save states using a temporary state file generated by the core itself. This is quite slow, but more importantly it causes a huge amount of unnecessary disk writes - when saving/loading the state of a WHDLoad install, for example, it is very easy to rack up many hundreds of megabytes of written data (not good for flash storage!). Writing to disk like this also precludes frontend features like rewind, readahead, etc.

This PR implements purely memory-based save states, so no more unnecessary disk writes.

**Note 1:** Rewind is quite useable now, provided granularity is set moderately high - 5 frames or so. *However:* rewind does not work reliably/at all for WHDLoad installs (and it can also fail when using an `(MD)` floppy disk playlist)

**Note 2:** Runahead does not work at present. I managed to get it sort-of working for non-`(MD)` floppy games using a couple of hacks, but it was far, far too slow to be useable. More importantly, CD32 games and most WHDLoad installs hang on load content (or segfault) with runahead enabled, and I couldn't determine why. So there's still more to do here...