### PR TITLE
Save state fixes

### DIFF
--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -20,8 +20,11 @@ extern int retroh;
 extern int pix_bytes;
 extern int zoomed_height;
 extern int imagename_timer;
-extern bool retro_update_av_info(bool, bool);
 extern void reset_drawing();
+
+extern bool retro_request_av_info_update;
+extern bool retro_av_info_change_timing;
+extern bool retro_av_info_is_ntsc;
 
 extern int vkey_pressed;
 extern int vkey_sticky;

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -79,7 +79,7 @@ extern unsigned int video_config;
 extern unsigned int video_config_aspect;
 extern unsigned int zoom_mode_id;
 extern unsigned int opt_zoom_mode_id;
-extern bool request_update_av_info;
+extern bool retro_request_av_info_update;
 extern bool request_reset_drawing;
 extern bool opt_statusbar_enhanced;
 extern int opt_statusbar_position;
@@ -158,7 +158,7 @@ void emu_function(int function)
             video_config_aspect = PUAE_VIDEO_NTSC;
          else if (video_config_aspect == PUAE_VIDEO_NTSC)
             video_config_aspect = PUAE_VIDEO_PAL;
-         request_update_av_info = true;
+         retro_request_av_info_update = true;
          break;
       case EMU_ZOOM_MODE_TOGGLE:
          if (zoom_mode_id == 0 && opt_zoom_mode_id == 0)
@@ -167,7 +167,7 @@ void emu_function(int function)
             zoom_mode_id = 0;
          else if (zoom_mode_id == 0)
             zoom_mode_id = opt_zoom_mode_id;
-         request_update_av_info = true;
+         retro_request_av_info_update = true;
          break;
       case EMU_TURBO_FIRE_TOGGLE:
          if (turbo_fire_button_disabled == -1 && turbo_fire_button == -1)

--- a/sources/src/custom.c
+++ b/sources/src/custom.c
@@ -77,6 +77,9 @@
 
 #ifdef __LIBRETRO__
 #include "libretro-glue.h"
+extern bool retro_request_av_info_update;
+extern bool retro_av_info_change_timing;
+extern bool retro_av_info_is_ntsc;
 #endif
 
 /* internal prototypes */
@@ -3235,7 +3238,9 @@ void compute_framesync (void)
 	);
 
 #ifdef __LIBRETRO__
-	retro_update_av_info(true, isntsc);
+	retro_request_av_info_update = true;
+	retro_av_info_change_timing  = true;
+	retro_av_info_is_ntsc        = isntsc;
 #endif
 
 	config_changed = 1;


### PR DESCRIPTION
This is a follow up to PR #249. It includes the following fixes:

- At present, any call to `retro_update_av_info()` that occurs outside of `retro_run()` is ignored (since it is unsafe to invoke this anywhere else). Such calls may happen on the first frame, and when loading a save state - and it turns out that this can cause problems in certain edge cases. For example, when running some NTSC content, we end up with the wrong video dimensions (until the next resolution change). This sort of error was hard to detect! Many apologies for missing it. This PR fixes the issue by deferring any av info updates that occur outside the main runloop to the next call of `retro_run()`.

- It turns out that rewind functionality can break in certain games due to an increase in save state size during runtime. This PR now sets a fixed save state size (determined at load content), so the frontend no longer has to deal with changing buffer sizes. Rewind should now always work in all cases.

**NOTE:** With the fixed size save states, and after some further investigation, I can confirm that *runahead now works in most cases* - **but** only if it is enabled *after* content is fully loaded.

Basically, there is window of ~300 frames at the start of the emulation runloop where we cannot save/load states on adjacent frames. This seems fundamental to the underlying puae code, and I have no idea how to fix it (or even if it can be fixed). But if runahead is enabled after this, it is actually quite useable - although it requires a beefy CPU.