### PR TITLE
Global Boot HD core option with HDF creation, Filesys fixes

### DIFF
--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -951,3 +951,139 @@ void zip_uncompress(char *in, char *out)
         uf = NULL;
     }
 }
+
+static int create_hdf (const char *path, off_t size)
+{
+    FILE *f;
+    void *buf;
+    const size_t CHUNK_SIZE = 4096;
+
+    if (size == 0)
+        return 0;
+
+    f = fopen (path, "wb+");
+    if (f) {
+        /*
+         * Try it the easy way.
+         */
+        if (fseeko (f, size - 1, SEEK_SET) == 0) {
+            fputc (0, f);
+            if (fseeko (f, 0, SEEK_SET) == 0) {
+                fclose (f);
+                return 0;
+            }
+        }
+
+        /*
+         * Okay. That failed. Let's assume seeking passed
+         * the end of a file ain't supported. Do it the
+         * hard way.
+         */
+        fseeko (f, 0, SEEK_SET);
+        buf = calloc (1, CHUNK_SIZE);
+
+        while (size >= (off_t) CHUNK_SIZE) {
+            if (fwrite (buf, CHUNK_SIZE, 1, f) != 1)
+                break;
+            size -= CHUNK_SIZE;
+        }
+
+        if (size < (off_t) CHUNK_SIZE) {
+            if (size == 0 || fwrite (buf, (size_t)size, 1, f) == 1) {
+                fclose (f);
+                return 0;
+            }
+        }
+    }
+
+    if (f) {
+        fclose (f);
+    }
+
+    return -1;
+}
+
+int make_hdf (char *hdf_path, char *hdf_size, char *device_name)
+{
+    uae_u64 size;
+    char *size_spec;
+
+    uae_u32 block_size = 512;
+    uae_u64 num_blocks;
+
+    uae_u32 cylinders;
+    uae_u32 blocks_per_track;
+    uae_u32 surfaces;
+
+    size = strtoll(hdf_size, &size_spec, 10);
+
+    /* Munge size specifier */
+    if (size > 0) {
+        char c = (toupper(*size_spec));
+
+        if (c == 'K')
+            size *= 1024;
+        else if (c == 'M' || c == '\0')
+            size *= 1024 * 1024;
+        else if (c == 'G')
+            size *= 1024 * 1024 * 1024;
+        else
+            size = 0;
+    }
+
+    if (size <= 0) {
+	    fprintf (stderr, "Invalid size\n");
+	    exit (EXIT_FAILURE);
+    }
+
+    if ((size >= (1LL << 31)) && (sizeof (off_t) < sizeof (uae_u64))) {
+	    fprintf (stderr, "Specified size too large (2GB file size is maximum).\n");
+	    exit (EXIT_FAILURE);
+    }
+
+    num_blocks = size / block_size;
+
+    /* We don't want more than (2^32)-1 blocks */
+    if (num_blocks >= (1LL << 32)) {
+	    fprintf (stderr, "Specified size too large (too many blocks).\n");
+	    exit (EXIT_FAILURE);
+    }
+
+    /*
+     * Try and work out some plausible geometry
+     *
+     * We try and set surfaces and blocks_per_track to keep
+     * cylinders < 65536. Prior to OS 3.9, FFS had problems with
+     * more cylinders than that.
+     */
+
+    /* The default practice in UAE hardfiles, so let's start there. */
+    blocks_per_track = 32;
+    surfaces = 1;
+
+    cylinders = num_blocks / (blocks_per_track * surfaces);
+
+    if (cylinders == 0) {
+	    fprintf (stderr, "Specified size is too small.\n");
+	    exit (EXIT_FAILURE);
+    }
+
+    while (cylinders > 65535 && surfaces < 255) {
+	    surfaces++;
+	    cylinders = num_blocks / (blocks_per_track * surfaces);
+    }
+
+    while (cylinders > 65535 && blocks_per_track < 255) {
+	    blocks_per_track++;
+	    cylinders = num_blocks / (blocks_per_track * surfaces);
+    }
+
+    /* Calculate size based on above geometry */
+    num_blocks = (uae_u64)cylinders * surfaces * blocks_per_track;
+
+    /* make file */
+    if (create_hdf (hdf_path, num_blocks * block_size) < 0)
+	    return EXIT_FAILURE;
+
+    return EXIT_SUCCESS;
+}

--- a/retrodep/retroglue.h
+++ b/retrodep/retroglue.h
@@ -7,6 +7,6 @@ void gz_uncompress(gzFile in, void *out);
 #include "deps/zlib/unzip.h"
 void zip_uncompress(char *in, char *out);
 
+int make_hdf (char *hdf_path, char *hdf_size, char *device_name);
+
 #endif
-
-

--- a/sources/src/statusline.c
+++ b/sources/src/statusline.c
@@ -200,6 +200,9 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
     if (gui_data.hd >= 0 || gui_data.cd >= 0 || gui_data.md >= 0)
         floppies = (opt_statusbar_enhanced) ? 1 : 0;
 
+    if (!gui_data.drive_disabled[0])
+        floppies = 1;
+
     for (led = 0; led < LED_MAX; led++) {
         int side, pos, num1 = -1, num2 = -1, num3 = -1, num4 = -1;
         int x, c, on = 0, am = 2;
@@ -214,13 +217,14 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             int pled = led - LED_DF0;
             int track = gui_data.drive_track[pled];
             pos = 6 + pled;
-            if (gui_data.hd >= 0 || gui_data.cd >= 0 || gui_data.md >= 0)
+            if ((gui_data.hd >= 0 || gui_data.cd >= 0 || gui_data.md >= 0) && !gui_data.df[0][0] && !gui_data.df[1][0])
             {
                 on_rgb = BLACK;
                 on_rgb2 = BLACK;
                 off_rgb = BLACK;
-            } else {
-            //if (!gui_data.drive_disabled[pled]) {
+            }
+            else
+            {
                 if (currprefs.chipset_mask & CSMASK_MASK)
                 {
                     on_rgb = YELLOW_BRIGHT;


### PR DESCRIPTION
- Core option for having a HD always attached, with HDF creation, as requested in #246 
  - HDF size options in MB are: 20, 40, 128, 256, 512
  - Files mode is ready for use without formatting

+ Filesys fixes:
   - Files under `S:` are always considered as scripts
   - Invalid filenames under WIN32 handled to prevent Workbench install failing in Files mode
+ Fixed RA disk index being at the last disk when `(MD)` is used, even though only the first drive is managed by the disk control
+ Fixed statusbar to show floppies with HD setups only when floppies are inserted
