### PR TITLE
Minor save state improvements

### DIFF
--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -14,6 +14,7 @@
 #endif
 
 #include "zfile.h"
+#include "retro_disk_control.h"
 
 extern int retrow;
 extern int retroh;
@@ -39,6 +40,7 @@ extern int retro_max_diwstop;
 extern char retro_system_directory[512];
 
 extern struct zfile *retro_deserialize_file;
+extern dc_storage *retro_dc;
 
 #ifndef _WIN32
 #define TCHAR char /* from sysdeps.h */

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -25,10 +25,18 @@
 // Disk control structure and functions
 #define DC_MAX_SIZE 20
 
-struct dc_storage{
+enum dc_image_type {
+	DC_IMAGE_TYPE_NONE = 0,
+	DC_IMAGE_TYPE_FLOPPY,
+	DC_IMAGE_TYPE_CD,
+	DC_IMAGE_TYPE_UNKNOWN
+};
+
+struct dc_storage {
 	char* command;
 	char* files[DC_MAX_SIZE];
 	char* labels[DC_MAX_SIZE];
+	enum dc_image_type types[DC_MAX_SIZE];
 	unsigned count;
 	int index;
 	bool eject_state;
@@ -40,5 +48,6 @@ void dc_parse_m3u(dc_storage* dc, const char* m3u_file, const char* save_dir);
 bool dc_add_file(dc_storage* dc, const char* filename, const char* label);
 void dc_reset(dc_storage* dc);
 void dc_free(dc_storage* dc);
+enum dc_image_type dc_get_image_type(const char* filename);
 
 #endif

--- a/sources/src/include/savestate.h
+++ b/sources/src/include/savestate.h
@@ -212,7 +212,7 @@ extern uae_u8 *save_hrtmon (int *, uae_u8 *);
 
 extern void savestate_initsave (const TCHAR *filename, int docompress, int nodialogs, bool save);
 #ifdef __LIBRETRO__
-extern struct zfile *save_state (const TCHAR *description);
+extern struct zfile *save_state (const TCHAR *description, uae_u64 size);
 void restore_state (void);
 #else
 extern int save_state (const TCHAR *filename, const TCHAR *description);

--- a/sources/src/savestate.c
+++ b/sources/src/savestate.c
@@ -1110,7 +1110,7 @@ static int save_state_internal (struct zfile *f, const TCHAR *description, int c
 }
 
 #ifdef __LIBRETRO__
-struct zfile *save_state (const TCHAR *description)
+struct zfile *save_state (const TCHAR *description, uae_u64 size)
 #else
 int save_state (const TCHAR *filename, const TCHAR *description)
 #endif
@@ -1138,7 +1138,7 @@ int save_state (const TCHAR *filename, const TCHAR *description)
 	savestate_nodialogs = 0;
 	custom_prepare_savestate ();
 #ifdef __LIBRETRO__
-	f = zfile_fopen_empty (NULL, description, 0);
+	f = zfile_fopen_empty (NULL, description, size);
 #else
 	f = zfile_fopen (filename, _T("w+b"), 0);
 #endif


### PR DESCRIPTION
This PR makes two small improvements to save state handling:

- When loading floppy disk content via `m3u` files, restoring a save state now updates the frontend with the correct 'currently selected' disk index (previously this was left at whatever index was selected before restoring the state, which was often wrong and made for a confusing user interface...)

- When creating save states, the memory buffer is now created with the correct 'final' size (instead of relying on dynamic allocation, expanding as required). I didn't actually expect this to have much effect, but it turns out all those `realloc`s were quite expensive: previously I could only run at fullspeed with rewind enabled with a granularity of 4-5 frames - now I can drop this down to 3.