### PR TITLE
VKBD touch control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ endif
 ifeq ($(DEBUG), 1)
    CFLAGS += -O0 -g
 else
-   CFLAGS += -O2
+   CFLAGS += -O3
    SHARED += -s
 endif
 

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -21,16 +21,12 @@ extern int retroh;
 extern int pix_bytes;
 extern int zoomed_height;
 extern int imagename_timer;
-extern void reset_drawing();
+extern void reset_drawing(void);
+extern void print_statusbar(void);
 
 extern bool retro_request_av_info_update;
 extern bool retro_av_info_change_timing;
 extern bool retro_av_info_is_ntsc;
-
-extern int vkey_pressed;
-extern int vkey_sticky;
-extern int vkey_sticky1;
-extern int vkey_sticky2;
 
 extern int retro_thisframe_first_drawn_line;
 extern int retro_thisframe_last_drawn_line;
@@ -59,6 +55,23 @@ int umain (int argc, TCHAR **argv);
 #define NPLGN 11
 #define NLIGN 8
 #define NLETT 9
+//#define POINTER_DEBUG
+#ifdef POINTER_DEBUG
+extern int pointer_x;
+extern int pointer_y;
+#endif
+
+extern int vkey_pos_x;
+extern int vkey_pos_y;
+extern int vkey_pressed;
+extern int vkey_sticky;
+extern int vkey_sticky1;
+extern int vkey_sticky2;
+
+extern int vkbd_x_min;
+extern int vkbd_x_max;
+extern int vkbd_y_min;
+extern int vkbd_y_max;
 
 // Colors
 #define RGB565(r, g, b) (((r) << (5+6)) | ((g) << 6) | (b))

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -3,6 +3,7 @@
 #include "libretro-mapper.h"
 #include "libretro-glue.h"
 #include "vkbd.h"
+#include "graph.h"
 #include "retro_files.h"
 #include "retro_strings.h"
 #include "retro_disk_control.h"
@@ -89,8 +90,6 @@ static int restart_pending = 0;
 unsigned short int retro_bmp[RETRO_BMP_SIZE];
 extern int SHIFTON;
 extern int STATUSON;
-extern void Print_Status(void);
-extern void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
 extern int prefs_changed;
 
 extern int turbo_fire_button;
@@ -4676,12 +4675,18 @@ void retro_run(void)
    restart_pending = m68k_go(1, 1);
 
    if (STATUSON == 1)
-      Print_Status();
+      print_statusbar();
    if (SHOWKEY == 1)
    {
       // Virtual keyboard requires a graceful redraw, blunt reset_drawing() interferes with zoom
       frame_redraw_necessary = 2;
-      virtual_kbd(retro_bmp, vkey_pos_x, vkey_pos_y);
+      print_virtual_kbd(retro_bmp);
+#ifdef POINTER_DEBUG
+      if (pix_bytes == 4)
+         DrawHlineBmp32((uint32_t *)retro_bmp, pointer_x, pointer_y, 2, 2, RGB888(30, 0, 30));
+      else
+         DrawHlineBmp(retro_bmp, pointer_x, pointer_y, 2, 2, RGB565(30, 0, 30));
+#endif
    }
    // Maximum 288p/576p PAL shenanigans:
    // Mask the last line(s), since UAE does not refresh the last line, and even its own OSD will leave trails

--- a/libretro/vkbd.c
+++ b/libretro/vkbd.c
@@ -7,12 +7,11 @@ extern int NPAGE;
 extern int SHOWKEYPOS;
 extern int SHOWKEYTRANS;
 extern int SHIFTON;
-extern int pix_bytes;
 extern int vkflag[8];
 extern unsigned int video_config_geometry;
 extern unsigned int opt_vkbd_alpha;
 
-void virtual_kbd(unsigned short int *pixels, int vx, int vy)
+void print_virtual_kbd(unsigned short int *pixels)
 {
    int x, y;
    bool shifted;
@@ -135,6 +134,12 @@ void virtual_kbd(unsigned short int *pixels, int vx, int vy)
    int XBASETEXT = ((XPADDING > 0) ? (XPADDING / 2) : 0) + (video_config_geometry & PUAE_VIDEO_SUPERHIRES) ? 12 : (video_config_geometry & PUAE_VIDEO_HIRES) ? 6 : 5;
    int YBASETEXT = YBASEKEY + ((video_config_geometry & PUAE_VIDEO_NTSC) ? 4 : 5);
 
+   /* Coordinates */
+   vkbd_x_min = XKEYSPACING;
+   vkbd_x_max = retrow - XKEYSPACING;
+   vkbd_y_min = YOFFSET + YBASEKEY + YKEYSPACING;
+   vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * NLIGN);
+
    /* Opacity */
    BKG_ALPHA = (SHOWKEYTRANS == -1) ? 255 : ALPHA;
 
@@ -234,10 +239,10 @@ void virtual_kbd(unsigned short int *pixels, int vx, int vy)
    }
 
    /* Selected key position */
-   XKEY  = XBASEKEY + (vx * XSIDE) + XOFFSET;
-   XTEXT = XBASETEXT + BKG_PADDING_X + (vx * XSIDE) + XOFFSET;
-   YKEY  = YOFFSET + YBASEKEY + (vy * YSIDE);
-   YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vy * YSIDE);
+   XKEY  = XBASEKEY + (vkey_pos_x * XSIDE) + XOFFSET;
+   XTEXT = XBASETEXT + BKG_PADDING_X + (vkey_pos_x * XSIDE) + XOFFSET;
+   YKEY  = YOFFSET + YBASEKEY + (vkey_pos_y * YSIDE);
+   YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
 
    /* Pressed key background color */
    if (vkflag[4] == 1)
@@ -256,12 +261,12 @@ void virtual_kbd(unsigned short int *pixels, int vx, int vy)
    if (pix_bytes == 4)
    {
       Draw_text32((uint32_t *)pix, XTEXT, YTEXT, FONT_COLOR_SEL, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-         (!shifted) ? MVk[(vy * NPLGN) + vx + page].norml : MVk[(vy * NPLGN) + vx + page].shift);
+         (!shifted) ? MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].norml : MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].shift);
    }
    else
    {
       Draw_text(pix, XTEXT, YTEXT, FONT_COLOR_SEL, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-         (!shifted) ? MVk[(vy * NPLGN) + vx + page].norml : MVk[(vy * NPLGN) + vx + page].shift);
+         (!shifted) ? MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].norml : MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].shift);
    }
 }
 

--- a/libretro/vkbd.h
+++ b/libretro/vkbd.h
@@ -1,7 +1,7 @@
 #ifndef VKBD_H
 #define VKBD_H
 
-extern void virtual_kbd(unsigned short int *pixels, int vx, int vy);
+extern void print_virtual_kbd(unsigned short int *pixels);
 extern int check_vkey(int x, int y);
 
 #endif


### PR DESCRIPTION
Only tested with Windows and mouse, since `RETRO_DEVICE_POINTER` also reacts with it. Hence also disabled real mouse control while VKBD is visible.

Bonus:
- Switched O2 to O3 for a small performance boost. No ill-effects witnessed yet, but standing by for surprises from other platforms.

