### PR TITLE
M3U+ZIP handling, CDTV option

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ Note the size of the HDF specified by SIZE_OF_HDF must be greater than size of t
 ## Using configuration files
 You can pass an '.uae' configuration file and the core will load the settings and start emulation.
 
-Look at the temporary configuration file "puae_libretro.uae" in RetroArch saves as a starting point for your own configuration files.
+Look at the temporary configuration file `puae_libretro.uae` in RetroArch saves as a starting point for your own configuration files.
+
+If the file `puae_libretro_global.uae` exists in RetroArch saves it will be appended to the temporary configuration file.
 
 ***Note that the use of configuration files is no longer encouraged or necessary. The core has been modified to always use the core options as a base, so that all custom configurations will be appended to the created configuration, effectively overriding the core options. The problem with this is that changing any core option while the core is running will reset all duplicate configurations. Therefore only add configurations which will require a restart or do not exist in the core options, if you must use a custom uae. If there is an option missing that is a must have, please make an issue about it.***
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The following models are provided:
 |A1200|Amiga 1200|AGA|2MB Chip RAM + 8MB Fast RAM|
 |A4030|Amiga 4000/030|AGA|2MB Chip RAM + 8MB Fast RAM|
 |A4040|Amiga 4000/040|AGA|2MB Chip RAM + 8MB Fast RAM|
+|CDTV|Amiga CDTV|ECS|1MB Chip RAM|
 |CD32|Amiga CD32|AGA|2MB Chip RAM|
 |CD32FR|Amiga CD32|AGA|2MB Chip RAM + 8MB Fast RAM|
 
@@ -77,6 +78,7 @@ It is critical to use Kickstarts with the correct MD5, otherwise the core might 
 |A600|KS v3.1 rev 40.063|**kick40063.A600**|524 288|e40a5dfb3d017ba8779faba30cbd1c8e|
 |A1200|KS v3.1 rev 40.068|**kick40068.A1200**|524 288|646773759326fbac3b2311fd8c8793ee|
 |A4000|KS v3.1 rev 40.068|**kick40068.A4000**|524 288|9bdedde6a4f33555b4a270c8ca53297d|
+|CDTV|CDTV extended ROM v1.00|**kick34005.CDTV**|262 144|89da1838a24460e4b93f4f0c5d92d48d|
 
 For CD32 you need either separate ROMs (Kickstart + extended ROM) or the combined ROM:
 
@@ -86,7 +88,6 @@ For CD32 you need either separate ROMs (Kickstart + extended ROM) or the combine
 | | | **OR** | | |
 |CD32|KS v3.1 rev 40.060|**kick40060.CD32**|524 288|5f8924d013dd57a89cf349f4cdedc6b1|
 |CD32|Extended ROM rev 40.060|**kick40060.CD32.ext**|524 288|bb72565701b1b6faece07d68ea5da639|
-
 
 ### Resolution and rendering
 These parameters control the output resolution of the core:
@@ -143,6 +144,7 @@ To do this just add the corresponding string to the filename:
 |**x**| |**(A4030)** or **(030)**|Amiga 4000/030, 2MB Chip RAM + 8MB Fast RAM|
 |**x**| |**(A4040)** or **(040)**|Amiga 4000/040, 2MB Chip RAM + 8MB Fast RAM|
 |**x**| |**(MD)**|*Insert each disk in a different drive (**Maximum 4 disks**)*|
+| |**x**|**CDTV**|Amiga CDTV, 1MB Chip RAM|
 | |**x**|**(CD32)** or **(CD32NF)**|Amiga CD32, 2MB Chip RAM|
 | |**x**|**(CD32FR)** or **FastRAM**|Amiga CD32, 2MB Chip RAM + 8MB Fast RAM|
 |**x**|**x**|**NTSC**|NTSC 60Hz|
@@ -186,7 +188,6 @@ ZIPs will be extracted to a temporary directory in RetroArch `saves` and then de
 - If the ZIP contains floppy disks, A M3U playlist will be created and launched.
 - Hard drive and CD images will be treated one by one and only the first file found is selected for launch.
 - If no disk/drive images are found, the ZIP will be treated as a directory.
-
 
 ### M3U support
 When you have a multi disk game, you can use a M3U file to specify each disk of the game and change them from the RetroArch Disk Control interface.

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -126,24 +126,6 @@ chipmem_size=4\n\
 fastmem_size=0\n\
 "
 
-#define CD32_CONFIG "\
-cpu_model=68020\n\
-chipset=aga\n\
-chipset_compatible=CD32\n\
-chipmem_size=4\n\
-fastmem_size=0\n\
-floppy0type=-1\n\
-"
-
-#define CD32FR_CONFIG "\
-cpu_model=68020\n\
-chipset=aga\n\
-chipset_compatible=CD32\n\
-chipmem_size=4\n\
-fastmem_size=8\n\
-floppy0type=-1\n\
-"
-
 #define A4030_CONFIG "\
 cpu_model=68030\n\
 fpu_model=68882\n\
@@ -162,12 +144,41 @@ chipmem_size=4\n\
 fastmem_size=8\n\
 "
 
+#define CDTV_CONFIG "\
+cpu_model=68000\n\
+chipset=ecs_agnus\n\
+chipset_compatible=CDTV\n\
+chipmem_size=2\n\
+bogomem_size=0\n\
+floppy0type=-1\n\
+"
+
+#define CD32_CONFIG "\
+cpu_model=68020\n\
+chipset=aga\n\
+chipset_compatible=CD32\n\
+chipmem_size=4\n\
+fastmem_size=0\n\
+floppy0type=-1\n\
+"
+
+#define CD32FR_CONFIG "\
+cpu_model=68020\n\
+chipset=aga\n\
+chipset_compatible=CD32\n\
+chipmem_size=4\n\
+fastmem_size=8\n\
+floppy0type=-1\n\
+"
+
+
 // Amiga kickstarts
 #define A500_ROM                "kick34005.A500"
 #define A500KS2_ROM             "kick37175.A500"
 #define A600_ROM                "kick40063.A600"
 #define A1200_ROM               "kick40068.A1200"
 #define A4000_ROM               "kick40068.A4000"
+#define CDTV_ROM                "kick34005.CDTV"
 #define CD32_ROM                "kick40060.CD32"
 #define CD32_ROM_EXT            "kick40060.CD32.ext"
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -510,26 +510,26 @@ void print_statusbar(void)
    BOX_Y = STAT_BASEY - BOX_PADDING;
 
    // Statusbar size
-   int BOX_LED_WIDTH = 20;
-   BOX_WIDTH = retrow - (BOX_LED_WIDTH * 5) - 2; // (LED-width * LED-num) - LED-border
+   int BOX_LED_WIDTH = 17;
+   BOX_WIDTH = retrow - (BOX_LED_WIDTH * 5); // (LED-width * LED-num)
    if (video_config & PUAE_VIDEO_HIRES && !(video_config & PUAE_VIDEO_DOUBLELINE))
-      BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 2) * 5) - 2;
+      BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 2) * 5);
    else if (video_config & PUAE_VIDEO_SUPERHIRES)
    {
       if (video_config & PUAE_VIDEO_DOUBLELINE)
-         BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 2) * 5) - 2;
+         BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 2) * 5);
       else
-         BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 4) * 5) - 2;
+         BOX_WIDTH = retrow - ((BOX_LED_WIDTH * 4) * 5);
    }
 
    // Video resolution
-   int STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*4);
+   int STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*4)+(FONT_WIDTH*16);
    char RESOLUTION[10] = {0};
    snprintf(RESOLUTION, sizeof(RESOLUTION), "%4dx%3d", retrow, zoomed_height);
 
    // Model & memory
-   int STAT_X_MODEL  = STAT_X+(FONT_SLOT*5)+(FONT_WIDTH*52);
-   int STAT_X_MEMORY = STAT_X+(FONT_SLOT*5)+(FONT_WIDTH*24);
+   int STAT_X_MODEL  = STAT_X+(FONT_SLOT*6)+(FONT_WIDTH*30);
+   int STAT_X_MEMORY = STAT_X+(FONT_SLOT*6)+(FONT_WIDTH*5);
    char MODEL[10] = {0};
    char MEMORY[5] = {0};
    float mem_size = 0;
@@ -562,9 +562,9 @@ void print_statusbar(void)
    // Double line positions
    if (video_config & PUAE_VIDEO_DOUBLELINE)
    {
-      STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*14)+(FONT_WIDTH*28);
-      STAT_X_MODEL      = STAT_X+(FONT_SLOT*15)+(FONT_WIDTH*72);
-      STAT_X_MEMORY     = STAT_X+(FONT_SLOT*15)+(FONT_WIDTH*48);
+      STAT_X_RESOLUTION = STAT_X+(FONT_SLOT*15)+(FONT_WIDTH*5);
+      STAT_X_MODEL      = STAT_X+(FONT_SLOT*17)+(FONT_WIDTH*15);
+      STAT_X_MEMORY     = STAT_X+(FONT_SLOT*16)+(FONT_WIDTH*25);
    }
 
    // Joy port indicators

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -554,6 +554,9 @@ void print_statusbar(void)
       case CP_A4000:
          snprintf(MODEL, sizeof(MODEL), "%s", "A4000");
          break;
+      case CP_CDTV:
+         snprintf(MODEL, sizeof(MODEL), "%s", " CDTV");
+         break;
       case CP_CD32:
          snprintf(MODEL, sizeof(MODEL), "%s", " CD32");
          break;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -232,6 +232,7 @@ void retro_set_environment(retro_environment_t cb)
             { "A1200", "A1200 (2MB Chip + 8MB Fast)" },
             { "A4030", "A4000/030 (2MB Chip + 8MB Fast)" },
             { "A4040", "A4000/040 (2MB Chip + 8MB Fast)" },
+            { "CDTV", "CDTV (1MB Chip)" },
             { "CD32", "CD32 (2MB Chip)" },
             { "CD32FR", "CD32 (2MB Chip + 8MB Fast)" },
             { NULL, NULL },
@@ -809,7 +810,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "puae_use_whdload_prefs",
          "WHDLoad Splash Screen Options",
-         "Space/Enter/Fire work as the WHDLoad Start-button. Core restart required.\nOverride with buttons while booting:\n- 'Config': Hold 2nd fire / Blue.\n- 'Splash': Hold LMB.\n- 'Config + Splash': Hold RMB.",
+         "Space/Enter/Fire work as the WHDLoad Start-button. Core restart required.\nOverride with buttons while booting:\n- 'Config': Hold 2nd fire / Blue\n- 'Splash': Hold LMB\n- 'Config + Splash': Hold RMB\n- ReadMe + MkCustom: Hold Red+Blue",
          {
             { "disabled", NULL },
             { "config", "Config (Show only if available)" },
@@ -3554,6 +3555,12 @@ bool retro_create_config()
       strcat(uae_machine, A4040_CONFIG);
       strcpy(uae_kickstart, A4000_ROM);
    }
+   else if (strcmp(opt_model, "CDTV") == 0)
+   {
+      strcat(uae_machine, CDTV_CONFIG);
+      strcpy(uae_kickstart, A500_ROM);
+      strcpy(uae_kickstart_ext, CDTV_ROM);
+   }
    else if (strcmp(opt_model, "CD32") == 0)
    {
       strcat(uae_machine, CD32_CONFIG);
@@ -3691,7 +3698,7 @@ bool retro_create_config()
             {
                // Use A4000/030
                fprintf(stdout, "[libretro-uae]: Found '(A4030)' or '(030)' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A4000/030 with Kickstart 3.1 r40.068\n");
+               fprintf(stdout, "[libretro-uae]: Booting A4000/030: '%s'\n", A4000_ROM);
                fprintf(configfile, A4030_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A4000_ROM);
             }
@@ -3699,7 +3706,7 @@ bool retro_create_config()
             {
                // Use A4000/040
                fprintf(stdout, "[libretro-uae]: Found '(A4040)' or '(040)' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A4000/040 with Kickstart 3.1 r40.068\n");
+               fprintf(stdout, "[libretro-uae]: Booting A4000/040: '%s'\n", A4000_ROM);
                fprintf(configfile, A4040_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A4000_ROM);
             }
@@ -3707,7 +3714,7 @@ bool retro_create_config()
             {
                // Use A1200 barebone
                fprintf(stdout, "[libretro-uae]: Found '(A1200OG)' or '(A1200NF)' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A1200 NoFast with Kickstart 3.1 r40.068\n");
+               fprintf(stdout, "[libretro-uae]: Booting A1200 NoFast: '%s'\n", A1200_ROM);
                fprintf(configfile, A1200OG_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A1200_ROM);
             }
@@ -3715,7 +3722,7 @@ bool retro_create_config()
             {
                // Use A1200
                fprintf(stdout, "[libretro-uae]: Found '(A1200)', 'AGA', 'CD32', or 'AmigaCD' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A1200 with Kickstart 3.1 r40.068\n");
+               fprintf(stdout, "[libretro-uae]: Booting A1200: '%s'\n", A1200_ROM);
                fprintf(configfile, A1200_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A1200_ROM);
             }
@@ -3723,7 +3730,7 @@ bool retro_create_config()
             {
                // Use A600
                fprintf(stdout, "[libretro-uae]: Found '(A600)' or 'ECS' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A600 with Kickstart 3.1 r40.063\n");
+               fprintf(stdout, "[libretro-uae]: Booting A600: '%s'\n", A600_ROM);
                fprintf(configfile, A600_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A600_ROM);
             }
@@ -3731,7 +3738,7 @@ bool retro_create_config()
             {
                // Use A500+
                fprintf(stdout, "[libretro-uae]: Found '(A500+)' or '(A500PLUS)' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A500+ with Kickstart 2.04 r37.175\n");
+               fprintf(stdout, "[libretro-uae]: Booting A500+: '%s'\n", A500KS2_ROM);
                fprintf(configfile, A500PLUS_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A500KS2_ROM);
             }
@@ -3739,7 +3746,7 @@ bool retro_create_config()
             {
                // Use A500 barebone
                fprintf(stdout, "[libretro-uae]: Found '(A500OG)' or '(512K)' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A500 512K with Kickstart 1.3 r34.005\n");
+               fprintf(stdout, "[libretro-uae]: Booting A500 512K: '%s'\n", A500_ROM);
                fprintf(configfile, A500OG_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A500_ROM);
             }
@@ -3747,7 +3754,7 @@ bool retro_create_config()
             {
                // Use A500
                fprintf(stdout, "[libretro-uae]: Found '(A500)' or 'OCS' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting A500 with Kickstart 1.3 r34.005\n");
+               fprintf(stdout, "[libretro-uae]: Booting A500: '%s'\n", A500_ROM);
                fprintf(configfile, A500_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, A500_ROM);
             }
@@ -3786,7 +3793,7 @@ bool retro_create_config()
 
                // No machine specified
                fprintf(stdout, "[libretro-uae]: No machine specified in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting default configuration\n");
+               fprintf(stdout, "[libretro-uae]: Booting default configuration: %s\n", uae_kickstart);
                fprintf(configfile, uae_machine);
                path_join((char*)&kickstart, retro_system_directory, uae_kickstart);
             }
@@ -4267,7 +4274,7 @@ bool retro_create_config()
             {
                // Use CD32 with Fast RAM
                fprintf(stdout, "[libretro-uae]: Found '(CD32FR)' or 'FastRAM' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting CD32 FastRAM with Kickstart 3.1 r40.060\n");
+               fprintf(stdout, "[libretro-uae]: Booting CD32 FastRAM: '%s'\n", CD32_ROM);
                fprintf(configfile, CD32FR_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, CD32_ROM);
                path_join((char*)&kickstart_ext, retro_system_directory, CD32_ROM_EXT);
@@ -4276,10 +4283,19 @@ bool retro_create_config()
             {
                // Use CD32 barebone
                fprintf(stdout, "[libretro-uae]: Found '(CD32)' or '(CD32NF)' in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting CD32 with Kickstart 3.1 r40.060\n");
+               fprintf(stdout, "[libretro-uae]: Booting CD32: '%s'\n", CD32_ROM);
                fprintf(configfile, CD32_CONFIG);
                path_join((char*)&kickstart, retro_system_directory, CD32_ROM);
                path_join((char*)&kickstart_ext, retro_system_directory, CD32_ROM_EXT);
+            }
+            else if (strstr(full_path, "CDTV"))
+            {
+               // Use CDTV
+               fprintf(stdout, "[libretro-uae]: Found 'CDTV' in filename '%s'\n", full_path);
+               fprintf(stdout, "[libretro-uae]: Booting CDTV: '%s'\n", CDTV_ROM);
+               fprintf(configfile, CDTV_CONFIG);
+               path_join((char*)&kickstart, retro_system_directory, A500_ROM);
+               path_join((char*)&kickstart_ext, retro_system_directory, CDTV_ROM);
             }
             else
             {
@@ -4293,7 +4309,7 @@ bool retro_create_config()
 
                // No machine specified
                fprintf(stdout, "[libretro-uae]: No machine specified in filename '%s'\n", full_path);
-               fprintf(stdout, "[libretro-uae]: Booting default configuration\n");
+               fprintf(stdout, "[libretro-uae]: Booting default configuration: %s\n", uae_kickstart);
                fprintf(configfile, uae_machine);
                path_join((char*)&kickstart, retro_system_directory, uae_kickstart);
                path_join((char*)&kickstart_ext, retro_system_directory, uae_kickstart_ext);
@@ -4335,7 +4351,7 @@ bool retro_create_config()
             stat(kickstart, &kickstart_st);
 
             // Verify extended ROM if external
-            if (kickstart_st.st_size == 524288)
+            if (kickstart_st.st_size <= 524288)
             {
                if (!file_exists(kickstart_ext))
                {
@@ -4355,6 +4371,10 @@ bool retro_create_config()
             {
                // Shared
                path_join((char*)&flash_file, retro_save_directory, LIBRETRO_PUAE_PREFIX);
+
+               // CDTV suffix
+               if (kickstart_st.st_size == 262144)
+                  snprintf(flash_file, sizeof(flash_file), "%s%s", flash_file, "_cdtv");
             }
             else
             {
@@ -4454,7 +4474,7 @@ bool retro_create_config()
          char kickstart[RETRO_PATH_MAX];
 
          // No machine specified
-         fprintf(stdout, "[libretro-uae]: Booting default configuration\n");
+         fprintf(stdout, "[libretro-uae]: Booting default configuration: %s\n", uae_kickstart);
          fprintf(configfile, uae_machine);
          path_join((char*)&kickstart, retro_system_directory, uae_kickstart);
 
@@ -4513,7 +4533,7 @@ bool retro_create_config()
          }
 
          // CD32 exception
-         if (strcmp(opt_model, "CD32") == 0 || strcmp(opt_model, "CD32FR") == 0)
+         if (strcmp(opt_model, "CD32") == 0 || strcmp(opt_model, "CD32FR") == 0 || strcmp(opt_model, "CDTV") == 0)
          {
             char kickstart_ext[RETRO_PATH_MAX];
             path_join((char*)&kickstart_ext, retro_system_directory, uae_kickstart_ext);
@@ -4534,7 +4554,7 @@ bool retro_create_config()
             stat(kickstart, &kickstart_st);
 
             // Verify extended ROM if external
-            if (kickstart_st.st_size == 524288)
+            if (kickstart_st.st_size <= 524288)
             {
                if (!file_exists(kickstart_ext))
                {
@@ -4551,6 +4571,9 @@ bool retro_create_config()
             char flash_file[RETRO_PATH_MAX];
             char flash_filepath[RETRO_PATH_MAX];
             path_join((char*)&flash_file, retro_save_directory, LIBRETRO_PUAE_PREFIX);
+            // CDTV suffix
+            if (kickstart_st.st_size == 262144)
+               snprintf(flash_file, sizeof(flash_file), "%s%s", flash_file, "_cdtv");
             fprintf(stdout, "[libretro-uae]: Using Flash RAM: '%s.nvr'\n", flash_file);
             fprintf(configfile, "flash_file=%s.nvr\n", (const char*)&flash_file);
          }

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -822,7 +822,7 @@ void gz_uncompress(gzFile in, FILE *out)
 
 #include "deps/zlib/unzip.h"
 #include "file/file_path.h"
-void zip_uncompress(char *in, char *out)
+void zip_uncompress(char *in, char *out, char *lastfile)
 {
     unzFile uf = NULL;
     unz_file_info file_info;
@@ -839,6 +839,7 @@ void zip_uncompress(char *in, char *out)
     for (i = 0; i < gi.number_entry; i++)
     {
         char filename_inzip[256];
+        char filename_withpath[512];
         char* filename_withoutpath;
         char* p;
         unz_file_info file_info;
@@ -853,9 +854,9 @@ void zip_uncompress(char *in, char *out)
         }
 
         err = unzGetCurrentFileInfo(uf, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
-
-        char filename_withpath[512];
         snprintf(filename_withpath, sizeof(filename_withpath), "%s%s%s", out, DIR_SEP_STR, filename_inzip);
+        if (dc_get_image_type(filename_inzip) == DC_IMAGE_TYPE_FLOPPY)
+            snprintf(lastfile, sizeof(filename_inzip), "%s", filename_inzip);
 
         p = filename_withoutpath = filename_inzip;
         while ((*p) != '\0')

--- a/retrodep/retroglue.h
+++ b/retrodep/retroglue.h
@@ -5,7 +5,7 @@
 void gz_uncompress(gzFile in, void *out);
 
 #include "deps/zlib/unzip.h"
-void zip_uncompress(char *in, char *out);
+void zip_uncompress(char *in, char *out, char *lastfile);
 
 int make_hdf (char *hdf_path, char *hdf_size, char *device_name);
 

--- a/sources/src/statusline.c
+++ b/sources/src/statusline.c
@@ -180,9 +180,9 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             num_multip = 4;
     }
 
-    int LED_WIDTH = 20;
-    int TD_WIDTH = LED_WIDTH * num_multip;
-    int TD_LED_WIDTH = LED_WIDTH * num_multip;
+    int LED_WIDTH = 17;
+    int TD_WIDTH = (LED_WIDTH * num_multip);
+    int TD_LED_WIDTH = TD_WIDTH;
 
     int x_start, j, led, border;
     uae_u32 c1, c2, cb;
@@ -198,10 +198,11 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
 
     int floppies = 1;
     if (gui_data.hd >= 0 || gui_data.cd >= 0 || gui_data.md >= 0)
+    {
         floppies = (opt_statusbar_enhanced) ? 1 : 0;
-
-    if (!gui_data.drive_disabled[0])
-        floppies = 1;
+        if (gui_data.df[0][0])
+            floppies = 1;
+    }
 
     for (led = 0; led < LED_MAX; led++) {
         int side, pos, num1 = -1, num2 = -1, num3 = -1, num4 = -1;
@@ -318,9 +319,9 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
                 int fps = (gui_data.fps + 5) / 10;
                 on_rgb = 0x000000;
                 off_rgb = gui_data.fps_color ? 0xcccc00 : 0x000000;
-                am = 3;
-                if (fps > 999) {
-                    num1 = 9;
+                am = 2;
+                if (fps > 99) {
+                    num1 = -1;
                     num2 = 9;
                     num3 = 9;
                 } else {
@@ -446,10 +447,10 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             //border = 1;// Disable rounded borders
         }
 
-        x = x_start + pos * TD_WIDTH;
+        x = x_start + 1 + pos * TD_WIDTH;
         if (!border)
             putpixel (buf, bpp, x - 1, cb, 0);
-        for (j = 0; j < TD_LED_WIDTH; j++)
+        for (j = 0; j < TD_LED_WIDTH - 1; j++)
             putpixel (buf, bpp, x + j, c, 0);
         if (!border)
             putpixel (buf, bpp, x + j, cb, 0);
@@ -465,6 +466,8 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
                     write_tdnumber (buf, bpp, x, y - TD_PADY, num2, pen_rgb, c2);
                     x += TD_NUM_WIDTH * num_multip;
                 }
+                if (num_multip == 2)
+                    x--;
                 write_tdnumber (buf, bpp, x, y - TD_PADY, num3, pen_rgb, c2);
                 x += TD_NUM_WIDTH * num_multip;
                 if (num4 > -1)


### PR DESCRIPTION
More use cases for archives and playlists:
- Floppy images can be zipped in M3Us
- Disk Control insertion understands ZIPs and M3Us
  - ZIP with a single disk will append, multiple files and M3Us will replace
  - Insertion will also accept UAE/HDF/LHA, which will require core restart

Bonus:
- CDTV (core option + file tag)
- Global conf file `puae_libretro_global.uae` 
- Statusbar adjusting


![retroarch_2020_04_02_04_59_22_203](https://user-images.githubusercontent.com/45124675/78306278-ac2f4f00-754b-11ea-81ca-4c82b6608ea8.png)
![retroarch_2020_04_02_06_19_48_269](https://user-images.githubusercontent.com/45124675/78306291-b18c9980-754b-11ea-9674-299e12c86f58.png)
![retroarch_2020_04_02_22_32_30_128](https://user-images.githubusercontent.com/45124675/78306297-b3eef380-754b-11ea-9710-100c5171eb31.png)

