### PR TITLE
Controls + Automatic zoom updates

### DIFF
--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -104,6 +104,7 @@ extern bool opt_keyrahkeypad;
 extern bool opt_keyboard_pass_through;
 extern int opt_cd32pad_options;
 extern int opt_retropad_options;
+extern char opt_joyport_order[5];
 int imagename_timer=0;
 static char statusbar_text[RETRO_PATH_MAX]={0};
 int turbo_fire_button_disabled=-1;
@@ -984,6 +985,7 @@ static int retro_button_to_uae_button(int retro_port, int i)
 
 static void process_controller(int retro_port, int i)
 {
+   int retro_port_uae = opt_joyport_order[retro_port] - 49;
    int uae_button = -1;
 
    if (i>3 && i<8) // Directions, need to fight around presses on the same axis
@@ -994,10 +996,10 @@ static void process_controller(int retro_port, int i)
          {
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN)
-            && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
+            && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
             {
-               retro_joystick(retro_port, 1, -1);
-               jflag[retro_port][i]=1;
+               retro_joystick(retro_port_uae, 1, -1);
+               jflag[retro_port_uae][i]=1;
             }
          }
          else
@@ -1005,25 +1007,25 @@ static void process_controller(int retro_port, int i)
          {
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP)
-            && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
+            && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
             {
-               retro_joystick(retro_port, 1, 1);
-               jflag[retro_port][i]=1;
+               retro_joystick(retro_port_uae, 1, 1);
+               jflag[retro_port_uae][i]=1;
             }
          }
 
          if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP)
-         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_UP]==1 && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
+         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_UP]==1 && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
          {
-            retro_joystick(retro_port, 1, 0);
-            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_UP]=0;
+            retro_joystick(retro_port_uae, 1, 0);
+            jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_UP]=0;
          }
          else
          if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN)
-         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_DOWN]==1 && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
+         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_DOWN]==1 && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]==0)
          {
-            retro_joystick(retro_port, 1, 0);
-            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_DOWN]=0;
+            retro_joystick(retro_port_uae, 1, 0);
+            jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_DOWN]=0;
          }
       }
 
@@ -1034,8 +1036,8 @@ static void process_controller(int retro_port, int i)
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
             {
-               retro_joystick(retro_port, 0, -1);
-               jflag[retro_port][i]=1;
+               retro_joystick(retro_port_uae, 0, -1);
+               jflag[retro_port_uae][i]=1;
             }
          }
          else
@@ -1044,23 +1046,23 @@ static void process_controller(int retro_port, int i)
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))
             {
-               retro_joystick(retro_port, 0, 1);
-               jflag[retro_port][i]=1;
+               retro_joystick(retro_port_uae, 0, 1);
+               jflag[retro_port_uae][i]=1;
             }
          }
 
          if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT)
-         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_LEFT]==1)
+         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_LEFT]==1)
          {
-            retro_joystick(retro_port, 0, 0);
-            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_LEFT]=0;
+            retro_joystick(retro_port_uae, 0, 0);
+            jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_LEFT]=0;
          }
          else
          if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
-         && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_RIGHT]==1)
+         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_RIGHT]==1)
          {
-            retro_joystick(retro_port, 0, 0);
-            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_RIGHT]=0;
+            retro_joystick(retro_port_uae, 0, 0);
+            jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_RIGHT]=0;
          }
       }
    }
@@ -1071,7 +1073,7 @@ static void process_controller(int retro_port, int i)
       // Alternate jump button, hijack SELECT flag
       if (uae_button == -2)
       {
-         if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]==0 && SHOWKEY==-1)
+         if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]==0 && SHOWKEY==-1)
          {
             // Skip RetroPad face button handling if keymapped
             if (uae_devices[retro_port] == RETRO_DEVICE_JOYPAD && mapper_keys[i] != 0
@@ -1080,13 +1082,13 @@ static void process_controller(int retro_port, int i)
              || i == RETRO_DEVICE_ID_JOYPAD_X
              || i == RETRO_DEVICE_ID_JOYPAD_Y
             ))
-               jflag[retro_port][i]=1;
+               jflag[retro_port_uae][i]=1;
             else
-               retro_joystick(retro_port, 1, -1);
-            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]=1;
+               retro_joystick(retro_port_uae, 1, -1);
+            jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]=1;
          }
          else
-         if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]==1
+         if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]==1
           && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))
          {
             // Skip RetroPad face button handling if keymapped
@@ -1096,16 +1098,16 @@ static void process_controller(int retro_port, int i)
              || i == RETRO_DEVICE_ID_JOYPAD_X
              || i == RETRO_DEVICE_ID_JOYPAD_Y
             ))
-               jflag[retro_port][i]=0;
+               jflag[retro_port_uae][i]=0;
             else
-               retro_joystick(retro_port, 1, 0);
-            jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT]=0;
+               retro_joystick(retro_port_uae, 1, 0);
+            jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]=0;
          }
       }
       // Normal button
       else if (uae_button != -1)
       {
-         if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port][i]==0 && SHOWKEY==-1)
+         if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port_uae][i]==0 && SHOWKEY==-1)
          {
             // Skip RetroPad face button handling if keymapped
             if ((uae_devices[retro_port] == RETRO_DEVICE_JOYPAD
@@ -1118,12 +1120,12 @@ static void process_controller(int retro_port, int i)
             ))
                ;// no-op
             else
-               retro_joystick_button(retro_port, uae_button, 1);
-            jflag[retro_port][i]=1;
+               retro_joystick_button(retro_port_uae, uae_button, 1);
+            jflag[retro_port_uae][i]=1;
             aflag[retro_port][i]=1;
          }
          else
-         if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port][i]==1)
+         if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port_uae][i]==1)
          {
             // Skip RetroPad face button handling if keymapped
             if ((uae_devices[retro_port] == RETRO_DEVICE_JOYPAD
@@ -1136,8 +1138,8 @@ static void process_controller(int retro_port, int i)
             ))
                ;// no-op
             else
-               retro_joystick_button(retro_port, uae_button, 0);
-            jflag[retro_port][i]=0;
+               retro_joystick_button(retro_port_uae, uae_button, 0);
+            jflag[retro_port_uae][i]=0;
             aflag[retro_port][i]=0;
          }
       }
@@ -1146,7 +1148,9 @@ static void process_controller(int retro_port, int i)
 
 static void process_turbofire(int retro_port, int i)
 {
+   int retro_port_uae = opt_joyport_order[retro_port] - 49;
    int retro_fire_button = RETRO_DEVICE_ID_JOYPAD_B;
+
    // Face button rotate correction for statusbar flag
    if ((uae_devices[retro_port] == RETRO_DEVICE_JOYPAD && (opt_retropad_options == 1 || opt_retropad_options == 3))
     || (uae_devices[retro_port] == RETRO_DEVICE_UAE_CD32PAD && (opt_cd32pad_options == 1 || opt_cd32pad_options == 3)))
@@ -1165,28 +1169,28 @@ static void process_turbofire(int retro_port, int i)
 
             if (turbo_toggle[retro_port] > (turbo_pulse / 2))
             {
-               retro_joystick_button(retro_port, 0, 0);
-               jflag[retro_port][retro_fire_button]=0;
+               retro_joystick_button(retro_port_uae, 0, 0);
+               jflag[retro_port_uae][retro_fire_button]=0;
             }
             else
             {
-               retro_joystick_button(retro_port, 0, 1);
-               jflag[retro_port][retro_fire_button]=1;
+               retro_joystick_button(retro_port_uae, 0, 1);
+               jflag[retro_port_uae][retro_fire_button]=1;
             }
          }
          else
          {
             turbo_state[retro_port]=1;
-            retro_joystick_button(retro_port, 0, 1);
-            jflag[retro_port][retro_fire_button]=1;
+            retro_joystick_button(retro_port_uae, 0, 1);
+            jflag[retro_port_uae][retro_fire_button]=1;
          }
       }
       else if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button) && turbo_state[retro_port]==1)
       {
          turbo_state[retro_port]=0;
          turbo_toggle[retro_port]=1;
-         retro_joystick_button(retro_port, 0, 0);
-         jflag[retro_port][retro_fire_button]=0;
+         retro_joystick_button(retro_port_uae, 0, 0);
+         jflag[retro_port_uae][retro_fire_button]=0;
       }
    }
 }
@@ -2113,8 +2117,8 @@ void retro_poll_event()
          }
       }
 
-      // Joypad movement only with digital mouse mode and virtual keyboard hidden
-      if (MOUSEMODE==1 && SHOWKEY==-1)
+      // Joypad movement only with digital mouse mode or analog joystick, and virtual keyboard hidden
+      if ((MOUSEMODE==1 || uae_devices[0] == RETRO_DEVICE_UAE_ANALOG || uae_devices[1] == RETRO_DEVICE_UAE_ANALOG) && SHOWKEY==-1)
       {
          for (j = 0; j < 2; j++)
          {

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -77,6 +77,7 @@ unsigned int opt_analogmouse_deadzone = 15;
 float opt_analogmouse_speed = 1.0;
 unsigned int opt_cd32pad_options = 0;
 unsigned int opt_retropad_options = 0;
+char opt_joyport_order[5] = "1234";
 
 #if defined(NATMEM_OFFSET)
 extern uae_u8 *natmem_offset;
@@ -819,6 +820,19 @@ void retro_set_environment(retro_environment_t cb)
             { NULL, NULL },
          },
          "disabled"
+      },
+      {
+         "puae_joyport_order",
+         "Joyport Order",
+         "Plug RetroPads in different ports. Useful for Arcadia system and games that support 4-player adapter.",
+         {
+            { "1234", "1-2-3-4" },
+            { "2143", "2-1-4-3" },
+            { "3412", "3-4-1-2" },
+            { "4321", "4-3-2-1" },
+            { NULL, NULL },
+         },
+         "1234"
       },
       {
          "puae_analogmouse",
@@ -2054,6 +2068,13 @@ static void update_variables(void)
    {
       if (strcmp(var.value, "disabled") == 0) opt_audio_options_display=0;
       else if (strcmp(var.value, "enabled") == 0) opt_audio_options_display=1;
+   }
+
+   var.key = "puae_joyport_order";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      snprintf(opt_joyport_order, sizeof(opt_joyport_order), "%s", var.value);
    }
 
    var.key = "puae_retropad_options";

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -110,11 +110,12 @@ unsigned int request_init_custom_timer = 0;
 unsigned int request_check_prefs_timer = 0;
 unsigned int zoom_mode_id = 0;
 unsigned int opt_zoom_mode_id = 0;
-int zoomed_height;
+int zoomed_height = 0;
 
 int opt_vertical_offset = 0;
 bool opt_vertical_offset_auto = true;
 extern int minfirstline;
+static int retro_thisframe_counter = 0;
 extern int retro_thisframe_first_drawn_line;
 static int retro_thisframe_first_drawn_line_old = -1;
 extern int retro_thisframe_last_drawn_line;
@@ -3425,12 +3426,11 @@ static bool retro_update_av_info(void)
        && retro_thisframe_first_drawn_line > 0 && retro_thisframe_last_drawn_line > 0
        && (retro_thisframe_first_drawn_line < 150 || retro_thisframe_last_drawn_line > 150)
       )
-         thisframe_y_adjust_new = (retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line - zoomed_height_normal) / 2 + retro_thisframe_first_drawn_line; // Smart
-         //thisframe_y_adjust_new = retro_thisframe_first_drawn_line + ((retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line) - zoomed_height_normal) / 2; // Simple
+         thisframe_y_adjust_new = (retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line - zoomed_height_normal) / 2 + retro_thisframe_first_drawn_line;
 
       /* Sensible limits */
       thisframe_y_adjust_new = (thisframe_y_adjust_new < 0) ? 0 : thisframe_y_adjust_new;
-      thisframe_y_adjust_new = (thisframe_y_adjust_new > (minfirstline + 50)) ? (minfirstline + 50) : thisframe_y_adjust_new;
+      thisframe_y_adjust_new = (thisframe_y_adjust_new > (minfirstline + 60)) ? (minfirstline + 60) : thisframe_y_adjust_new;
       if (retro_thisframe_first_drawn_line == -1 && retro_thisframe_last_drawn_line == -1)
           thisframe_y_adjust_new = thisframe_y_adjust_old;
 
@@ -3463,10 +3463,7 @@ static bool retro_update_av_info(void)
        && retro_max_diwstop > max_diwstop_limit
        && (retro_max_diwstop - retro_min_diwstart) <= (retrow + 2*diw_multiplier)
       )
-      {
-         visible_left_border_new = (retro_max_diwstop - retro_min_diwstart - retrow) / 2 + retro_min_diwstart; // Smart
-         //visible_left_border_new = retro_max_diwstop - retrow - (retro_max_diwstop - retro_min_diwstart - retrow) / 2; // Simple
-      }
+         visible_left_border_new = (retro_max_diwstop - retro_min_diwstart - retrow) / 2 + retro_min_diwstart;
       else if (retro_min_diwstart == 30000 && retro_max_diwstop == 0)
          visible_left_border_new = visible_left_border;
 
@@ -4818,23 +4815,38 @@ void update_audiovideo(void)
    // Automatic vertical offset
    if (opt_vertical_offset_auto && zoom_mode_id != 0)
    {
-      if (((retro_thisframe_first_drawn_line != retro_thisframe_first_drawn_line_old)
-         ||(retro_thisframe_last_drawn_line  != retro_thisframe_last_drawn_line_old))
+      if (( retro_thisframe_first_drawn_line != retro_thisframe_first_drawn_line_old
+         || retro_thisframe_last_drawn_line  != retro_thisframe_last_drawn_line_old)
          && retro_thisframe_first_drawn_line != -1
          && retro_thisframe_last_drawn_line  != -1
+         && retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line > 20
+         && (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1 || abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
       )
       {
+         //printf("thisframe first:%d old:%d last:%d old:%d\n", retro_thisframe_first_drawn_line, retro_thisframe_first_drawn_line_old, retro_thisframe_last_drawn_line, retro_thisframe_last_drawn_line_old);
          // Prevent interlace stuttering by requiring a change of at least 2 lines
+         // and also prevent sudden resolution switching by requiring the change to stabilize (count +-1 as stable) for a few frames
          if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1)
          {
             retro_thisframe_first_drawn_line_old = retro_thisframe_first_drawn_line;
-            retro_request_av_info_update = true;
+            retro_thisframe_counter = 1;
          }
          if (abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
          {
             retro_thisframe_last_drawn_line_old = retro_thisframe_last_drawn_line;
-            retro_request_av_info_update = true;
+            retro_thisframe_counter = 1;
          }
+      }
+      else if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) < 2 && abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) < 2)
+      {
+         if (retro_thisframe_counter > 0)
+            retro_thisframe_counter++;
+
+         if (retro_thisframe_counter > 4)
+            retro_request_av_info_update = true;
+
+         if (retro_request_av_info_update)
+            retro_thisframe_counter = 0;
       }
    }
    else
@@ -4854,12 +4866,18 @@ void update_audiovideo(void)
    // Automatic horizontal offset
    if (opt_horizontal_offset_auto)
    {
-      if ((retro_min_diwstart != retro_min_diwstart_old) ||
-          (retro_max_diwstop != retro_max_diwstop_old))
+      if (( retro_min_diwstart != retro_min_diwstart_old
+         || retro_max_diwstop  != retro_max_diwstop_old)
+         && retro_min_diwstart != 30000
+         && retro_max_diwstop  != 0
+      )
       {
+         //printf("diwstart:%d old:%d diwstop:%d old:%d\n", retro_min_diwstart, retro_min_diwstart_old, retro_max_diwstop, retro_max_diwstop_old);
          retro_min_diwstart_old = retro_min_diwstart;
          retro_max_diwstop_old = retro_max_diwstop;
-         retro_request_av_info_update = true;
+         // Not triggered in the middle of vertical offset stabilize count
+         if (retro_thisframe_counter == 0)
+            retro_request_av_info_update = true;
       }
    }
    else


### PR DESCRIPTION
Controls:
- In analog joystick mode D-Pad did nothing, therefore it now always controls mouse to minimize manual joy/mouse switching
- Core option for reordering joystick ports
  - Aimed at Arcadia and 4-player adapter games

Automatic zoom:
- Less aggressive operation = the change of geometry now requires first and last drawn lines to stabilize for couple of frames
  - Downside is that there is a minor delay in the zoom, but upside is that there are less unwarranted and pointless geometry changes
  - Mainly affects games with full screen slide animations and other transition gimmicks that trigger the calculations, mostly for no proper reason
    - Clear performance improvements at least in: Sink or Swim, Tiny Skweeks, Pinball Fantasies CD32, Soccer Kid AGA
- Finetuned maximum `thisframe_y_adjust` to allow the bottom right part of Agony intro screen to stay in view

Of course the geometry changes do not really affect a beefy GPU running at max clocks, but it certainly does when running at idle clocks with tweaked frame delay.

And please do let me know if you can find some cases which are still bad or even worse!
