### PR TITLE
CD startup delayed insert, Autozoom improvement

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -119,8 +119,10 @@ extern int minfirstline;
 static int retro_thisframe_counter = 0;
 extern int retro_thisframe_first_drawn_line;
 static int retro_thisframe_first_drawn_line_old = -1;
+static int retro_thisframe_first_drawn_line_start = -1;
 extern int retro_thisframe_last_drawn_line;
 static int retro_thisframe_last_drawn_line_old = -1;
+static int retro_thisframe_last_drawn_line_start = -1;
 extern int thisframe_y_adjust;
 static int thisframe_y_adjust_old = 0;
 static int thisframe_y_adjust_update_frame_timer = 3;
@@ -1689,7 +1691,7 @@ static void update_variables(void)
          else if (strcmp(var.value, "enhanced") == 0) changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A1200;
          else if (strcmp(var.value, "auto") == 0)
          {
-            if (currprefs.cpu_model == 68020)
+            if (currprefs.cpu_model >= 68020)
                changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A1200;
             else
                changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A500;
@@ -4762,11 +4764,10 @@ void update_audiovideo(void)
    if (filter_type_update)
    {
       filter_type_update = false;
-      if (currprefs.cpu_model == 68020)
+      if (currprefs.cpu_model >= 68020)
          changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A1200;
       else
          changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A500;
-      config_changed = 0;
    }
 
    // Automatic video resolution
@@ -4873,17 +4874,25 @@ void update_audiovideo(void)
          // and also prevent sudden resolution switching by requiring the change to stabilize (count +-1 as stable) for a few frames
          if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1)
          {
+            if (retro_thisframe_counter == 0)
+               retro_thisframe_first_drawn_line_start = retro_thisframe_first_drawn_line_old;
             retro_thisframe_first_drawn_line_old = retro_thisframe_first_drawn_line;
             retro_thisframe_counter = 1;
          }
          if (abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
          {
+            if (retro_thisframe_counter == 0)
+               retro_thisframe_last_drawn_line_start = retro_thisframe_last_drawn_line_old;
             retro_thisframe_last_drawn_line_old = retro_thisframe_last_drawn_line;
             retro_thisframe_counter = 1;
          }
       }
       else if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) < 2 && abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) < 2)
       {
+         // Reset the counter if the values return to the starting point during counting
+         if (retro_thisframe_first_drawn_line == retro_thisframe_first_drawn_line_start && retro_thisframe_last_drawn_line == retro_thisframe_last_drawn_line_start)
+            retro_thisframe_counter = 0;
+
          if (retro_thisframe_counter > 0)
             retro_thisframe_counter++;
 

--- a/retrodep/sysconfig.h
+++ b/retrodep/sysconfig.h
@@ -44,6 +44,7 @@
 #define ACTION_REPLAY /* Action Replay 1/2/3 support */
 #define NCR /* A4000T/A4091, 53C710/53C770 SCSI */
 #define A2091 /* A590/A2091 SCSI */
+#define SCSIEMU /* uaescsi.device emulation */
 #define CDTV /* CDTV emulation */
 #define CD32 /* CD32 emulation */
 #define SERIAL_PORT /* serial port emulation */

--- a/sources/src/blkdev.c
+++ b/sources/src/blkdev.c
@@ -600,11 +600,7 @@ void check_prefs_changed_cd (void)
 	currprefs.sound_volume_cd = changed_prefs.sound_volume_cd;
 }
 
-#ifdef __LIBRETRO__
-void check_changes (int unitnum)
-#else
 static void check_changes (int unitnum)
-#endif
 {
 	struct blkdevstate *st = &state[unitnum];
 	bool changed = false;
@@ -661,13 +657,11 @@ static void check_changes (int unitnum)
 			gotsem = false;
 		}
 	}
-#ifndef __LIBRETRO__
 	if (st->imagechangetime == 0)
 		return;
 	st->imagechangetime--;
 	if (st->imagechangetime > 0)
 		return;
-#endif
 	if (blkdevsema)
 		gotsem = getsem2 (unitnum, true);
 	_tcscpy (currprefs.cdslots[unitnum].name, st->newimagefile);


### PR DESCRIPTION
- Added a core option for delayed CD insert on startup for those pesky games that won't run when powering on with disc inserted, even on the real thing (Xenon 2 CDTV, Total Carnage CD32)
  Closes #272 
- Yet another pointless work reducing autozoom improvement:
  - Skip geometry update if the used values return back to the original values during the stabilization period (Lethal Weapon screen fades)
- Fixed sound filter type not updating on startup, which seems to have been broken for a long time, from libco removal perhaps

Bonus:
- Found a way to remove my hacks to get CD eject/insert detection working by adding `#define SCSIEMU`, because only then was `blkdev_vsync()` run, which does the necessary `check_changes()` automatically
