### PR TITLE
Backport double line field interlace

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ With these settings all the standard resolutions are available:
 When using low resolution mode, rendering will be halved horizontally and forced into Single Line mode. Scaling shaders looks great but high resolution games and Workbench are badly rendered.
 
 When using high resolution Double Line mode, rendering will be doubled vertically. It is compatible with high resolution games and Workbench, but scaling shaders will look ugly.
-Double Line shows interlaced fields separately in one frame, which will halve the framerate, and thus movement will be jerky.
+Double Line shows interlaced fields separately and is suited for deinterlacing shaders.
 
 When using high resolution Single Line mode, rendering is presented as is. It delivers the best of both worlds, and looks great with high resolution games, Workbench and shaders.
-Single Line combines interlaced fields into one field, which will keep the full framerate, but high resolution images will be blocky.
+Single Line combines interlaced fields into one field, which will make high resolution images blocky.
 
 - Automatic Resolution defaults to Hires and selects SuperHires when needed (practically only in Workbench and Super Skidmarks).
 - Automatic Line Mode defaults to Single Line and selects Double Line on interlaced screens.
@@ -374,7 +374,7 @@ filesystem2=rw,DH0:data:/emuroms/amiga/,0
 ```
 
 Windows tip:
-- If paths are enclosed with quotes, Windows needs double blackslashes: `filesystem2=rw,DH0:data:"c:\\emuroms\\amiga",0`.
+- If paths are enclosed with quotes, Windows needs double backslashes: `filesystem2=rw,DH0:data:"c:\\emuroms\\amiga",0`.
 
 Linux tip:
 - Leave the ending slash to the path to make sure UAE sees it as a directory.

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -99,7 +99,7 @@ extern unsigned int turbo_pulse;
 unsigned int inputdevice_finalized = 0;
 int pix_bytes = 2;
 static bool pix_bytes_initialized = false;
-bool filter_type_update = true;
+bool automatic_sound_filter_type_update = true;
 bool fake_ntsc = false;
 bool real_ntsc = false;
 bool forced_video = false;
@@ -1680,6 +1680,7 @@ static void update_variables(void)
    {
       if (strcmp(var.value, "auto"))
       {
+         automatic_sound_filter_type_update = false;
          strcat(uae_config, "sound_filter_type=");
          strcat(uae_config, var.value);
          strcat(uae_config, "\n");
@@ -1689,13 +1690,7 @@ static void update_variables(void)
       {
          if (strcmp(var.value, "standard") == 0) changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A500;
          else if (strcmp(var.value, "enhanced") == 0) changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A1200;
-         else if (strcmp(var.value, "auto") == 0)
-         {
-            if (currprefs.cpu_model >= 68020)
-               changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A1200;
-            else
-               changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A500;
-         }
+         else if (strcmp(var.value, "auto") == 0) automatic_sound_filter_type_update = true;
       }
    }
 
@@ -4761,9 +4756,10 @@ void update_audiovideo(void)
       imagename_timer--;
 
    // Update audio settings
-   if (filter_type_update)
+   if (automatic_sound_filter_type_update)
    {
-      filter_type_update = false;
+      automatic_sound_filter_type_update = false;
+      config_changed = 1;
       if (currprefs.cpu_model >= 68020)
          changed_prefs.sound_filter_type=FILTER_SOUND_TYPE_A1200;
       else

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -4767,7 +4767,7 @@ void update_audiovideo(void)
    }
 
    // Automatic video resolution
-   if (opt_video_resolution_auto && request_init_custom_timer == 0)
+   if (opt_video_resolution_auto)
    {
       int current_resolution = GET_RES_DENISE (bplcon0);
       //printf("BPLCON0: %d, %d, %d %d\n", bplcon0, current_resolution, diwfirstword_total, diwlastword_total);
@@ -4818,7 +4818,7 @@ void update_audiovideo(void)
    }
 
    // Automatic video vresolution (Line Mode)
-   if (opt_video_vresolution_auto && request_init_custom_timer == 0)
+   if (opt_video_vresolution_auto)
    {
       int current_interlace = interlace_seen;
 
@@ -4855,7 +4855,7 @@ void update_audiovideo(void)
    }
 
    // Automatic vertical offset
-   if (opt_vertical_offset_auto && zoom_mode_id != 0)
+   if (opt_vertical_offset_auto && zoom_mode_id != 0 && !retro_request_av_info_update)
    {
       if (( retro_thisframe_first_drawn_line != retro_thisframe_first_drawn_line_old
          || retro_thisframe_last_drawn_line  != retro_thisframe_last_drawn_line_old)
@@ -4914,7 +4914,7 @@ void update_audiovideo(void)
    }
 
    // Automatic horizontal offset
-   if (opt_horizontal_offset_auto)
+   if (opt_horizontal_offset_auto && !retro_request_av_info_update)
    {
       if (( retro_min_diwstart != retro_min_diwstart_old
          || retro_max_diwstop  != retro_max_diwstop_old)

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -331,6 +331,9 @@ int check_prefs_changed_gfx (void)
     if (currprefs.gfx_vresolution      != changed_prefs.gfx_vresolution)
         currprefs.gfx_vresolution       = changed_prefs.gfx_vresolution;
 
+    if (currprefs.gfx_scandoubler      != changed_prefs.gfx_scandoubler)
+        currprefs.gfx_scandoubler       = changed_prefs.gfx_scandoubler;
+
     gfxvidinfo.width_allocated          = currprefs.gfx_size_win.width;
     gfxvidinfo.height_allocated         = currprefs.gfx_size_win.height;
     gfxvidinfo.rowbytes                 = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes;

--- a/sources/src/custom.c
+++ b/sources/src/custom.c
@@ -6668,6 +6668,21 @@ static void hsync_handler_post (bool onvsync)
 		nextline_how = nln_normal;
 		if (doflickerfix () && interlace_seen > 0) {
 			lineno *= 2;
+#ifdef __LIBRETRO__
+		} else if (currprefs.gfx_vresolution && (doublescan <= 0 || interlace_seen > 0)) {
+			lineno *= 2;
+			if (interlace_seen) {
+				if (!lof_current) {
+					lineno++;
+					nextline_how = nln_lower_black;
+				} else {
+					nextline_how = nln_upper_black;
+				}
+			} else {
+				nextline_how = nln_doubled;
+			}
+        }
+#else
 		} else if (currprefs.gfx_vresolution && (doublescan <= 0 || interlace_seen > 0)) {
 			lineno *= 2;
 			if (interlace_seen) {
@@ -6681,6 +6696,7 @@ static void hsync_handler_post (bool onvsync)
 				nextline_how = currprefs.gfx_vresolution > VRES_NONDOUBLE && currprefs.gfx_scanlines == false ? nln_doubled : nln_nblack;
 			}
 		}
+#endif
 		prev_lineno = next_lineno;
 		next_lineno = lineno;
 		reset_decisions ();

--- a/sources/src/include/drawing.h
+++ b/sources/src/include/drawing.h
@@ -267,7 +267,11 @@ enum nln_how {
 	/* Interlace, doubled display, lower line.  */
 	nln_lower,
 	/* This line normal, next one black.  */
-	nln_nblack
+	nln_nblack,
+	nln_upper_black,
+	nln_lower_black,
+	nln_upper_black_always,
+	nln_lower_black_always
 };
 
 extern void hsync_record_line_state (int lineno, enum nln_how, int changed);


### PR DESCRIPTION
New stuff:
- Replaced current framerate halving double line frame with full framerate double line field
- Added core option "Remove Interlace Artifacts" which behaves best on static screens
  - Confusingly the option is named `gfx_flickerfixer` in confs and `gfx_scandoubler` internally, but according to the changelog it is neither:
> - "Flicker fixer" renamed to "Remove interlace artifacts" (it really
  isn't same as flickerfixer or scandoubler)

Fixes:
- Sound filter type option was accidentally forced at "Automatic"
- More autozoom+centering solutions
  - Allow UAE internal centerings but prevent RA geometry sets in certain situations
- Random crash when changing resolution and interlacing at the same time in WB

Bonus:
- Core option unifications and reorganizings