### PR TITLE
Attempt to fix crash when reloading core on static builds

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -3090,6 +3090,9 @@ void retro_deinit(void)
    // Clean ZIP temp
    if (retro_temp_directory && path_is_directory(retro_temp_directory))
       remove_recurse(retro_temp_directory);
+
+   // 'Reset' troublesome static variable
+   pix_bytes_initialized = false;
 }
 
 unsigned retro_api_version(void)

--- a/sources/src/zfile.c
+++ b/sources/src/zfile.c
@@ -37,6 +37,8 @@ static struct zfile *zlist = 0;
 
 const TCHAR *uae_archive_extensions[] = { _T("zip"), _T("rar"), _T("7z"), _T("lha"), _T("lzh"), _T("lzx"), _T("tar"), NULL };
 
+static struct zvolume *zvolume_list = NULL;
+
 #define MAX_CACHE_ENTRIES 10
 
 struct zdisktrack
@@ -211,6 +213,7 @@ void zfile_exit (void)
 		zlist = l->next;
 		zfile_free (l);
 	}
+	zvolume_list = NULL;
 }
 
 void zfile_fclose (struct zfile *f)
@@ -2320,8 +2323,6 @@ uae_u32 zfile_crc32 (struct zfile *f)
 	xfree (p);
 	return crc;
 }
-
-static struct zvolume *zvolume_list;
 
 static void recurparent (TCHAR *newpath, struct znode *zn, int recurse)
 {


### PR DESCRIPTION
At present, the core will crash the second time content is loaded when using a static build (Switch, etc.). I don't have any supported hardware to test this on, but by building under Linux using the `--enable-preserve_dylib` configure option I was able reproduce a segfault and graphical corruption caused by static variables carrying over incorrect values from the previous run.

This trivial PR 'resets' these static variables appropriately. I hope this will fix issue #215 - if anyone could test a static build, I would be grateful!