### PR TITLE
Model preset overrides, Optional region search

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ The whole path (filename and directory) will be searched for the following tags 
 | |**x**|**CDTV**|Amiga CDTV, 1MB Chip RAM|
 | |**x**|**(CD32)** or **(CD32NF)**|Amiga CD32, 2MB Chip RAM|
 | |**x**|**(CD32FR)** or **FastRAM**|Amiga CD32, 2MB Chip RAM + 8MB Fast RAM|
-|**x**|**x**|**NTSC**|NTSC 60Hz|
-|**x**|**x**|**PAL**|PAL 50Hz|
+|**x**|**x**|**NTSC** or **(USA)**|NTSC 60Hz|
+|**x**|**x**|**PAL** or **(Europe)** or **(Denmark|Finland|France|Germany|Italy|Spain|Sweden)**|PAL 50Hz|
 
 Example: When launching "Alien Breed 2 AGA.hdf" or "AGA/Alien Breed 2.hdf" the model will be Amiga 1200.
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -72,6 +72,8 @@ float opt_analogmouse_speed = 1.0;
 unsigned int opt_cd32pad_options = 0;
 unsigned int opt_retropad_options = 0;
 char opt_joyport_order[5] = "1234";
+bool mousemode_locked = false;
+extern int MOUSEMODE;
 
 #if defined(NATMEM_OFFSET)
 extern uae_u8 *natmem_offset;
@@ -859,8 +861,19 @@ void retro_set_environment(retro_environment_t cb)
          "disabled"
       },
       {
+         "puae_joyport",
+         "RetroPad Joystick/Mouse",
+         "Changes D-Pad control between joyports. Hotkey toggling will disable this option until core restart.",
+         {
+            { "joystick", "Joystick (Port 1)" },
+            { "mouse", "Mouse (Port 2)" },
+            { NULL, NULL },
+         },
+         "Joystick"
+      },
+      {
          "puae_joyport_order",
-         "Joyport Order",
+         "RetroPad Joyport Order",
          "Plug RetroPads in different ports. Useful for Arcadia system and games that support 4-player adapter.",
          {
             { "1234", "1-2-3-4" },
@@ -2147,6 +2160,14 @@ static void update_variables(void)
    {
       if (strcmp(var.value, "disabled") == 0) opt_audio_options_display=0;
       else if (strcmp(var.value, "enabled") == 0) opt_audio_options_display=1;
+   }
+
+   var.key = "puae_joyport";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "joystick") == 0 && !mousemode_locked) MOUSEMODE=-1;
+      else if (strcmp(var.value, "mouse") == 0 && !mousemode_locked) MOUSEMODE=1;
    }
 
    var.key = "puae_joyport_order";

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -87,105 +87,23 @@ extern int vkbd_y_max;
 #define RGB888(r, g, b) (((r * 255 / 31) << (16)) | ((g * 255 / 31) << 8) | (b * 255 / 31))
 #define ARGB888(a, r, g, b) ((a << 24) | (r << 16) | (g << 8) | b)
 
-// Amiga models
-// chipmem_size 1 = 0.5MB, 2 = 1MB, 4 = 2MB
-// bogomem_size 2 = 0.5MB, 4 = 1MB, 6 = 1.5MB, 7 = 1.8MB
+// Configs
+enum EMU_CONFIG {
+   EMU_CONFIG_A500 = 0,
+   EMU_CONFIG_A500OG,
+   EMU_CONFIG_A500PLUS,
+   EMU_CONFIG_A600,
+   EMU_CONFIG_A1200,
+   EMU_CONFIG_A1200OG,
+   EMU_CONFIG_A4030,
+   EMU_CONFIG_A4040,
+   EMU_CONFIG_CDTV,
+   EMU_CONFIG_CD32,
+   EMU_CONFIG_CD32FR,
+   EMU_CONFIG_COUNT
+};
 
-#define A500_CONFIG "\
-cpu_model=68000\n\
-chipset=ocs\n\
-chipset_compatible=A500\n\
-chipmem_size=1\n\
-bogomem_size=2\n\
-"
-
-#define A500OG_CONFIG "\
-cpu_model=68000\n\
-chipset=ocs\n\
-chipset_compatible=A500\n\
-chipmem_size=1\n\
-bogomem_size=0\n\
-"
-
-#define A500PLUS_CONFIG "\
-cpu_model=68000\n\
-chipset=ecs\n\
-chipset_compatible=A500+\n\
-chipmem_size=2\n\
-bogomem_size=0\n\
-"
-
-#define A600_CONFIG "\
-cpu_model=68000\n\
-chipset=ecs\n\
-chipset_compatible=A600\n\
-chipmem_size=4\n\
-fastmem_size=8\n\
-"
-
-#define A1200_CONFIG "\
-cpu_model=68020\n\
-chipset=aga\n\
-chipset_compatible=A1200\n\
-chipmem_size=4\n\
-fastmem_size=8\n\
-"
-
-#define A1200OG_CONFIG "\
-cpu_model=68020\n\
-chipset=aga\n\
-chipset_compatible=A1200\n\
-chipmem_size=4\n\
-fastmem_size=0\n\
-"
-
-#define A4030_CONFIG "\
-cpu_model=68030\n\
-fpu_model=68882\n\
-chipset=aga\n\
-chipset_compatible=A4000\n\
-chipmem_size=4\n\
-fastmem_size=8\n\
-"
-
-#define A4040_CONFIG "\
-cpu_model=68040\n\
-fpu_model=68040\n\
-chipset=aga\n\
-chipset_compatible=A4000\n\
-chipmem_size=4\n\
-fastmem_size=8\n\
-"
-
-#define CDTV_CONFIG "\
-cpu_model=68000\n\
-chipset=ecs_agnus\n\
-chipset_compatible=CDTV\n\
-chipmem_size=2\n\
-bogomem_size=0\n\
-floppy0type=-1\n\
-"
-
-#define CD32_CONFIG "\
-cpu_model=68020\n\
-chipset=aga\n\
-chipset_compatible=CD32\n\
-chipmem_size=4\n\
-fastmem_size=0\n\
-floppy0type=-1\n\
-"
-
-#define CD32FR_CONFIG "\
-cpu_model=68020\n\
-chipset=aga\n\
-chipset_compatible=CD32\n\
-chipmem_size=4\n\
-fastmem_size=8\n\
-floppy0type=-1\n\
-"
-
-
-// Amiga kickstarts
+// Kickstarts
 #define A500_ROM                "kick34005.A500"
 #define A500KS2_ROM             "kick37175.A500"
 #define A600_ROM                "kick40063.A600"
@@ -195,7 +113,7 @@ floppy0type=-1\n\
 #define CD32_ROM                "kick40060.CD32"
 #define CD32_ROM_EXT            "kick40060.CD32.ext"
 
-// Amiga files
+// Supported files
 #define ADF_FILE_EXT            "adf"
 #define ADZ_FILE_EXT            "adz"
 #define FDI_FILE_EXT            "fdi"
@@ -213,7 +131,7 @@ floppy0type=-1\n\
 #define M3U_FILE_EXT            "m3u"
 #define LIBRETRO_PUAE_PREFIX    "puae_libretro"
 
-// Amiga video
+// Video
 #define PUAE_VIDEO_PAL          0x01
 #define PUAE_VIDEO_NTSC         0x02
 #define PUAE_VIDEO_HIRES        0x04

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -52,8 +52,7 @@ int MOUSEMODE=-1,SHOWKEY=-1,SHOWKEYPOS=-1,SHOWKEYTRANS=1;
 
 unsigned int mouse_speed[2]={0};
 extern int pix_bytes;
-extern bool fake_ntsc;
-extern bool real_ntsc;
+extern void retro_reset_soft();
 
 #ifdef POINTER_DEBUG
 int pointer_x = 0;
@@ -159,12 +158,9 @@ void emu_function(int function)
          memset(jflag, 0, 2*16*sizeof jflag[0][0]);
          break;
       case EMU_RESET:
-         uae_reset(0, 1); /* hardreset, keyboardreset */
-         fake_ntsc = false;
+         retro_reset_soft();
          break;
       case EMU_ASPECT_RATIO_TOGGLE:
-         if (real_ntsc)
-            break;
          if (video_config_aspect == 0)
             video_config_aspect = (video_config & PUAE_VIDEO_NTSC) ? PUAE_VIDEO_PAL : PUAE_VIDEO_NTSC;
          else if (video_config_aspect == PUAE_VIDEO_PAL)

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -94,6 +94,7 @@ extern bool retro_request_av_info_update;
 extern bool request_reset_drawing;
 extern int opt_statusbar;
 extern int opt_statusbar_position;
+extern bool mousemode_locked;
 extern unsigned int opt_analogmouse;
 extern unsigned int opt_analogmouse_deadzone;
 extern float opt_analogmouse_speed;
@@ -153,6 +154,7 @@ void emu_function(int function)
          request_reset_drawing = true;
          break;
       case EMU_MOUSE_TOGGLE:
+         mousemode_locked = true;
          MOUSEMODE = -MOUSEMODE;
          // Reset flags to prevent sticky keys
          memset(jflag, 0, 2*16*sizeof jflag[0][0]);


### PR DESCRIPTION
Major:
- Model presets can be customized with config files
  Closes #285 
- Region forcing via filename tags is optional, default is enabled

Minor:
- No-Intro tags added to region forcing
- Corrections to real NTSC behavior (aspect ratio toggle, statusbar position)

Bonus:
- Core option for defaulting/setting D-Pad control mode (Joystick/Mouse)