### PR TITLE
Autozoom improvements, Content path unicode

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5181,37 +5181,54 @@ void update_audiovideo(void)
          || retro_thisframe_last_drawn_line  != retro_thisframe_last_drawn_line_old)
          && retro_thisframe_first_drawn_line != -1
          && retro_thisframe_last_drawn_line  != -1
-         && retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line > 1
-         && (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1 || abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
+         && retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line > 40
+         && (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) >= 1
+          || abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) >= 1)
       )
       {
          //printf("thisframe first:%3d old:%3d start:%3d last:%3d old:%3d start:%3d\n", retro_thisframe_first_drawn_line, retro_thisframe_first_drawn_line_old, retro_thisframe_first_drawn_line_start, retro_thisframe_last_drawn_line, retro_thisframe_last_drawn_line_old, retro_thisframe_last_drawn_line_start);
          // Prevent interlace stuttering by requiring a change of at least 2 lines
          // and also prevent sudden resolution switching by requiring the change to stabilize (count +-1 as stable) for a few frames
-         if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1)
+         if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1
+          || abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
          {
             if (retro_thisframe_counter == 0)
-               retro_thisframe_first_drawn_line_start = retro_thisframe_first_drawn_line_old;
-            if (retro_thisframe_first_drawn_line_start == -1)
-               retro_thisframe_first_drawn_line_start = retro_thisframe_first_drawn_line;
-            retro_thisframe_first_drawn_line_old = retro_thisframe_first_drawn_line;
+            {
+               if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) > 1)
+                  retro_thisframe_first_drawn_line_start = retro_thisframe_first_drawn_line_old;
+               if (retro_thisframe_first_drawn_line_start == -1)
+                  retro_thisframe_first_drawn_line_start = retro_thisframe_first_drawn_line;
+
+               if (abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
+                  retro_thisframe_last_drawn_line_start = retro_thisframe_last_drawn_line_old;
+               if (retro_thisframe_last_drawn_line_start == -1)
+                  retro_thisframe_last_drawn_line_start = retro_thisframe_last_drawn_line;
+            }
             retro_thisframe_counter = 1;
          }
-         if (abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) > 1)
-         {
-            if (retro_thisframe_counter == 0)
-               retro_thisframe_last_drawn_line_start = retro_thisframe_last_drawn_line_old;
-            if (retro_thisframe_last_drawn_line_start == -1)
-               retro_thisframe_last_drawn_line_start = retro_thisframe_last_drawn_line;
-            retro_thisframe_last_drawn_line_old = retro_thisframe_last_drawn_line;
+         else if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) == 1
+               || abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) == 1)
             retro_thisframe_counter = 1;
-         }
+
+         retro_thisframe_first_drawn_line_old = retro_thisframe_first_drawn_line;
+         retro_thisframe_last_drawn_line_old = retro_thisframe_last_drawn_line;
       }
-      //else if (abs(retro_thisframe_first_drawn_line_old - retro_thisframe_first_drawn_line) < 2 && abs(retro_thisframe_last_drawn_line_old - retro_thisframe_last_drawn_line) < 2)
-      else if (retro_thisframe_counter > 0 && retro_thisframe_first_drawn_line != -1 && retro_thisframe_last_drawn_line != -1)
+      else if (retro_thisframe_counter > 0
+            && retro_thisframe_first_drawn_line != -1
+            && retro_thisframe_last_drawn_line  != -1
+            && retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line > 40
+      )
       {
+         //printf("thiscnt %d first:%3d old:%3d start:%3d last:%3d old:%3d start:%3d\n", retro_thisframe_counter, retro_thisframe_first_drawn_line, retro_thisframe_first_drawn_line_old, retro_thisframe_first_drawn_line_start, retro_thisframe_last_drawn_line, retro_thisframe_last_drawn_line_old, retro_thisframe_last_drawn_line_start);
+         // Reset counter if the first drawn line changes while the last line stays the same
+         if (retro_thisframe_first_drawn_line != retro_thisframe_first_drawn_line_start
+          && retro_thisframe_last_drawn_line  == retro_thisframe_last_drawn_line_start
+          && abs(retro_thisframe_first_drawn_line_start - retro_thisframe_first_drawn_line) < 40)
+            retro_thisframe_counter = 0;
+
          // Prevent geometry change but allow vertical centering if the values return to the starting point during counting
-         if (retro_thisframe_first_drawn_line == retro_thisframe_first_drawn_line_start && retro_thisframe_last_drawn_line == retro_thisframe_last_drawn_line_start)
+         if (retro_thisframe_first_drawn_line == retro_thisframe_first_drawn_line_start
+          && retro_thisframe_last_drawn_line  == retro_thisframe_last_drawn_line_start)
             retro_av_info_change_geometry = false;
 
          if (retro_thisframe_counter > 0)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3007,10 +3007,6 @@ void retro_init(void)
             sizeof(retro_save_directory));
    }
 
-   //printf("Retro SYSTEM_DIRECTORY %s\n",retro_system_directory);
-   //printf("Retro SAVE_DIRECTORY %s\n",retro_save_directory);
-   //printf("Retro CONTENT_DIRECTORY %s\n",retro_content_directory);
-
    // Disk control interface
    retro_dc = dc_create();
 
@@ -3112,6 +3108,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       int uae_port;
       uae_port = (port==0) ? 1 : 0;
       cd32_pad_enabled[uae_port] = 0;
+#if 0
       switch (device)
       {
          case RETRO_DEVICE_JOYPAD:
@@ -3120,7 +3117,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 
          case RETRO_DEVICE_UAE_CD32PAD:
             fprintf(stdout, "[libretro-uae]: Controller %u: CD32 Pad\n", (port+1));
-            cd32_pad_enabled[uae_port]=1;
+            cd32_pad_enabled[uae_port] = 1;
             break;
 
          case RETRO_DEVICE_UAE_ANALOG:
@@ -3136,9 +3133,13 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
             break;
 
          case RETRO_DEVICE_NONE:
-            fprintf(stdout, "[libretro-uae]: Controller %u: Unplugged\n", (port+1));
+            fprintf(stdout, "[libretro-uae]: Controller %u: None\n", (port+1));
             break;
       }
+#else
+      if (device == RETRO_DEVICE_UAE_CD32PAD)
+         cd32_pad_enabled[uae_port] = 1;
+#endif
 
       /* After startup input_get_default_joystick will need to be refreshed for cd32<>joystick change to work.
          Doing updateconfig straight from boot will crash, hence inputdevice_finalized */

--- a/sources/src/custom.c
+++ b/sources/src/custom.c
@@ -8184,7 +8184,9 @@ uae_u8 *save_cycles (int *len, uae_u8 *dstptr)
 	save_u32 (CYCLE_UNIT);
 	save_u64 (get_cycles ());
 	save_u32 (extra_cycle);
+#ifndef __LIBRETRO__
 	write_log (_T("SAVECYCLES %08lX\n"), get_cycles ());
+#endif
 	*len = dst - dstbak;
 	return dstbak;
 }
@@ -8196,7 +8198,9 @@ uae_u8 *restore_cycles (uae_u8 *src)
 	restore_u32 ();
 	start_cycles = restore_u64 ();
 	extra_cycle = restore_u32 ();
+#ifndef __LIBRETRO__
 	write_log (_T("RESTORECYCLES %08lX\n"), start_cycles);
+#endif
 	return src;
 }
 

--- a/sources/src/savestate.c
+++ b/sources/src/savestate.c
@@ -499,8 +499,10 @@ static void restore_header (uae_u8 *src)
 	emuname = restore_string ();
 	emuversion = restore_string ();
 	description = restore_string ();
+#if OPEN_LOG > 0
 	write_log (_T("Saved with: '%s %s', description: '%s'\n"),
 		emuname, emuversion, description);
+#endif
 	xfree (description);
 	xfree (emuversion);
 	xfree (emuname);
@@ -538,16 +540,20 @@ void restore_state (const TCHAR *filename)
 	chunk = restore_chunk (f, name, &len, &totallen, &filepos);
 #ifdef __LIBRETRO__
 	if (!chunk || _tcsncmp (name, _T("ASF "), 4)) {
-		write_log (_T("libretro serialization data is not an AmigaStateFile\n"));
+		write_log (_T("STATERESTORE libretro serialization data is not an AmigaStateFile\n"));
 		goto error;
 	}
-	write_log (_T("STATERESTORE: libretro serialization data\n"));
+#if OPEN_LOG > 0
+	write_log (_T("STATERESTORE libretro serialization data:\n"));
+#endif
 #else
 	if (!chunk || _tcsncmp (name, _T("ASF "), 4)) {
 		write_log (_T("%s is not an AmigaStateFile\n"), filename);
 		goto error;
 	}
+#if OPEN_LOG > 0
 	write_log (_T("STATERESTORE: '%s'\n"), filename);
+#endif
 #endif
 	config_changed = 1;
 	savestate_file = f;
@@ -1178,13 +1184,17 @@ int save_state (const TCHAR *filename, const TCHAR *description)
 	int v = save_state_internal (f, description, comp, true);
 #ifdef __LIBRETRO__
 	if (v)
-		write_log (_T("libretro serialization complete\n"));
+#if OPEN_LOG > 0
+		write_log (_T("STATESAVE libretro serialization complete\n"));
+#endif
 	savestate_state = 0;
 	zfile_fseek (f, 0, SEEK_SET);
 	return f;
 #else
 	if (v)
+#if OPEN_LOG > 0
 		write_log (_T("Save of '%s' complete\n"), filename);
+#endif
 	zfile_fclose (f);
 	savestate_state = 0;
 	return v;
@@ -1767,10 +1777,12 @@ retry2:
 			staterecords_first -= staterecords_max;
 	}
 
+#if OPEN_LOG > 0
 	write_log (_T("state capture %d (%010d/%03d,%d/%d) (%d bytes, alloc %d)\n"),
 		replaycounter, hsync_counter, vsync_counter,
 		hsync_counter % current_maxvpos (), current_maxvpos (),
 		st->end - st->data, statefile_alloc);
+#endif
 
 	if (firstcapture) {
 		savestate_memorysave ();


### PR DESCRIPTION
Regular:
- Autozoom improvements
  - The earthquake effect in "Lollypop" no longer resizes the geometry
  - Please let me know at once if something else is or got broken!
- Content path can include non-ascii characters like `å` `ä` `ö`

Bonus:
- "Wait for Blitter" restored as the default
- Logging noise reduced
