### PR TITLE
Fallback for capsimg path

### DIFF
--- a/sources/src/caps/caps.c
+++ b/sources/src/caps/caps.c
@@ -79,6 +79,8 @@ static int load_capslib (void)
 #ifdef __LIBRETRO__
     snprintf(CAPSLIB_PATH, RETRO_PATH_MAX, "%s%c%s", retro_system_directory, DIR_SEP_CHR, CAPSLIB_NAME);
     if (!file_exists(CAPSLIB_PATH))
+        snprintf(CAPSLIB_PATH, RETRO_PATH_MAX, "%s", CAPSLIB_NAME);
+    if (!file_exists(CAPSLIB_PATH))
     {
         snprintf(retro_message_msg, sizeof(retro_message_msg), "CAPS library '%s' not found!", CAPSLIB_NAME);
         retro_message = true;


### PR DESCRIPTION
Allow placing capsimg library also in the executable path. Aimed at Android+dlopen permission issue:

> 06-11 15:40:47.611 13410 13429 E linker  : library "/storage/emulated/0/RetroArch/system/capsimg.so"
("/storage/emulated/0/RetroArch/system/capsimg.so") needed or dlopened by
"/data/data/com.retroarch.ra32/cores/puae_libretro_android.so" is not accessible for the namespace: [
name="classloader-namespace", 
ld_library_paths="",
default_library_paths="/data/app/com.retroarch.ra32-1/lib/arm:/data/app/com.retroarch.ra32-1/base.apk!/lib/armeabi-v7a",
permitted_paths="/data:/mnt/expand:/data/data/com.retroarch.ra32"
]
