### PR TITLE
Directory filesystem fix, Control maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ And of course for the RetroArch/Libretro team: "http://www.libretro.com/"
 |---|---|
 |B|Fire button 1 / Red|
 |A|Fire button 2 / Blue|
+|X|Space|
 |L2|Left mouse button|
 |R2|Right mouse button|
 |Select|Toggle virtual keyboard|

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3158,7 +3158,7 @@ void retro_get_system_info(struct retro_system_info *info)
    info->library_version  = "2.6.1" GIT_VERSION;
    info->need_fullpath    = true;
    info->block_extract    = true;
-   info->valid_extensions = "adf|adz|dms|fdi|ipf|hdf|hdz|lha|cue|ccd|nrg|mds|iso|uae|m3u|zip";
+   info->valid_extensions = "adf|adz|dms|fdi|ipf|hdf|hdz|lha|slave|cue|ccd|nrg|mds|iso|uae|m3u|zip";
 }
 
 double retro_get_aspect_ratio(unsigned int width, unsigned int height, bool pixel_aspect)
@@ -4070,6 +4070,7 @@ bool retro_create_config()
        || strendswith(full_path, HDZ_FILE_EXT)
        || strendswith(full_path, LHA_FILE_EXT)
        || strendswith(full_path, M3U_FILE_EXT)
+       || strendswith(full_path, "slave")
        || path_is_directory(full_path))
       {
 	     // Open tmp config file
@@ -4153,6 +4154,7 @@ bool retro_create_config()
                      if (  strendswith(full_path, HDF_FILE_EXT)
                         || strendswith(full_path, HDZ_FILE_EXT)
                         || strendswith(full_path, LHA_FILE_EXT)
+                        || strendswith(full_path, "slave")
                         || path_is_directory(full_path))
                      {
                         uae_machine[0] = '\0';
@@ -4254,6 +4256,7 @@ bool retro_create_config()
             if (strendswith(full_path, HDF_FILE_EXT)
              || strendswith(full_path, HDZ_FILE_EXT)
              || strendswith(full_path, LHA_FILE_EXT)
+             || strendswith(full_path, "slave")
              || path_is_directory(full_path))
             {
                char *tmp_str = NULL;
@@ -4357,10 +4360,12 @@ bool retro_create_config()
 
                   // Attach game image
                   tmp_str = string_replace_substring(full_path, "\\", "\\\\");
+                  if (strendswith(full_path, "slave"))
+                     path_parent_dir(tmp_str);
 
                   if (strendswith(full_path, LHA_FILE_EXT))
                      fprintf(configfile, "filesystem2=ro,DH0:LHA:\"%s\",0\n", (const char*)tmp_str);
-                  else if (path_is_directory(full_path))
+                  else if (path_is_directory(full_path) || strendswith(full_path, "slave"))
                      fprintf(configfile, "filesystem2=rw,DH0:%s:\"%s\",0\n", path_basename(tmp_str), (const char*)tmp_str);
                   else
                      fprintf(configfile, "hardfile2=rw,DH0:\"%s\",32,1,2,512,0,,uae1\n", (const char*)tmp_str);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1094,7 +1094,7 @@ void retro_set_environment(retro_environment_t cb)
          "RetroPad X",
          "VKBD: Toggle position. Remapping to non-keyboard keys overrides VKBD function!",
          {{ NULL, NULL }},
-         "---"
+         "RETROK_SPACE"
       },
       {
          "puae_mapper_l",

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1008,7 +1008,7 @@ void retro_set_environment(retro_environment_t cb)
             { "enabled", NULL },
             { NULL, NULL },
          },
-         "disabled"
+         "enabled"
       },
       /* Hotkeys */
       {

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1202,6 +1202,7 @@ void retro_set_environment(retro_environment_t cb)
          "Replaces the mapped button with a turbo fire button.",
          {
             { "disabled", NULL },
+            { "B", "RetroPad B" },
             { "A", "RetroPad A" },
             { "Y", "RetroPad Y" },
             { "X", "RetroPad X" },
@@ -2203,6 +2204,7 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0) turbo_fire_button=-1;
+      else if (strcmp(var.value, "B") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_B;
       else if (strcmp(var.value, "A") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_A;
       else if (strcmp(var.value, "Y") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_Y;
       else if (strcmp(var.value, "X") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_X;
@@ -2210,8 +2212,6 @@ static void update_variables(void)
       else if (strcmp(var.value, "R") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_R;
       else if (strcmp(var.value, "L2") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_L2;
       else if (strcmp(var.value, "R2") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_R2;
-      else if (strcmp(var.value, "L3") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_L3;
-      else if (strcmp(var.value, "R3") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_R3;
    }
 
    var.key = "puae_turbo_pulse";

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -1069,7 +1069,7 @@ static void process_controller(int retro_port, int i)
    {
       uae_button = retro_button_to_uae_button(retro_port, i);
 
-      // Alternate jump button, hijack SELECT flag
+      // Alternative jump button, hijack SELECT flag
       if (uae_button == -2)
       {
          if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i) && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT]==0 && SHOWKEY==-1)
@@ -1173,19 +1173,19 @@ static void process_turbofire(int retro_port, int i)
             if (turbo_toggle[retro_port] > (turbo_pulse / 2))
             {
                retro_joystick_button(retro_port_uae, 0, 0);
-               jflag[retro_port_uae][retro_fire_button]=0;
+               jflag[retro_port_uae][retro_fire_button]=mapper_flag[retro_port_uae][retro_fire_button]=0;
             }
             else
             {
                retro_joystick_button(retro_port_uae, 0, 1);
-               jflag[retro_port_uae][retro_fire_button]=1;
+               jflag[retro_port_uae][retro_fire_button]=mapper_flag[retro_port_uae][retro_fire_button]=1;
             }
          }
          else
          {
             turbo_state[retro_port]=1;
             retro_joystick_button(retro_port_uae, 0, 1);
-            jflag[retro_port_uae][retro_fire_button]=1;
+            jflag[retro_port_uae][retro_fire_button]=mapper_flag[retro_port_uae][retro_fire_button]=1;
          }
       }
       else if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button) && turbo_state[retro_port]==1)
@@ -1193,7 +1193,7 @@ static void process_turbofire(int retro_port, int i)
          turbo_state[retro_port]=0;
          turbo_toggle[retro_port]=1;
          retro_joystick_button(retro_port_uae, 0, 0);
-         jflag[retro_port_uae][retro_fire_button]=0;
+         jflag[retro_port_uae][retro_fire_button]=mapper_flag[retro_port_uae][retro_fire_button]=0;
       }
    }
 }

--- a/sources/src/fsdb.c
+++ b/sources/src/fsdb.c
@@ -183,14 +183,15 @@ static a_inode *aino_from_buf (a_inode *base, uae_u8 *buf, long off)
 	return aino;
 }
 
+a_inode *custom_fsdb_lookup_aino_aname(a_inode *base, const TCHAR *aname);
 a_inode *fsdb_lookup_aino_aname (a_inode *base, const TCHAR *aname)
 {
 	FILE *f;
 
 	f = get_fsdb (base, _T("r+b"));
 	if (f == 0) {
-//		if (currprefs.filesys_custom_uaefsdb && (base->volflags & MYVOLUMEINFO_STREAMS))
-//			return custom_fsdb_lookup_aino_aname (base, aname);
+		if (currprefs.filesys_custom_uaefsdb && (base->volflags & MYVOLUMEINFO_STREAMS))
+			return custom_fsdb_lookup_aino_aname (base, aname);
 		return 0;
 	}
 	for (;;) {
@@ -211,6 +212,7 @@ a_inode *fsdb_lookup_aino_aname (a_inode *base, const TCHAR *aname)
     return 0;
 }
 
+a_inode *custom_fsdb_lookup_aino_nname(a_inode *base, const TCHAR *nname);
 a_inode *fsdb_lookup_aino_nname (a_inode *base, const TCHAR *nname)
 {
 	FILE *f;
@@ -218,8 +220,8 @@ a_inode *fsdb_lookup_aino_nname (a_inode *base, const TCHAR *nname)
 
 	f = get_fsdb (base, _T("r+b"));
 	if (f == 0) {
-//		if (currprefs.filesys_custom_uaefsdb && (base->volflags & MYVOLUMEINFO_STREAMS))
-//			return custom_fsdb_lookup_aino_nname (base, nname);
+		if (currprefs.filesys_custom_uaefsdb && (base->volflags & MYVOLUMEINFO_STREAMS))
+			return custom_fsdb_lookup_aino_nname (base, nname);
 		return 0;
 	}
 	s = ua (nname);
@@ -239,6 +241,7 @@ a_inode *fsdb_lookup_aino_nname (a_inode *base, const TCHAR *nname)
 	return 0;
 }
 
+int custom_fsdb_used_as_nname(a_inode *base, const TCHAR *nname);
 int fsdb_used_as_nname (a_inode *base, const TCHAR *nname)
 {
 	FILE *f;
@@ -246,8 +249,8 @@ int fsdb_used_as_nname (a_inode *base, const TCHAR *nname)
 
 	f = get_fsdb (base, _T("r+b"));
 	if (f == 0) {
-//		if (currprefs.filesys_custom_uaefsdb && (base->volflags & MYVOLUMEINFO_STREAMS))
-//			return custom_fsdb_used_as_nname (base, nname);
+		if (currprefs.filesys_custom_uaefsdb && (base->volflags & MYVOLUMEINFO_STREAMS))
+			return custom_fsdb_used_as_nname (base, nname);
 		return 0;
 	}
 	for (;;) {

--- a/sources/src/fsdb_unix.c
+++ b/sources/src/fsdb_unix.c
@@ -14,9 +14,14 @@
 #include "fsdb.h"
 #include "misc.h"
 
+#ifdef __LIBRETRO__
+#include "string/stdstring.h"
+#endif
+
 /* these are deadly (but I think allowed on the Amiga): */
-#define NUM_EVILCHARS 7
-static TCHAR evilchars[NUM_EVILCHARS] = { '\\', '*', '?', '\"', '<', '>', '|' };
+#define NUM_EVILCHARS 9
+static TCHAR evilchars[NUM_EVILCHARS] = { '%', '\\', '*', '?', '\"', '/', '<', '>', '|' };
+static char hex_chars[] = "0123456789abcdef";
 
 #define UAEFSDB_BEGINS "__uae___"
 #define UAEFSDB_BEGINSX "__uae___*"
@@ -37,6 +42,16 @@ static TCHAR evilchars[NUM_EVILCHARS] = { '\\', '*', '?', '\"', '<', '>', '|' };
 * Offset 1118, 257 * 2 bytes, nname
 *        1632
 */
+
+typedef struct fsdb_file_info {
+    int type;
+    uint32_t mode;
+    int days;
+    int mins;
+    int ticks;
+    char *comment;
+
+} fsdb_file_info;
 
 #define TRACING_ENABLED 0
 #if TRACING_ENABLED
@@ -162,6 +177,11 @@ int fsdb_name_invalid_dir (const TCHAR *n)
     return v;
 }
 
+static uae_u32 filesys_parse_mask(uae_u32 mask)
+{
+    return mask ^ 0xf;
+}
+
 int fsdb_exists (const char *nname)
 {
     struct stat statbuf;
@@ -267,35 +287,256 @@ int fsdb_mode_representable_p (const a_inode *aino, int amigaos_mode)
         return 0;
 }
 
-char *fsdb_create_unique_nname (a_inode *base, const char *suggestion)
+char *aname_to_nname(const char *aname, int ascii)
 {
-	TCHAR *c;
-	TCHAR tmp[256] = UAEFSDB_BEGINS;
-	int i;
+    size_t len = strlen(aname);
+    unsigned int repl_1 = UINT_MAX;
+    unsigned int repl_2 = UINT_MAX;
 
-	_tcsncat (tmp, suggestion, 240);
+    TCHAR a = aname[0];
+    TCHAR b = (a == '\0' ? a : aname[1]);
+    TCHAR c = (b == '\0' ? b : aname[2]);
+    TCHAR d = (c == '\0' ? c : aname[3]);
 
-        /* replace the evil ones... */
-        for (i = 0; i < NUM_EVILCHARS; i++)
-                while ((c = _tcschr (tmp, evilchars[i])) != 0)
-                        *c = '_';
+    if (a >= 'a' && a <= 'z') a -= 32;
+    if (b >= 'a' && b <= 'z') b -= 32;
+    if (c >= 'a' && c <= 'z') c -= 32;
 
-        while ((c = _tcschr (tmp, '.')) != 0)
-                *c = '_';
-        while ((c = _tcschr (tmp, ' ')) != 0)
-                *c = '_';
+    // reserved dos devices in Windows
+    size_t ll = 0;
+    if (a == 'A' && b == 'U' && c == 'X') ll = 3; // AUX
+    if (a == 'C' && b == 'O' && c == 'N') ll = 3; // CON
+    if (a == 'P' && b == 'R' && c == 'N') ll = 3; // PRN
+    if (a == 'N' && b == 'U' && c == 'L') ll = 3; // NUL
+    if (a == 'L' && b == 'P' && c == 'T' && (d >= '0' && d <= '9')) ll = 4; // LPT#
+    if (a == 'C' && b == 'O' && c == 'M' && (d >= '0' && d <= '9')) ll = 4; // COM#
+    // AUX.anything, CON.anything etc.. are also illegal names in Windows
+    if (ll && (len == ll || (len > ll && aname[ll] == '.'))) {
+        repl_1 = 2;
+    }
 
-        for (;;) {
-                TCHAR *p = build_nname (base->nname, tmp);
-                if (!fsdb_exists (p)) {
-                        write_log (_T("unique name: %s\n"), p);
-                        return p;
-                }
-                xfree (p);
-                /* tmpnam isn't reentrant and I don't really want to hack configure
-                * right now to see whether tmpnam_r is available...  */
-                for (i = 0; i < 8; i++) {
-                        tmp[i+8] = "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"[rand () % 63];
-                }
+    // spaces and periods at the end are a no-no in Windows
+    int ei = len - 1;
+    if (aname[ei] == '.' || aname[ei] == ' ') {
+        repl_2 = ei;
+    }
+
+    // allocating for worst-case scenario here (max replacements)
+    char *buf = (char*) malloc(len * 3 + 1);
+    char *p = buf;
+
+    int repl, j;
+    unsigned char x;
+    for (unsigned int i = 0; i < len; i++) {
+        x = (unsigned char) aname[i];
+        repl = 0;
+        if (i == repl_1) {
+            repl = 1;
         }
+        else if (i == repl_2) {
+            repl = 2;
+        }
+        else if (x < 32) {
+            // these are not allowed on Windows
+            repl = 1;
+        }
+        else if (ascii && x > 127) {
+            repl = 1;
+        }
+        for (j = 0; j < NUM_EVILCHARS; j++) {
+            if (x == evilchars[j]) {
+                repl = 1;
+                break;
+            }
+        }
+        if (i == len - 1) {
+            // last character, we can now check the file ending
+            if (len >= 5 && strncasecmp(aname + len - 5, ".uaem", 5) == 0) {
+                // we don't allow Amiga files ending with .uaem, so we replace
+                // the last character
+                repl = 1;
+            }
+        }
+        if (repl) {
+            //*p++ = '%';
+            //*p++ = hex_chars[(x & 0xf0) >> 4];
+            //*p++ = hex_chars[x & 0xf];
+            *p++ = x;
+        }
+        else {
+            *p++ = x;
+        }
+    }
+    *p++ = '\0';
+
+    if (ascii) {
+        return buf;
+    }
+
+    char* result = ua(buf);
+    if (ll > 0) {
+        _tcscpy(result, UAEFSDB_BEGINS);
+        _tcscat(result, buf);
+    }
+
+    free(buf);
+
+    //write_log("aname_to_nname %s => %s\n", aname, result);
+    return result;
+}
+
+static unsigned char char_to_hex(unsigned char c)
+{
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return 10 + c - 'a';
+    }
+    if (c >= 'A' && c <= 'F') {
+        return 10 + c - 'A';
+    }
+    return 0;
+}
+
+static char *nname_to_aname(const char *nname, int noconvert)
+{
+    char *cresult;
+    int len = strlen(nname);
+    cresult = strdup(nname);
+    if (!cresult) {
+        write_log("[WARNING] nname_to_aname %s => Failed\n", nname);
+        return NULL;
+    }
+
+    char *result = strdup(cresult);
+    unsigned char *p = (unsigned char *) result;
+    for (int i = 0; i < len; i++) {
+        unsigned char c = cresult[i];
+        if (c == '%' && i < len - 2) {
+            *p++ = (char_to_hex(cresult[i + 1]) << 4) |
+                    char_to_hex(cresult[i + 2]);
+            i += 2;
+        } else {
+            *p++ = c;
+        }
+    }
+    *p++ = '\0';
+    free(cresult);
+
+    result = string_replace_substring(result, UAEFSDB_BEGINS, "");
+    //write_log("nname_to_aname %s => %s\n", nname, result);
+    return result;
+}
+
+TCHAR *fsdb_create_unique_nname(a_inode *base, const TCHAR *suggestion)
+{
+    char *nname = aname_to_nname(suggestion, 0);
+    TCHAR *p = build_nname(base->nname, nname);
+    free(nname);
+    return p;
+}
+
+/* Return 1 if the nname is a special host-only name which must be translated
+ * to aname using fsdb.
+ */
+a_inode *custom_fsdb_lookup_aino_nname(a_inode *base, const TCHAR *aname);
+int custom_fsdb_used_as_nname(a_inode *base, const TCHAR *nname)
+{
+    if (custom_fsdb_lookup_aino_nname (base, nname))
+        return 1;
+    return 0;
+}
+
+static int fsdb_get_file_info(const char *nname, fsdb_file_info *info)
+{
+    int error = 0;
+    info->comment = NULL;
+    info->type = my_existsdir(nname) ? 2 : 1;
+    info->mode = 15;
+    return error;
+}
+
+a_inode *custom_fsdb_lookup_aino_aname(a_inode *base, const TCHAR *aname)
+{
+    char *nname = aname_to_nname(aname, 0);
+    //find_nname_case(base->nname, &nname);
+    char *full_nname = build_nname(base->nname, nname);
+    if (!my_existsfile(full_nname) || !fsdb_name_invalid(aname))
+        return 0;
+
+    fsdb_file_info info;
+    fsdb_get_file_info(full_nname, &info);
+    if (!info.type) {
+        if (info.comment) {
+            free(info.comment);
+            info.comment = NULL;
+        }
+        free(full_nname);
+        free(nname);
+        return NULL;
+    }
+    a_inode *aino = xcalloc (a_inode, 1);
+    aino->aname = nname_to_aname(nname, 0);
+    free(nname);
+    aino->nname = full_nname;
+#if 0
+    if (info.comment) {
+        aino->comment = nname_to_aname(info.comment, 1);
+        free(info.comment);
+    }
+    else {
+        aino->comment = NULL;
+    }
+#endif
+    aino->amigaos_mode = filesys_parse_mask(info.mode);
+    aino->dir = info.type == 2;
+    aino->has_dbentry = 0;
+    aino->dirty = 0;
+    aino->db_offset = 0;
+    return aino;
+}
+
+a_inode *custom_fsdb_lookup_aino_nname(a_inode *base, const TCHAR *nname)
+{
+    char *tmp_nname = string_replace_substring(nname, UAEFSDB_BEGINS, "");
+    char *full_nname = build_nname(base->nname, nname);
+    if (fsdb_name_invalid(nname)) {
+        _tcscpy(tmp_nname, UAEFSDB_BEGINS);
+        _tcscat(tmp_nname, nname);
+        full_nname = build_nname(base->nname, tmp_nname);
+    }
+
+    if (_tcscmp(tmp_nname, nname) == 0)
+        return 0;
+
+    fsdb_file_info info;
+    fsdb_get_file_info(full_nname, &info);
+    if (!info.type) {
+        if (info.comment) {
+            free(info.comment);
+            info.comment = NULL;
+        }
+        free(full_nname);
+        return NULL;
+    }
+
+    a_inode *aino = xcalloc (a_inode, 1);
+    aino->aname = nname_to_aname(nname, 0);
+    aino->nname = full_nname;
+#if 0
+    if (info.comment) {
+        aino->comment = nname_to_aname(info.comment, 1);
+        free(info.comment);
+    }
+    else {
+        aino->comment = NULL;
+    }
+#endif
+    aino->amigaos_mode = filesys_parse_mask(info.mode);
+    aino->dir = info.type == 2;
+    aino->has_dbentry = 0;
+    aino->dirty = 0;
+    aino->db_offset = 0;
+    return aino;
 }


### PR DESCRIPTION
Major:
- Updated directory filesystem with illegal filenames
  - In practice fixes the Space Taxi 3 input config screen in Windows directory mode, because `con` needs to be named `__uae___con` on the host and vice versa in the emulation
![retroarch_2020_07_15_23_53_23_185](https://user-images.githubusercontent.com/45124675/87604244-fbffe380-c700-11ea-8f60-c841526a2872.png)
- Allowed launching extracted `.slave` files
  - Does not actually launch the correct slave when there are multiple slaves, so for now it just does the same as launching the directory!

Minor:
- Added RetroPad B to turbo fire options
- Defaulted RetroPad X to Space
- Defaulted RetroPad mapping options visibility
