### PR TITLE
(Oh No! More) Directory filesystem fixes

### DIFF
--- a/retrodep/sysconfig.h
+++ b/retrodep/sysconfig.h
@@ -7,7 +7,7 @@
 #define CAPS /* CAPS-image support */
 #define FDI2RAW /* FDI 1.0 and 2.x image support */
 //#define WITH_CHD
-//#define A_ZIP
+#define A_ZIP
 //#define A_RAR
 //#define A_7Z
 #define A_LHA

--- a/sources/src/zfile_archive.c
+++ b/sources/src/zfile_archive.c
@@ -22,7 +22,11 @@
 
 #include "options.h"
 #include "zfile.h"
+#ifdef __LIBRETRO__
+#include "deps/zlib/unzip.h"
+#else
 #include "archivers/zip/unzip.h"
+#endif
 #include "archivers/dms/pfile.h"
 #include "crc32.h"
 #include "zarchive.h"
@@ -381,7 +385,11 @@ struct zvolume *archive_directory_zip (struct zfile *z)
 	struct zvolume *zv;
 	int err;
 
+#ifdef __LIBRETRO__
+	uz = unzOpen (z->name);
+#else
 	uz = unzOpen (z);
+#endif
 	if (!uz)
 		return 0;
 	if (unzGoToFirstFile (uz) != UNZ_OK)
@@ -440,7 +448,11 @@ static struct zfile *archive_do_zip (struct znode *zn, struct zfile *z, int flag
 	TCHAR *name = z ? z->archiveparent->name : zn->volume->root.fullname;
 	char *s;
 
+#ifdef __LIBRETRO__
+	uz = unzOpen (name);
+#else
 	uz = unzOpen (z ? z->archiveparent : zn->volume->archive);
+#endif
 	if (!uz)
 		return 0;
 	if (z)


### PR DESCRIPTION
- Removed redundant leftover steps (`tmp_nname` shenanigans) during initial feature inclusion, which caused random crashes in some cases
- Fixed heap block past requested size -errors if Amiga is rebooted after accessing a `__uae___`-prefixed file and the same file is accessed again
- Fixed illegal filesystem character handling for directories

Some WHDLoad slaves such as "Pinball Dreams" and "Hook" will use rather harsh naming conventions for save directories when saves are redirected using `SavePath` (mandatory for readonly-LHA launching):
- `-->PinballDreams<--`
- `->HOOK<-`

Which means these need to be renamed and evaded, and the current maneuvers were only targeting the file named `con` in Space Taxi 3.

If WHDLoad installs are used as extracted files or if the core option is in HDF-mode, this will not be a problem, so I never would have noticed these on my own, since I use extracted files for serious gaming.

Credits for noticing the monsters and for teaming up to destroy them goes to @jdgleaver 


Bonus:
- Enabled and fixed using ZIPs via .uae confs (Both `floppyX=` and `filesystem2=`)
  Closes #304 


