### PR TITLE
More maintenance

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -69,7 +69,6 @@ SOURCES_C += $(EMU)/main.c \
 	$(EMU)/aros.rom.c \
 	$(EMU)/specialmonitors.c \
 	$(EMU)/writelog.c \
-	$(EMU)/debug.c \
 	$(EMU)/identify.c \
 	$(EMU)/picasso96.c \
 	$(EMU)/blkdev.c \
@@ -111,6 +110,7 @@ SOURCES_C += $(EMU)/main.c \
 	$(RETRODEP)/main.c \
 	$(RETRODEP)/machdep/support.c \
 	$(RETRODEP)/gui.c \
+	$(RETRODEP)/debug.c \
 	$(RETRODEP)/retroglue.c \
 	$(RETRODEP)/sounddep/sound.c \
 	$(RETRODEP)/threaddep/thread.c

--- a/Makefile.common
+++ b/Makefile.common
@@ -27,7 +27,6 @@ SOURCES_C += $(EMU)/main.c \
 	$(EMU)/keybuf.c \
 	$(EMU)/expansion.c \
 	$(EMU)/inputrecord.c \
-	$(EMU)/keymap/keymap.c \
 	$(EMU)/diskutil.c \
 	$(EMU)/caps/caps.c \
 	$(EMU)/caps/uae_dlopen.c \

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The whole path (filename and directory) will be searched for the following tags 
 | |**x**|**(CD32FR)** or **FastRAM**|Amiga CD32, 2MB Chip RAM + 8MB Fast RAM|
 |**x**|**x**|**NTSC** or **(USA)**|NTSC 60Hz|
 |**x**|**x**|**PAL** or **(Europe)** or **(Denmark)** or **(Finland)** or **(France)** or **(Germany)** or **(Italy)** or **(Spain)** or **(Sweden)**|PAL 50Hz|
+|**x**|**x**|**(CE)**|Force CPU Cycle-exact|
 
 Example: When launching "Alien Breed 2 AGA.hdf" or "AGA/Alien Breed 2.hdf" the model will be Amiga 1200.
 

--- a/libretro/graph.c
+++ b/libretro/graph.c
@@ -9,43 +9,43 @@
 
 unsigned short blend(unsigned short fg, unsigned short bg, unsigned int alpha)
 {
-   // Split foreground into components
+   /* Split foreground into components */
    unsigned fg_r = fg >> 11;
    unsigned fg_g = (fg >> 5) & ((1u << 6) - 1);
    unsigned fg_b = fg & ((1u << 5) - 1);
 
-   // Split background into components
+   /* Split background into components */
    unsigned bg_r = bg >> 11;
    unsigned bg_g = (bg >> 5) & ((1u << 6) - 1);
    unsigned bg_b = bg & ((1u << 5) - 1);
 
-   // Alpha blend components
+   /* Alpha blend components */
    unsigned out_r = (fg_r * alpha + bg_r * (255 - alpha)) / 255;
    unsigned out_g = (fg_g * alpha + bg_g * (255 - alpha)) / 255;
    unsigned out_b = (fg_b * alpha + bg_b * (255 - alpha)) / 255;
 
-   // Pack result
+   /* Pack result */
    return (unsigned short) ((out_r << 11) | (out_g << 5) | out_b);
 }
 
 uint32_t blend32(uint32_t fg, uint32_t bg, unsigned int alpha)
 {
-   // Split foreground into components
+   /* Split foreground into components */
    unsigned fg_r = (fg >> 16) & 0xFF;
    unsigned fg_g = (fg >> 8) & 0xFF;
    unsigned fg_b = (fg >> 0) & 0xFF;
 
-   // Split background into components
+   /* Split background into components */
    unsigned bg_r = (bg >> 16) & 0xFF;
    unsigned bg_g = (bg >> 8) & 0xFF;
    unsigned bg_b = (bg >> 0) & 0xFF;
 
-   // Alpha blend components
+   /* Alpha blend components */
    unsigned out_r = (fg_r * alpha + bg_r * (255 - alpha)) / 255;
    unsigned out_g = (fg_g * alpha + bg_g * (255 - alpha)) / 255;
    unsigned out_b = (fg_b * alpha + bg_b * (255 - alpha)) / 255;
 
-   // Pack result
+   /* Pack result */
    return (uint32_t) ((out_r << 16) | (out_g << 8) | out_b);
 }
 
@@ -279,7 +279,7 @@ void Draw_string(unsigned short *surf, signed short int x, signed short int y,
    if (!string)
       return;
 
-   // Pseudo transparency for now
+   /* Pseudo transparency for now */
    if (alpha < 255)
    {
       fg = blend(fg, ((bg == 0) ? 0xFFFF : bg), alpha);
@@ -291,14 +291,14 @@ void Draw_string(unsigned short *surf, signed short int x, signed short int y,
    int surfw = strlen * 7 * xscale;
    int surfh = 8 * yscale;
 
-   // No horizontal wrap
+   /* No horizontal wrap */
    if ((surfw + x) > retrow)
       return;
 
    linesurf = (unsigned char*)malloc(sizeof(unsigned short)*surfw*surfh);
    yptr = (unsigned short *)&linesurf[0];
 
-   // Skip the 8th row
+   /* Skip the 8th row */
    surfh -= 1;
 
    for(ypixel = 0; ypixel < 8; ypixel++)
@@ -346,7 +346,7 @@ void Draw_string32(uint32_t *surf, signed short int x, signed short int y,
    if (!string)
       return;
 
-   // Pseudo transparency for now
+   /* Pseudo transparency for now */
    if (alpha < 255)
    {
       fg = blend32(fg, ((bg == 0) ? 0xFFFFFFFF : bg), alpha);
@@ -358,14 +358,14 @@ void Draw_string32(uint32_t *surf, signed short int x, signed short int y,
    int surfw = strlen * 7 * xscale;
    int surfh = 8 * yscale;
 
-   // No horizontal wrap
+   /* No horizontal wrap */
    if ((surfw + x) > retrow)
       return;
 
    linesurf = (uint32_t *)malloc(sizeof(uint32_t)*surfw*surfh);
    yptr = (uint32_t *)&linesurf[0];
 
-   // Skip the 8th row
+   /* Skip the 8th row */
    surfh -= 1;
 
    for(ypixel = 0; ypixel < 8; ypixel++)

--- a/libretro/graph.h
+++ b/libretro/graph.h
@@ -3,8 +3,8 @@
 
 typedef struct
 {
-	int x, y;
-	int dx, dy;
+   int x, y;
+   int dx, dy;
 } box;
 
 extern void DrawFBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color, unsigned int alpha);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3238,7 +3238,7 @@ static bool retro_update_av_info(void)
          PAL mode V=49.9201Hz H=15625.0881Hz (227x312+1) IDX=10 (PAL) D=0 RTG=0/0
    */
 
-   video_config_old = video_config;
+   video_config_old      = video_config;
    video_config_geometry = video_config;
 
    /* When timing & geometry is changed */
@@ -3306,26 +3306,26 @@ static bool retro_update_av_info(void)
 
    /* Horizontal centering thresholds */
    static int min_diwstart_limit_hires = 220;
-   static int max_diwstop_limit_hires = 600;
-   static int min_diwstart_limit = 220;
-   static int max_diwstop_limit = 600;
+   static int max_diwstop_limit_hires  = 600;
+   static int min_diwstart_limit       = 220;
+   static int max_diwstop_limit        = 600;
    if (video_config & PUAE_VIDEO_SUPERHIRES)
    {
       min_diwstart_limit = min_diwstart_limit_hires * 2;
-      max_diwstop_limit = max_diwstop_limit_hires * 2;
-      width_multiplier = 4;
+      max_diwstop_limit  = max_diwstop_limit_hires * 2;
+      width_multiplier   = 4;
    }
    else if (video_config & PUAE_VIDEO_HIRES)
    {
       min_diwstart_limit = min_diwstart_limit_hires;
-      max_diwstop_limit = max_diwstop_limit_hires;
-      width_multiplier = 2;
+      max_diwstop_limit  = max_diwstop_limit_hires;
+      width_multiplier   = 2;
    }
    else
    {
       min_diwstart_limit = min_diwstart_limit_hires / 2;
-      max_diwstop_limit = max_diwstop_limit_hires / 2;
-      width_multiplier = 1;
+      max_diwstop_limit  = max_diwstop_limit_hires / 2;
+      width_multiplier   = 1;
    }
 
    /* Geometry dimensions */
@@ -3389,21 +3389,9 @@ static bool retro_update_av_info(void)
       defaulth = retroh;
    }
 
-   static struct retro_system_av_info new_av_info;
-   retro_get_system_av_info(&new_av_info);
-
    /* Disable Hz change if not allowed */
    if (!video_config_allow_hz_change)
       change_timing = false;
-
-   /* Timing or geometry update */
-   if (change_timing)
-   {
-      new_av_info.timing.fps = hz;
-      environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_av_info);
-   }
-   else if (change_geometry)
-      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
 
    /* Ensure statusbar stays visible at the bottom */
    opt_statusbar_position_offset = 0;
@@ -3459,31 +3447,31 @@ static bool retro_update_av_info(void)
    switch (zoom_mode_id)
    {
       case 1:
-         zoomed_width = 360;
+         zoomed_width  = 360;
          zoomed_height = (video_config_geometry & PUAE_VIDEO_NTSC) ? 240 : 270;
          break;
       case 2:
-         zoomed_width = 348;
+         zoomed_width  = 348;
          zoomed_height = (video_config_geometry & PUAE_VIDEO_NTSC) ? 240 : 264;
          break;
       case 3:
-         zoomed_width = 332;
+         zoomed_width  = 332;
          zoomed_height = (video_config_geometry & PUAE_VIDEO_NTSC) ? 240 : 256;
          break;
       case 4:
-         zoomed_width = 320;
+         zoomed_width  = 320;
          zoomed_height = 240;
          break;
       case 5:
-         zoomed_width = 320;
+         zoomed_width  = 320;
          zoomed_height = 224;
          break;
       case 6:
-         zoomed_width = 320;
+         zoomed_width  = 320;
          zoomed_height = 216;
          break;
       case 7:
-         zoomed_width = 320;
+         zoomed_width  = 320;
          zoomed_height = 200;
          break;
       case 8:
@@ -3500,7 +3488,7 @@ static bool retro_update_av_info(void)
          zoomed_height = (zoomed_height < 200) ? 200 : zoomed_height;
          break;
       default:
-         zoomed_width = retrow;
+         zoomed_width  = retrow;
          zoomed_height = retroh;
          break;
    }
@@ -3568,12 +3556,14 @@ static bool retro_update_av_info(void)
          zoomed_width = retrow;
    }
 
+   struct retro_system_av_info new_av_info;
+   retro_get_system_av_info(&new_av_info);
+
    if (zoomed_height != retroh || zoomed_width != retrow)
    {
-      new_av_info.geometry.base_width = zoomed_width;
-      new_av_info.geometry.base_height = zoomed_height;
+      new_av_info.geometry.base_width   = zoomed_width;
+      new_av_info.geometry.base_height  = zoomed_height;
       new_av_info.geometry.aspect_ratio = retro_get_aspect_ratio(zoomed_width, zoomed_height, false);
-      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
 
       /* Ensure statusbar stays visible at the bottom */
       if (opt_statusbar_position >= 0 && (retroh - zoomed_height - opt_statusbar_position_offset) >= opt_statusbar_position)
@@ -3582,10 +3572,19 @@ static bool retro_update_av_info(void)
       //fprintf(stdout, "ztatusbar:%3d old:%3d offset:%3d, defaulth:%d retroz:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, defaulth, zoomed_height);
    }
 
+   /* Timing or geometry update */
+   if (change_timing)
+   {
+      new_av_info.timing.fps = hz;
+      environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_av_info);
+   }
+   else if (change_geometry)
+      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
+
    /* If zoom mode should be vertically centered automagically */
    if (opt_vertical_offset_auto && (zoom_mode_id != 0 || zoomed_height != retroh))
    {
-      int zoomed_height_normal = (video_config & PUAE_VIDEO_DOUBLELINE) ? zoomed_height / 2 : zoomed_height;
+      int zoomed_height_normal   = (video_config & PUAE_VIDEO_DOUBLELINE) ? zoomed_height / 2 : zoomed_height;
       int thisframe_y_adjust_new = minfirstline;
 
       /* Need proper values for calculations */
@@ -3646,11 +3645,11 @@ static bool retro_update_av_info(void)
    if (av_log)
    {
       if (change_timing)
-         fprintf(stdout, "* Update av_info: %dx%d %0.4fHz, zoomed: %dx%d, video_config:%d\n", retrow, retroh, hz, zoomed_width, zoomed_height, video_config_geometry);
+         fprintf(stdout, "* Update av_info : %dx%d %0.4fHz, zoomed: %dx%d, video_config:%d\n", retrow, retroh, hz, zoomed_width, zoomed_height, video_config_geometry);
       else if (change_geometry)
          fprintf(stdout, "* Update geometry: %dx%d, zoomed: %dx%d, video_config:%d\n", retrow, retroh, zoomed_width, zoomed_height, video_config_geometry);
       else
-         fprintf(stdout, "* Update zoom: %dx%d, zoomed: %dx%d, video_config:%d\n", retrow, retroh, zoomed_width, zoomed_height, video_config_geometry);
+         fprintf(stdout, "* Update center  : %dx%d, zoomed: %dx%d, video_config:%d\n", retrow, retroh, zoomed_width, zoomed_height, video_config_geometry);
    }
 
    /* Triggers check_prefs_changed_gfx() in vsync_handle_check() */
@@ -3687,16 +3686,14 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
       }
    }
 
-   static struct retro_game_geometry geom;
-   geom.base_width = retrow;
-   geom.base_height = retroh;
-   geom.max_width = EMULATOR_MAX_WIDTH;
-   geom.max_height = EMULATOR_MAX_HEIGHT;
-   geom.aspect_ratio = retro_get_aspect_ratio(retrow, retroh, false);
+   info->geometry.base_width   = retrow;
+   info->geometry.base_height  = retroh;
+   info->geometry.max_width    = EMULATOR_MAX_WIDTH;
+   info->geometry.max_height   = EMULATOR_MAX_HEIGHT;
+   info->geometry.aspect_ratio = retro_get_aspect_ratio(retrow, retroh, false);
 
-   info->geometry = geom;
-   info->timing.sample_rate = 44100.0;
-   info->timing.fps = (retro_get_region() == RETRO_REGION_NTSC) ? PUAE_VIDEO_HZ_NTSC : PUAE_VIDEO_HZ_PAL;
+   info->timing.sample_rate    = 44100.0;
+   info->timing.fps            = (retro_get_region() == RETRO_REGION_NTSC) ? PUAE_VIDEO_HZ_NTSC : PUAE_VIDEO_HZ_PAL;
 }
 
 void retro_set_video_refresh(retro_video_refresh_t cb)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -104,6 +104,7 @@ extern unsigned int turbo_pulse;
 unsigned int inputdevice_finalized = 0;
 unsigned int pix_bytes = 2;
 static bool pix_bytes_initialized = false;
+static bool cpu_cycle_exact_force = false;
 bool automatic_sound_filter_type_update = true;
 bool fake_ntsc = false;
 bool real_ntsc = false;
@@ -1731,7 +1732,7 @@ static void update_variables(void)
          strcat(uae_config, "cycle_exact=true\n");
       }
 
-      if (libretro_runloop_active)
+      if (libretro_runloop_active && !cpu_cycle_exact_force)
       {
          if (!strcmp(var.value, "normal"))
          {
@@ -4893,6 +4894,10 @@ static bool retro_create_config()
    if (opt_region_auto)
       retro_force_region(&configfile);
 
+   // Forced Cycle-exact
+   if (strstr(full_path, "(CE)"))
+      fprintf(configfile, "cycle_exact=true\n");
+
    // Close tmp config
    fclose(configfile);
 
@@ -4906,6 +4911,8 @@ static bool retro_create_config()
             real_ntsc = true;
          if (strstr(filebuf, "ntsc=false") && filebuf[0] == 'n')
             real_ntsc = false;
+         if (strstr(filebuf, "cycle_exact=true") && filebuf[0] == 'c')
+            cpu_cycle_exact_force = true;
       }
       fclose(configfile);
    }

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -162,13 +162,13 @@ struct zfile *retro_deserialize_file = NULL;
 static size_t save_state_file_size = 0;
 
 #include "libretro-keyboard.i"
-int keyId(const char *val)
+static int retro_key_id(const char *val)
 {
    int i = 0;
-   while (keyDesc[i] != NULL)
+   while (retro_key_name[i] != NULL)
    {
-      if (!strcmp(keyDesc[i], val))
-         return keyVal[i];
+      if (!strcmp(retro_key_name[i], val))
+         return retro_key_value[i];
       i++;
    }
    return 0;
@@ -1362,10 +1362,19 @@ void retro_set_environment(retro_environment_t cb)
       { NULL, NULL, NULL, {{0}}, NULL },
    };
 
-   /* fill in the values for all the mappers */
+   /* Fill in the values for all the mappers */
    int i = 0;
    int j = 0;
    int hotkey = 0;
+   int hotkeys_skipped = 0;
+   /* Count special hotkeys */
+   while (retro_key_name[j] && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
+   {
+      if (retro_key_value[j] < 0)
+         hotkeys_skipped++;
+      ++j;
+   }
+
    while (core_options[i].key)
    {
       if (strstr(core_options[i].key, "puae_mapper_"))
@@ -1385,18 +1394,21 @@ void retro_set_environment(retro_environment_t cb)
          j = 0;
          if (hotkey)
          {
-             while (keyDescHotkeys[j] && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
+             while (retro_key_name[j] && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
              {
-                core_options[i].values[j].value = keyDescHotkeys[j];
+                if (j == 0)
+                   core_options[i].values[j].value = retro_key_name[j];
+                else
+                   core_options[i].values[j].value = retro_key_name[j + hotkeys_skipped + 1];
                 core_options[i].values[j].label = NULL;
                 ++j;
              };
          }
          else
          {
-             while (keyDesc[j] && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
+             while (retro_key_name[j] && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
              {
-                core_options[i].values[j].value = keyDesc[j];
+                core_options[i].values[j].value = retro_key_name[j];
                 core_options[i].values[j].label = NULL;
                 ++j;
              };
@@ -2387,140 +2399,140 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_SELECT] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_SELECT] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_start";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_START] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_START] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_b";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_B] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_B] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_a";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_A] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_A] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_y";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_Y] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_Y] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_x";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_X] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_X] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_l";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_r";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_l2";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L2] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L2] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_r2";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R2] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R2] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_l3";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L3] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L3] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_r3";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R3] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R3] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_lr";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[16] = keyId(var.value);
+      mapper_keys[16] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_ll";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[17] = keyId(var.value);
+      mapper_keys[17] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_ld";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[18] = keyId(var.value);
+      mapper_keys[18] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_lu";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[19] = keyId(var.value);
+      mapper_keys[19] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_rr";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[20] = keyId(var.value);
+      mapper_keys[20] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_rl";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[21] = keyId(var.value);
+      mapper_keys[21] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_rd";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[22] = keyId(var.value);
+      mapper_keys[22] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_ru";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[23] = keyId(var.value);
+      mapper_keys[23] = retro_key_id(var.value);
    }
 
    /* Mapper hotkeys */
@@ -2528,42 +2540,42 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[24] = keyId(var.value);
+      mapper_keys[24] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_statusbar";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[25] = keyId(var.value);
+      mapper_keys[25] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_mouse_toggle";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[26] = keyId(var.value);
+      mapper_keys[26] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_reset";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[27] = keyId(var.value);
+      mapper_keys[27] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_aspect_ratio_toggle";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[28] = keyId(var.value);
+      mapper_keys[28] = retro_key_id(var.value);
    }
 
    var.key = "puae_mapper_zoom_mode_toggle";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[29] = keyId(var.value);
+      mapper_keys[29] = retro_key_id(var.value);
    }
 
    /*** Options display ***/

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -34,9 +34,9 @@ int retrow = 0;
 int retroh = 0;
 int defaultw = EMULATOR_DEF_WIDTH;
 int defaulth = EMULATOR_DEF_HEIGHT;
-char retro_key_state[RETROK_LAST];
-char retro_key_state_old[RETROK_LAST];
-unsigned short int retro_bmp[RETRO_BMP_SIZE];
+char retro_key_state[RETROK_LAST] = {0};
+char retro_key_state_old[RETROK_LAST] = {0};
+unsigned short int retro_bmp[RETRO_BMP_SIZE] = {0};
 
 extern int frame_redraw_necessary;
 extern int bplcon0;
@@ -2984,7 +2984,6 @@ static void fallback_log(enum retro_log_level level, const char *fmt, ...)
    va_end(va);
 }
 
-/* Init */
 void retro_init(void)
 {
    struct retro_log_callback log;
@@ -3018,7 +3017,7 @@ void retro_init(void)
    }
    else
    {
-      /* make retro_save_directory the same in case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY is not implemented by the frontend */
+      /* Make retro_save_directory the same in case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY is not implemented by the frontend */
       strlcpy(retro_save_directory,
               retro_system_directory,
               sizeof(retro_save_directory));
@@ -4939,6 +4938,14 @@ static bool retro_update_av_info(void)
          retroh = PUAE_VIDEO_HEIGHT_NTSC;
          break;
    }
+
+   /* Width multiplier */
+   if (video_config & PUAE_VIDEO_SUPERHIRES)
+      width_multiplier = 4;
+   else if (video_config & PUAE_VIDEO_HIRES)
+      width_multiplier = 2;
+   else
+      width_multiplier = 1;
 
    /* Restore actual canvas height for aspect ratio toggling in real NTSC, otherwise toggling is broken */
    if (!change_timing && real_ntsc && video_config_aspect == PUAE_VIDEO_PAL)

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -30,10 +30,6 @@ extern void print_statusbar(void);
 extern bool retro_message;
 extern char retro_message_msg[1024];
 
-extern bool retro_request_av_info_update;
-extern bool retro_av_info_change_timing;
-extern bool retro_av_info_is_ntsc;
-
 extern int retro_thisframe_first_drawn_line;
 extern int retro_thisframe_last_drawn_line;
 extern int retro_min_diwstart;
@@ -56,17 +52,17 @@ int umain (int argc, TCHAR **argv);
 #define DIR_SEP_STR "/"
 #endif
 
-// VKBD
-#define NPLGN 11
-#define NLIGN 8
-#define NLETT 9
-//#define POINTER_DEBUG
+/* VKBD */
+#define VKBDX 11
+#define VKBDY 8
+#if 0
+#define POINTER_DEBUG
+#endif
 #ifdef POINTER_DEBUG
 extern int pointer_x;
 extern int pointer_y;
 #endif
 
-extern int SHOWKEY;
 extern int vkey_pos_x;
 extern int vkey_pos_y;
 extern int vkey_pressed;
@@ -79,18 +75,18 @@ extern int vkbd_x_max;
 extern int vkbd_y_min;
 extern int vkbd_y_max;
 
-// Statusbar
+/* Statusbar */
 #define STATUSBAR_BOTTOM    0x01
 #define STATUSBAR_TOP       0x02
 #define STATUSBAR_BASIC     0x04
 #define STATUSBAR_MINIMAL   0x08
 
-// Colors
+/* Colors */
 #define RGB565(r, g, b) ((((r>>3)<<11) | ((g>>2)<<5) | (b>>3)))
 #define RGB888(r, g, b) (((r * 255 / 31) << (16)) | ((g * 255 / 31) << 8) | (b * 255 / 31))
 #define ARGB888(a, r, g, b) ((a << 24) | (r << 16) | (g << 8) | b)
 
-// Configs
+/* Configs */
 enum EMU_CONFIG {
    EMU_CONFIG_A500 = 0,
    EMU_CONFIG_A500OG,
@@ -106,7 +102,7 @@ enum EMU_CONFIG {
    EMU_CONFIG_COUNT
 };
 
-// Kickstarts
+/* Kickstarts */
 #define A500_ROM                "kick34005.A500"
 #define A500KS2_ROM             "kick37175.A500"
 #define A600_ROM                "kick40063.A600"
@@ -116,10 +112,10 @@ enum EMU_CONFIG {
 #define CD32_ROM                "kick40060.CD32"
 #define CD32_ROM_EXT            "kick40060.CD32.ext"
 
-// Support files
+/* Support files */
 #define LIBRETRO_PUAE_PREFIX    "puae_libretro"
 
-// Video
+/* Video */
 #define PUAE_VIDEO_PAL          0x01
 #define PUAE_VIDEO_NTSC         0x02
 #define PUAE_VIDEO_HIRES        0x04
@@ -144,13 +140,13 @@ enum EMU_CONFIG {
 #define PUAE_VIDEO_HEIGHT_PAL   576
 #define PUAE_VIDEO_HEIGHT_NTSC  480
 
-// Libretro video
+/* Libretro video */
 #define EMULATOR_DEF_WIDTH      720
 #define EMULATOR_DEF_HEIGHT     576
 #define EMULATOR_MAX_WIDTH      (EMULATOR_DEF_WIDTH * 2)
 #define EMULATOR_MAX_HEIGHT     EMULATOR_DEF_HEIGHT
+#define RETRO_BMP_SIZE          (EMULATOR_DEF_WIDTH * EMULATOR_DEF_HEIGHT * 4) /* 4x is big enough for 24-bit SuperHires double line */
 
-#define RETRO_BMP_SIZE          (EMULATOR_DEF_WIDTH * EMULATOR_DEF_HEIGHT * 4) // 4x is big enough for 24-bit SuperHires double line
 extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
 extern unsigned int pix_bytes;
 extern int retrow;

--- a/libretro/libretro-keyboard.i
+++ b/libretro/libretro-keyboard.i
@@ -1,154 +1,154 @@
-const char* keyDesc[] = {
-"---",//0,
-"TOGGLE_VKBD",//-11,
-"TOGGLE_STATUSBAR",//-12,
-"SWITCH_JOYMOUSE",//-13,
-"MOUSE_LEFT_BUTTON",//-2,
-"MOUSE_RIGHT_BUTTON",//-3,
-"MOUSE_MIDDLE_BUTTON",//-4,
-"MOUSE_SLOWER",//-5,
-"MOUSE_FASTER",//-6,
-"JOYSTICK_FIRE",//-7
-"JOYSTICK_2ND_FIRE",//-8
-"RETROK_BACKSPACE",//8,
-"RETROK_TAB",//9,
-//"RETROK_CLEAR",//12,
-"RETROK_RETURN",//13,
-//"RETROK_PAUSE",//19,
-"RETROK_ESCAPE",//27,
-"RETROK_SPACE",//32,
-//"RETROK_EXCLAIM",//33,
-//"RETROK_QUOTEDBL",//34,
-//"RETROK_HASH",//35,
-//"RETROK_DOLLAR",//36,
-//"RETROK_AMPERSAND",//38,
-"RETROK_QUOTE",//39,
-"RETROK_LEFTPAREN",//40,
-"RETROK_RIGHTPAREN",//41,
-"RETROK_ASTERISK",//42,
-"RETROK_PLUS",//43,
-"RETROK_COMMA",//44,
-"RETROK_MINUS",//45,
-"RETROK_PERIOD",//46,
-"RETROK_SLASH",//47,
-"RETROK_0",//48,
-"RETROK_1",//49,
-"RETROK_2",//50,
-"RETROK_3",//51,
-"RETROK_4",//52,
-"RETROK_5",//53,
-"RETROK_6",//54,
-"RETROK_7",//55,
-"RETROK_8",//56,
-"RETROK_9",//57,
-"RETROK_COLON",//58,
-"RETROK_SEMICOLON",//59,
-"RETROK_LESS",//60,
-"RETROK_EQUALS",//61,
-"RETROK_GREATER",//62,
-//"RETROK_QUESTION",//63,
-//"RETROK_AT",//64,
-"RETROK_LEFTBRACKET",//91,
-"RETROK_BACKSLASH",//92,
-"RETROK_RIGHTBRACKET",//93,
-"RETROK_CARET",//94,
-"RETROK_UNDERSCORE",//95,
-"RETROK_BACKQUOTE",//96,
-"RETROK_a",//97,
-"RETROK_b",//98,
-"RETROK_c",//99,
-"RETROK_d",//100,
-"RETROK_e",//101,
-"RETROK_f",//102,
-"RETROK_g",//103,
-"RETROK_h",//104,
-"RETROK_i",//105,
-"RETROK_j",//106,
-"RETROK_k",//107,
-"RETROK_l",//108,
-"RETROK_m",//109,
-"RETROK_n",//110,
-"RETROK_o",//111,
-"RETROK_p",//112,
-"RETROK_q",//113,
-"RETROK_r",//114,
-"RETROK_s",//115,
-"RETROK_t",//116,
-"RETROK_u",//117,
-"RETROK_v",//118,
-"RETROK_w",//119,
-"RETROK_x",//120,
-"RETROK_y",//121,
-"RETROK_z",//122,
-"RETROK_DELETE",//127,
-"RETROK_KP0",//256,
-"RETROK_KP1",//257,
-"RETROK_KP2",//258,
-"RETROK_KP3",//259,
-"RETROK_KP4",//260,
-"RETROK_KP5",//261,
-"RETROK_KP6",//262,
-"RETROK_KP7",//263,
-"RETROK_KP8",//264,
-"RETROK_KP9",//265,
-"RETROK_KP_PERIOD",//266,
-"RETROK_KP_DIVIDE",//267,
-"RETROK_KP_MULTIPLY",//268,
-"RETROK_KP_MINUS",//269,
-"RETROK_KP_PLUS",//270,
-"RETROK_KP_ENTER",//271,
-"RETROK_KP_EQUALS",//272,
-"RETROK_UP",//273,
-"RETROK_DOWN",//274,
-"RETROK_RIGHT",//275,
-"RETROK_LEFT",//276,
-"RETROK_INSERT",//277,
-"RETROK_HOME",//278,
-"RETROK_END",//279,
-"RETROK_PAGEUP",//280,
-"RETROK_PAGEDOWN",//281,
-"RETROK_F1",//282,
-"RETROK_F2",//283,
-"RETROK_F3",//284,
-"RETROK_F4",//285,
-"RETROK_F5",//286,
-"RETROK_F6",//287,
-"RETROK_F7",//288,
-"RETROK_F8",//289,
-"RETROK_F9",//290,
-"RETROK_F10",//291,
-"RETROK_F11",//292,
-"RETROK_F12",//293,
-//"RETROK_F13",//294,
-//"RETROK_F14",//295,
-//"RETROK_F15",//296,
-//"RETROK_NUMLOCK",//300,
-//"RETROK_CAPSLOCK",//301,
-//"RETROK_SCROLLOCK",//302,
-"RETROK_RSHIFT",//303,
-"RETROK_LSHIFT",//304,
-"RETROK_RCTRL",//305,
-"RETROK_LCTRL",//306,
-"RETROK_RALT",//307,
-"RETROK_LALT",//308,
-"RETROK_RMETA",//309,
-"RETROK_LMETA",//310,
-//"RETROK_LSUPER",//311,
-//"RETROK_RSUPER",//312,
-"RETROK_MODE",//313,
-"RETROK_COMPOSE",//314,
-"RETROK_HELP",//315,
-//"RETROK_PRINT",//316,
-//"RETROK_SYSREQ",//317,
-//"RETROK_BREAK",//318,
-//"RETROK_MENU",//319,
-//"RETROK_POWER",//320,
-//"RETROK_EURO",//321,
-//"RETROK_UNDO",//322,
+static const char* retro_key_name[] = {
+"---",                  /* 0 */
+"TOGGLE_VKBD",          /* -11 */
+"TOGGLE_STATUSBAR",     /* -12 */
+"SWITCH_JOYMOUSE",      /* -13 */
+"MOUSE_LEFT_BUTTON",    /* -2 */
+"MOUSE_RIGHT_BUTTON",   /* -3 */
+"MOUSE_MIDDLE_BUTTON",  /* -4 */
+"MOUSE_SLOWER",         /* -5 */
+"MOUSE_FASTER",         /* -6 */
+"JOYSTICK_FIRE",        /* -7 */
+"JOYSTICK_2ND_FIRE",    /* -8 */
+"RETROK_BACKSPACE",     /* 8 */
+"RETROK_TAB",           /* 9 */
+/*"RETROK_CLEAR",*/     /* 12 */
+"RETROK_RETURN",        /* 13 */
+/*"RETROK_PAUSE",*/     /* 19 */
+"RETROK_ESCAPE",        /* 27 */
+"RETROK_SPACE",         /* 32 */
+/*"RETROK_EXCLAIM",*/   /* 33 */
+/*"RETROK_QUOTEDBL",*/  /* 34 */
+/*"RETROK_HASH",*/      /* 35 */
+/*"RETROK_DOLLAR",*/    /* 36 */
+/*"RETROK_AMPERSAND",*/ /* 38 */
+"RETROK_QUOTE",         /* 39 */
+"RETROK_LEFTPAREN",     /* 40 */
+"RETROK_RIGHTPAREN",    /* 41 */
+"RETROK_ASTERISK",      /* 42 */
+"RETROK_PLUS",          /* 43 */
+"RETROK_COMMA",         /* 44 */
+"RETROK_MINUS",         /* 45 */
+"RETROK_PERIOD",        /* 46 */
+"RETROK_SLASH",         /* 47 */
+"RETROK_0",             /* 48 */
+"RETROK_1",             /* 49 */
+"RETROK_2",             /* 50 */
+"RETROK_3",             /* 51 */
+"RETROK_4",             /* 52 */
+"RETROK_5",             /* 53 */
+"RETROK_6",             /* 54 */
+"RETROK_7",             /* 55 */
+"RETROK_8",             /* 56 */
+"RETROK_9",             /* 57 */
+"RETROK_COLON",         /* 58 */
+"RETROK_SEMICOLON",     /* 59 */
+"RETROK_LESS",          /* 60 */
+"RETROK_EQUALS",        /* 61 */
+"RETROK_GREATER",       /* 62 */
+/*"RETROK_QUESTION",*/  /* 63 */
+/*"RETROK_AT",*/        /* 64 */
+"RETROK_LEFTBRACKET",   /* 91 */
+"RETROK_BACKSLASH",     /* 92 */
+"RETROK_RIGHTBRACKET",  /* 93 */
+"RETROK_CARET",         /* 94 */
+"RETROK_UNDERSCORE",    /* 95 */
+"RETROK_BACKQUOTE",     /* 96 */
+"RETROK_a",             /* 97 */
+"RETROK_b",             /* 98 */
+"RETROK_c",             /* 99 */
+"RETROK_d",             /* 100 */
+"RETROK_e",             /* 101 */
+"RETROK_f",             /* 102 */
+"RETROK_g",             /* 103 */
+"RETROK_h",             /* 104 */
+"RETROK_i",             /* 105 */
+"RETROK_j",             /* 106 */
+"RETROK_k",             /* 107 */
+"RETROK_l",             /* 108 */
+"RETROK_m",             /* 109 */
+"RETROK_n",             /* 110 */
+"RETROK_o",             /* 111 */
+"RETROK_p",             /* 112 */
+"RETROK_q",             /* 113 */
+"RETROK_r",             /* 114 */
+"RETROK_s",             /* 115 */
+"RETROK_t",             /* 116 */
+"RETROK_u",             /* 117 */
+"RETROK_v",             /* 118 */
+"RETROK_w",             /* 119 */
+"RETROK_x",             /* 120 */
+"RETROK_y",             /* 121 */
+"RETROK_z",             /* 122 */
+"RETROK_DELETE",        /* 127 */
+"RETROK_KP0",           /* 256 */
+"RETROK_KP1",           /* 257 */
+"RETROK_KP2",           /* 258 */
+"RETROK_KP3",           /* 259 */
+"RETROK_KP4",           /* 260 */
+"RETROK_KP5",           /* 261 */
+"RETROK_KP6",           /* 262 */
+"RETROK_KP7",           /* 263 */
+"RETROK_KP8",           /* 264 */
+"RETROK_KP9",           /* 265 */
+"RETROK_KP_PERIOD",     /* 266 */
+"RETROK_KP_DIVIDE",     /* 267 */
+"RETROK_KP_MULTIPLY",   /* 268 */
+"RETROK_KP_MINUS",      /* 269 */
+"RETROK_KP_PLUS",       /* 270 */
+"RETROK_KP_ENTER",      /* 271 */
+"RETROK_KP_EQUALS",     /* 272 */
+"RETROK_UP",            /* 273 */
+"RETROK_DOWN",          /* 274 */
+"RETROK_RIGHT",         /* 275 */
+"RETROK_LEFT",          /* 276 */
+"RETROK_INSERT",        /* 277 */
+"RETROK_HOME",          /* 278 */
+"RETROK_END",           /* 279 */
+"RETROK_PAGEUP",        /* 280 */
+"RETROK_PAGEDOWN",      /* 281 */
+"RETROK_F1",            /* 282 */
+"RETROK_F2",            /* 283 */
+"RETROK_F3",            /* 284 */
+"RETROK_F4",            /* 285 */
+"RETROK_F5",            /* 286 */
+"RETROK_F6",            /* 287 */
+"RETROK_F7",            /* 288 */
+"RETROK_F8",            /* 289 */
+"RETROK_F9",            /* 290 */
+"RETROK_F10",           /* 291 */
+"RETROK_F11",           /* 292 */
+"RETROK_F12",           /* 293 */
+/*"RETROK_F13",*/       /* 294 */
+/*"RETROK_F14",*/       /* 295 */
+/*"RETROK_F15",*/       /* 296 */
+/*"RETROK_NUMLOCK",*/   /* 300 */
+/*"RETROK_CAPSLOCK",*/  /* 301 */
+/*"RETROK_SCROLLOCK",*/ /* 302 */
+"RETROK_RSHIFT",        /* 303 */
+"RETROK_LSHIFT",        /* 304 */
+"RETROK_RCTRL",         /* 305 */
+"RETROK_LCTRL",         /* 306 */
+"RETROK_RALT",          /* 307 */
+"RETROK_LALT",          /* 308 */
+"RETROK_RMETA",         /* 309 */
+"RETROK_LMETA",         /* 310 */
+/*"RETROK_LSUPER",*/    /* 311 */
+/*"RETROK_RSUPER",*/    /* 312 */
+"RETROK_MODE",          /* 313 */
+"RETROK_COMPOSE",       /* 314 */
+"RETROK_HELP",          /* 315 */
+/*"RETROK_PRINT",*/     /* 316 */
+/*"RETROK_SYSREQ",*/    /* 317 */
+/*"RETROK_BREAK",*/     /* 318 */
+/*"RETROK_MENU",*/      /* 319 */
+/*"RETROK_POWER",*/     /* 320 */
+/*"RETROK_EURO",*/      /* 321 */
+/*"RETROK_UNDO",*/      /* 322 */
 NULL
 };
 
-int keyVal[] = {
+static int retro_key_value[] = {
 0,
 -11,
 -12,
@@ -162,16 +162,16 @@ int keyVal[] = {
 -8,
 8,
 9,
-//12,
+/*12,*/
 13,
-//19,
+/*19,*/
 27,
 32,
-//33,
-//34,
-//35,
-//36,
-//38,
+/*33,*/
+/*34,*/
+/*35,*/
+/*36,*/
+/*38,*/
 39,
 40,
 41,
@@ -196,8 +196,8 @@ int keyVal[] = {
 60,
 61,
 62,
-//63,
-//64,
+/*63,*/
+/*64,*/
 91,
 92,
 93,
@@ -269,12 +269,12 @@ int keyVal[] = {
 291,
 292,
 293,
-//294,
-//295,
-//296,
-//300,
-//301,
-//302,
+/*294,*/
+/*295,*/
+/*296,*/
+/*300,*/
+/*301,*/
+/*302,*/
 303,
 304,
 305,
@@ -283,319 +283,17 @@ int keyVal[] = {
 308,
 309,
 310,
-//311,
-//312,
+/*311,*/
+/*312,*/
 313,
 314,
 315,
-//316,
-//317,
-//318,
-//319,
-//320,
-//321,
-//322,
--1
-};
-
-
-
-const char* keyDescHotkeys[] = {
-"---",//0,
-//"TOGGLE_VKBD",//-11,
-//"TOGGLE_STATUSBAR",//-12,
-//"SWITCH_JOYMOUSE",//-13,
-//"MOUSE_LEFT_BUTTON",//-2,
-//"MOUSE_RIGHT_BUTTON",//-3,
-//"MOUSE_MIDDLE_BUTTON",//-4,
-//"MOUSE_SLOWER",//-5,
-//"MOUSE_FASTER",//-6,
-//"JOYSTICK_FIRE",//-7
-//"JOYSTICK_2ND_FIRE",//-8
-"RETROK_BACKSPACE",//8,
-"RETROK_TAB",//9,
-//"RETROK_CLEAR",//12,
-"RETROK_RETURN",//13,
-//"RETROK_PAUSE",//19,
-"RETROK_ESCAPE",//27,
-"RETROK_SPACE",//32,
-//"RETROK_EXCLAIM",//33,
-//"RETROK_QUOTEDBL",//34,
-//"RETROK_HASH",//35,
-//"RETROK_DOLLAR",//36,
-//"RETROK_AMPERSAND",//38,
-"RETROK_QUOTE",//39,
-"RETROK_LEFTPAREN",//40,
-"RETROK_RIGHTPAREN",//41,
-"RETROK_ASTERISK",//42,
-"RETROK_PLUS",//43,
-"RETROK_COMMA",//44,
-"RETROK_MINUS",//45,
-"RETROK_PERIOD",//46,
-"RETROK_SLASH",//47,
-"RETROK_0",//48,
-"RETROK_1",//49,
-"RETROK_2",//50,
-"RETROK_3",//51,
-"RETROK_4",//52,
-"RETROK_5",//53,
-"RETROK_6",//54,
-"RETROK_7",//55,
-"RETROK_8",//56,
-"RETROK_9",//57,
-"RETROK_COLON",//58,
-"RETROK_SEMICOLON",//59,
-"RETROK_LESS",//60,
-"RETROK_EQUALS",//61,
-"RETROK_GREATER",//62,
-//"RETROK_QUESTION",//63,
-//"RETROK_AT",//64,
-"RETROK_LEFTBRACKET",//91,
-"RETROK_BACKSLASH",//92,
-"RETROK_RIGHTBRACKET",//93,
-"RETROK_CARET",//94,
-"RETROK_UNDERSCORE",//95,
-"RETROK_BACKQUOTE",//96,
-"RETROK_a",//97,
-"RETROK_b",//98,
-"RETROK_c",//99,
-"RETROK_d",//100,
-"RETROK_e",//101,
-"RETROK_f",//102,
-"RETROK_g",//103,
-"RETROK_h",//104,
-"RETROK_i",//105,
-"RETROK_j",//106,
-"RETROK_k",//107,
-"RETROK_l",//108,
-"RETROK_m",//109,
-"RETROK_n",//110,
-"RETROK_o",//111,
-"RETROK_p",//112,
-"RETROK_q",//113,
-"RETROK_r",//114,
-"RETROK_s",//115,
-"RETROK_t",//116,
-"RETROK_u",//117,
-"RETROK_v",//118,
-"RETROK_w",//119,
-"RETROK_x",//120,
-"RETROK_y",//121,
-"RETROK_z",//122,
-"RETROK_DELETE",//127,
-"RETROK_KP0",//256,
-"RETROK_KP1",//257,
-"RETROK_KP2",//258,
-"RETROK_KP3",//259,
-"RETROK_KP4",//260,
-"RETROK_KP5",//261,
-"RETROK_KP6",//262,
-"RETROK_KP7",//263,
-"RETROK_KP8",//264,
-"RETROK_KP9",//265,
-"RETROK_KP_PERIOD",//266,
-"RETROK_KP_DIVIDE",//267,
-"RETROK_KP_MULTIPLY",//268,
-"RETROK_KP_MINUS",//269,
-"RETROK_KP_PLUS",//270,
-"RETROK_KP_ENTER",//271,
-"RETROK_KP_EQUALS",//272,
-"RETROK_UP",//273,
-"RETROK_DOWN",//274,
-"RETROK_RIGHT",//275,
-"RETROK_LEFT",//276,
-"RETROK_INSERT",//277,
-"RETROK_HOME",//278,
-"RETROK_END",//279,
-"RETROK_PAGEUP",//280,
-"RETROK_PAGEDOWN",//281,
-"RETROK_F1",//282,
-"RETROK_F2",//283,
-"RETROK_F3",//284,
-"RETROK_F4",//285,
-"RETROK_F5",//286,
-"RETROK_F6",//287,
-"RETROK_F7",//288,
-"RETROK_F8",//289,
-"RETROK_F9",//290,
-"RETROK_F10",//291,
-"RETROK_F11",//292,
-"RETROK_F12",//293,
-//"RETROK_F13",//294,
-//"RETROK_F14",//295,
-//"RETROK_F15",//296,
-//"RETROK_NUMLOCK",//300,
-//"RETROK_CAPSLOCK",//301,
-//"RETROK_SCROLLOCK",//302,
-"RETROK_RSHIFT",//303,
-"RETROK_LSHIFT",//304,
-"RETROK_RCTRL",//305,
-"RETROK_LCTRL",//306,
-"RETROK_RALT",//307,
-"RETROK_LALT",//308,
-"RETROK_RMETA",//309,
-"RETROK_LMETA",//310,
-//"RETROK_LSUPER",//311,
-//"RETROK_RSUPER",//312,
-"RETROK_MODE",//313,
-"RETROK_COMPOSE",//314,
-"RETROK_HELP",//315,
-//"RETROK_PRINT",//316,
-//"RETROK_SYSREQ",//317,
-//"RETROK_BREAK",//318,
-//"RETROK_MENU",//319,
-//"RETROK_POWER",//320,
-//"RETROK_EURO",//321,
-//"RETROK_UNDO",//322,
-NULL
-};
-
-int keyValHotkeys[] = {
-0,
-//-11,
-//-12,
-//-13,
-//-2,
-//-3,
-//-4,
-//-5,
-//-6,
-//-7,
-//-8,
-8,
-9,
-//12,
-13,
-//19,
-27,
-32,
-//33,
-//34,
-//35,
-//36,
-//38,
-39,
-40,
-41,
-42,
-43,
-44,
-45,
-46,
-47,
-48,
-49,
-50,
-51,
-52,
-53,
-54,
-55,
-56,
-57,
-58,
-59,
-60,
-61,
-62,
-//63,
-//64,
-91,
-92,
-93,
-94,
-95,
-96,
-97,
-98,
-99,
-100,
-101,
-102,
-103,
-104,
-105,
-106,
-107,
-108,
-109,
-110,
-111,
-112,
-113,
-114,
-115,
-116,
-117,
-118,
-119,
-120,
-121,
-122,
-127,
-256,
-257,
-258,
-259,
-260,
-261,
-262,
-263,
-264,
-265,
-266,
-267,
-268,
-269,
-270,
-271,
-272,
-273,
-274,
-275,
-276,
-277,
-278,
-279,
-280,
-281,
-282,
-283,
-284,
-285,
-286,
-287,
-288,
-289,
-290,
-291,
-292,
-293,
-//294,
-//295,
-//296,
-//300,
-//301,
-//302,
-303,
-304,
-305,
-306,
-307,
-308,
-309,
-310,
-//311,
-//312,
-313,
-314,
-315,
-//316,
-//317,
-//318,
-//319,
-//320,
-//321,
-//322,
+/*316,*/
+/*317,*/
+/*318,*/
+/*319,*/
+/*320,*/
+/*321,*/
+/*322,*/
 -1
 };

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -39,12 +39,21 @@ void gettimeofday (struct timeval *tv, void *blah)
 #include <time.h>
 #endif
 
-/* Mouse speed flags */
-#define MOUSE_SPEED_SLOWER 1
-#define MOUSE_SPEED_FASTER 2
-/* Mouse speed multipliers */
-#define MOUSE_SPEED_SLOW 5
-#define MOUSE_SPEED_FAST 2
+extern char retro_key_state[RETROK_LAST];
+extern char retro_key_state_old[RETROK_LAST];
+
+static retro_input_state_t input_state_cb;
+static retro_input_poll_t input_poll_cb;
+
+void retro_set_input_state(retro_input_state_t cb)
+{
+   input_state_cb = cb;
+}
+
+void retro_set_input_poll(retro_input_poll_t cb)
+{
+   input_poll_cb = cb;
+}
 
 #ifdef POINTER_DEBUG
 int pointer_x = 0;
@@ -60,6 +69,14 @@ int vkbd_x_max = 0;
 int vkbd_y_min = 0;
 int vkbd_y_max = 0;
 
+/* Mouse speed flags */
+#define MOUSE_SPEED_SLOWER 1
+#define MOUSE_SPEED_FASTER 2
+/* Mouse speed multipliers */
+#define MOUSE_SPEED_SLOW 5
+#define MOUSE_SPEED_FAST 2
+
+/* Core flags */
 int vkflag[9] = {0};
 int retro_capslock = false;
 bool retro_mousemode = false;
@@ -73,7 +90,6 @@ static int jbt[2][24] = {0};
 static int kbt[16] = {0};
 static int mapper_flag[4][16] = {0};
 
-extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
 extern void retro_reset_soft();
 extern bool retro_statusbar;
 extern bool retro_vkbd;
@@ -200,22 +216,6 @@ void emu_function(int function)
          }
          break;
    }
-}
-
-extern char retro_key_state[RETROK_LAST];
-extern char retro_key_state_old[RETROK_LAST];
-
-static retro_input_state_t input_state_cb;
-static retro_input_poll_t input_poll_cb;
-
-void retro_set_input_state(retro_input_state_t cb)
-{
-   input_state_cb = cb;
-}
-
-void retro_set_input_poll(retro_input_poll_t cb)
-{
-   input_poll_cb = cb;
 }
 
 #ifdef WIIU

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -518,8 +518,8 @@ void print_statusbar(void)
    snprintf(RESOLUTION, sizeof(RESOLUTION), "%4dx%3d", zoomed_width, zoomed_height);
 
    // Model & memory
-   int STAT_X_MODEL  = STAT_X + (FONT_SLOT*6) + (FONT_WIDTH*30) - ZOOMED_WIDTH_OFFSET;
-   int STAT_X_MEMORY = STAT_X + (FONT_SLOT*6) + (FONT_WIDTH*5) - ZOOMED_WIDTH_OFFSET;
+   int STAT_X_MODEL  = STAT_X + (FONT_SLOT*6) + (FONT_WIDTH*32) - ZOOMED_WIDTH_OFFSET;
+   int STAT_X_MEMORY = STAT_X + (FONT_SLOT*6) + (FONT_WIDTH*6) - ZOOMED_WIDTH_OFFSET;
    // Sacrifice memory slot if there is not enough width
    if (!(video_config & PUAE_VIDEO_DOUBLELINE))
    {

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -23,14 +23,14 @@
 #include "sys/timer.h"
 #include <sys/time.h>
 #include <time.h>
-#define usleep  sys_timer_usleep
+#define usleep sys_timer_usleep
 
 void gettimeofday (struct timeval *tv, void *blah)
 {
    int64_t time = sys_time_get_system_time();
 
    tv->tv_sec  = time / 1000000;
-   tv->tv_usec = time - (tv->tv_sec * 1000000);  // implicit rounding will take care of this for us
+   tv->tv_usec = time - (tv->tv_sec * 1000000); /* implicit rounding will take care of this for us */
 }
 
 #else
@@ -39,24 +39,12 @@ void gettimeofday (struct timeval *tv, void *blah)
 #include <time.h>
 #endif
 
-// Mouse speed flags
+/* Mouse speed flags */
 #define MOUSE_SPEED_SLOWER 1
 #define MOUSE_SPEED_FASTER 2
-// Mouse speed multipliers
+/* Mouse speed multipliers */
 #define MOUSE_SPEED_SLOW 5
 #define MOUSE_SPEED_FAST 2
-
-int NPAGE = -1;
-int SHIFTON = -1;
-int STATUSON = -1;
-int LEDON = -1;
-int MOUSEMODE = -1;
-int SHOWKEY = -1;
-int SHOWKEYPOS = -1;
-int SHOWKEYTRANS = 1;
-
-unsigned int mouse_speed[2] = {0};
-extern void retro_reset_soft();
 
 #ifdef POINTER_DEBUG
 int pointer_x = 0;
@@ -73,6 +61,10 @@ int vkbd_y_min = 0;
 int vkbd_y_max = 0;
 
 int vkflag[9] = {0};
+int retro_capslock = false;
+bool retro_mousemode = false;
+bool mousemode_locked = false;
+static unsigned int mouse_speed[2] = {0};
 static int jflag[4][16] = {0};
 static int kjflag[2][16] = {0};
 static int mflag[2][16] = {0};
@@ -82,6 +74,12 @@ static int kbt[16] = {0};
 static int mapper_flag[4][16] = {0};
 
 extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
+extern void retro_reset_soft();
+extern bool retro_statusbar;
+extern bool retro_vkbd;
+extern bool retro_vkbd_page;
+extern bool retro_vkbd_position;
+extern bool retro_vkbd_transparent;
 extern void retro_key_up(int);
 extern void retro_key_down(int);
 extern void retro_mouse(int, int, int);
@@ -99,7 +97,6 @@ extern bool request_update_av_info;
 extern bool request_reset_drawing;
 extern int opt_statusbar;
 extern int opt_statusbar_position;
-extern bool mousemode_locked;
 extern unsigned int opt_analogmouse;
 extern unsigned int opt_analogmouse_deadzone;
 extern float opt_analogmouse_speed;
@@ -152,17 +149,16 @@ void emu_function(int function)
    switch (function)
    {
       case EMU_VKBD:
-         SHOWKEY = -SHOWKEY;
+         retro_vkbd = !retro_vkbd;
          break;
       case EMU_STATUSBAR:
-         STATUSON = -STATUSON;
-         LEDON = -LEDON;
+         retro_statusbar = !retro_statusbar;
          request_reset_drawing = true;
          break;
       case EMU_MOUSE_TOGGLE:
          mousemode_locked = true;
-         MOUSEMODE = -MOUSEMODE;
-         // Reset flags to prevent sticky keys
+         retro_mousemode = !retro_mousemode;
+         /* Reset flags to prevent sticky keys */
          memset(jflag, 0, 2*16*sizeof jflag[0][0]);
          break;
       case EMU_RESET:
@@ -245,18 +241,18 @@ long GetTicks(void)
 static char* joystick_value_human(int val[16], int uae_device)
 {
    /*
-      uae_device:
-      0 = Single button joystick (Keyrah + Parallel)
-      1 = RetroPad
-      2 = CD32 Pad
-      3 = Mouse
-      4 = Analog joystick
-   */
+    * uae_device:
+    * 0 = Single button joystick (Keyrah + Parallel)
+    * 1 = RetroPad
+    * 2 = CD32 Pad
+    * 3 = Mouse
+    * 4 = Analog joystick
+    */
 
    static char str[4] = {0};
    sprintf(str, "%3s", "   ");
 
-   if (val[RETRO_DEVICE_ID_JOYPAD_UP] || val[RETRO_DEVICE_ID_JOYPAD_SELECT]) // Unused SELECT acts as a jump button
+   if (val[RETRO_DEVICE_ID_JOYPAD_UP] || val[RETRO_DEVICE_ID_JOYPAD_SELECT]) /* Unused SELECT acts as a jump button */
       str[1] = 30;
 
    else if (val[RETRO_DEVICE_ID_JOYPAD_DOWN])
@@ -501,26 +497,28 @@ void print_statusbar(void)
    int STAT_BASEY           = 0;
    int TEXT_LENGTH          = (video_config & PUAE_VIDEO_DOUBLELINE) ? 100 : 43;
 
-   // Statusbar location
-   if (opt_statusbar_position < 0) // Top
+   /* Statusbar location */
+   /* Top */
+   if (opt_statusbar_position < 0)
       STAT_BASEY = BOX_PADDING;
-   else // Bottom
+   /* Bottom */
+   else
       STAT_BASEY = gfxvidinfo.outheight - opt_statusbar_position - BOX_HEIGHT + BOX_PADDING;
    BOX_Y = STAT_BASEY - BOX_PADDING;
 
-   // Statusbar size
+   /* Statusbar size */
    BOX_WIDTH = zoomed_width;
    int ZOOMED_WIDTH_OFFSET = retrow - zoomed_width;
 
-   // Video resolution
+   /* Video resolution */
    int STAT_X_RESOLUTION = STAT_X + (FONT_SLOT*4) + (FONT_WIDTH*16) - (ZOOMED_WIDTH_OFFSET/2);
    char RESOLUTION[10] = {0};
    snprintf(RESOLUTION, sizeof(RESOLUTION), "%4dx%3d", zoomed_width, zoomed_height);
 
-   // Model & memory
+   /* Model & memory */
    int STAT_X_MODEL  = STAT_X + (FONT_SLOT*6) + (FONT_WIDTH*32) - ZOOMED_WIDTH_OFFSET;
    int STAT_X_MEMORY = STAT_X + (FONT_SLOT*6) + (FONT_WIDTH*6) - ZOOMED_WIDTH_OFFSET;
-   // Sacrifice memory slot if there is not enough width
+   /* Sacrifice memory slot if there is not enough width */
    if (!(video_config & PUAE_VIDEO_DOUBLELINE))
    {
       if (STAT_X_MEMORY < (STAT_X_RESOLUTION + FONT_SLOT + (FONT_WIDTH*20)))
@@ -560,7 +558,7 @@ void print_statusbar(void)
          break;
    }
 
-   // Double line positions
+   /* Double line positions */
    if (video_config & PUAE_VIDEO_DOUBLELINE)
    {
       STAT_X_RESOLUTION = STAT_X + (FONT_SLOT*15) + (FONT_WIDTH*5) - ZOOMED_WIDTH_OFFSET;
@@ -568,7 +566,7 @@ void print_statusbar(void)
       STAT_X_MEMORY     = STAT_X + (FONT_SLOT*16) + (FONT_WIDTH*25) - ZOOMED_WIDTH_OFFSET;
    }
 
-   // Joy port indicators
+   /* Joy port indicators */
    char JOYPORT1[10] = {0};
    char JOYPORT2[10] = {0};
    char JOYPORT3[10] = {0};
@@ -577,8 +575,8 @@ void print_statusbar(void)
    char JOYMODE1[5] = {0};
    char JOYMODE2[5] = {0};
 
-   // Regular joyflags
-   if (MOUSEMODE == -1)
+   /* Regular joyflags */
+   if (!retro_mousemode)
    {
        sprintf(JOYMODE1, "%2s", "J1");
        sprintf(JOYMODE2, "%2s", "J2");
@@ -589,11 +587,11 @@ void print_statusbar(void)
        sprintf(JOYMODE2, "%2s", "M2");
    }
 
-   // Normal ports
+   /* Normal ports */
    sprintf(JOYPORT1, "%2s%3s", JOYMODE1, joystick_value_human(jflag[0], (uae_devices[0] == RETRO_DEVICE_UAE_CD32PAD) ? 2 : 1));
    sprintf(JOYPORT2, "%2s%3s", JOYMODE2, joystick_value_human(jflag[1], (uae_devices[1] == RETRO_DEVICE_UAE_CD32PAD) ? 2 : 1));
 
-   // Parallel ports, hidden if not connected
+   /* Parallel ports, hidden if not connected */
    if (uae_devices[2])
       sprintf(JOYPORT3, "J3%3s", joystick_value_human(jflag[2], 0));
    else
@@ -603,19 +601,19 @@ void print_statusbar(void)
    else
       sprintf(JOYPORT4, "%5s", "");
 
-   // Mouse flags
+   /* Mouse flags */
    if (!flag_empty(mflag[1]))
       sprintf(JOYPORT1, "%2s%3s", "M1", joystick_value_human(mflag[1], 3));
    if (!flag_empty(mflag[0]))
       sprintf(JOYPORT2, "%2s%3s", "M2", joystick_value_human(mflag[0], 3));
 
-   // Analog flags
+   /* Analog flags */
    if (!flag_empty(aflag[0]) && uae_devices[0] == RETRO_DEVICE_UAE_ANALOG)
       sprintf(JOYPORT1, "%2s%3s", "A1", joystick_value_human(aflag[0], 4));
    if (!flag_empty(aflag[1]) && uae_devices[1] == RETRO_DEVICE_UAE_ANALOG)
       sprintf(JOYPORT2, "%2s%3s", "A2", joystick_value_human(aflag[1], 4));
 
-   // Keyrah joyflags
+   /* Keyrah joyflags */
    if (opt_keyrah_keypad)
    {
       if (!flag_empty(kjflag[0]))
@@ -624,7 +622,7 @@ void print_statusbar(void)
          sprintf(JOYPORT2, "%2s%3s", "K2", joystick_value_human(kjflag[1], 0));
    }
 
-   // Button colorize CD32 Pad
+   /* Button colorize CD32 Pad */
    bool JOYPORT1_COLORIZE = false;
    bool JOYPORT2_COLORIZE = false;
    if (uae_devices[0] == RETRO_DEVICE_UAE_CD32PAD)
@@ -632,7 +630,7 @@ void print_statusbar(void)
    if (uae_devices[1] == RETRO_DEVICE_UAE_CD32PAD)
       JOYPORT2_COLORIZE = true;
 
-   // Statusbar output
+   /* Statusbar output */
    if (pix_bytes == 4)
    {
       DrawFBoxBmp32((uint32_t *)retro_bmp, 0, BOX_Y, BOX_WIDTH, BOX_HEIGHT, RGB888(0,0,0), 255);
@@ -845,10 +843,10 @@ static int retro_button_to_uae_button(int retro_port, int i)
 {
    int uae_button = -1;
 
-   // CD32 Pad
+   /* CD32 Pad */
    if (uae_devices[retro_port] == RETRO_DEVICE_UAE_CD32PAD)
    {
-      // Face button rotate
+      /* Face button rotate */
       if (opt_cd32pad_options == 1 || opt_cd32pad_options == 3)
       {
          switch (i)
@@ -876,7 +874,7 @@ static int retro_button_to_uae_button(int retro_port, int i)
                break;
          }
       }
-      // Face button normal
+      /* Face button normal */
       else
       {
          switch (i)
@@ -904,16 +902,16 @@ static int retro_button_to_uae_button(int retro_port, int i)
                break;
          }
       }
-      // Face button jump
+      /* Face button jump */
       if (opt_cd32pad_options == 2 && i == RETRO_DEVICE_ID_JOYPAD_A)
          uae_button = -2;
       else if (opt_cd32pad_options == 3 && i == RETRO_DEVICE_ID_JOYPAD_B)
          uae_button = -2;
    }
-   // RetroPad + Joystick
+   /* RetroPad + Joystick */
    else if (uae_devices[retro_port] == RETRO_DEVICE_JOYPAD || uae_devices[retro_port] == RETRO_DEVICE_UAE_JOYSTICK)
    {
-      // Face button rotate
+      /* Face button rotate */
       if (opt_retropad_options == 1 || opt_retropad_options == 3)
       {
          switch (i)
@@ -932,7 +930,7 @@ static int retro_button_to_uae_button(int retro_port, int i)
                break;
          }
       }
-      // Face button normal
+      /* Face button normal */
       else
       {
          switch (i)
@@ -951,13 +949,13 @@ static int retro_button_to_uae_button(int retro_port, int i)
                break;
          }
       }
-      // Face button jump
+      /* Face button jump */
       if (opt_retropad_options == 2 && i == RETRO_DEVICE_ID_JOYPAD_A)
          uae_button = -2;
       else if (opt_retropad_options == 3 && i == RETRO_DEVICE_ID_JOYPAD_B)
          uae_button = -2;
    }
-   // Analog joystick
+   /* Analog joystick */
    else
    {
       switch (i)
@@ -985,12 +983,12 @@ static void process_controller(int retro_port, int i)
    int retro_port_uae = opt_joyport_order[retro_port] - 49;
    int uae_button = -1;
 
-   if (i > 3 && i < 8) // Directions, need to fight around presses on the same axis
+   if (i > 3 && i < 8) /* Directions, need to fight around presses on the same axis */
    {
       if ((i == RETRO_DEVICE_ID_JOYPAD_UP || i == RETRO_DEVICE_ID_JOYPAD_DOWN)
       && !jflag[retro_port][RETRO_DEVICE_ID_JOYPAD_SELECT])
       {
-         if (i == RETRO_DEVICE_ID_JOYPAD_UP && SHOWKEY == -1)
+         if (i == RETRO_DEVICE_ID_JOYPAD_UP && !retro_vkbd)
          {
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN)
@@ -1001,7 +999,7 @@ static void process_controller(int retro_port, int i)
             }
          }
          else
-         if (i == RETRO_DEVICE_ID_JOYPAD_DOWN && SHOWKEY == -1)
+         if (i == RETRO_DEVICE_ID_JOYPAD_DOWN && !retro_vkbd)
          {
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP)
@@ -1031,7 +1029,7 @@ static void process_controller(int retro_port, int i)
 
       if (i == RETRO_DEVICE_ID_JOYPAD_LEFT || i == RETRO_DEVICE_ID_JOYPAD_RIGHT)
       {
-         if (i == RETRO_DEVICE_ID_JOYPAD_LEFT && SHOWKEY == -1)
+         if (i == RETRO_DEVICE_ID_JOYPAD_LEFT && !retro_vkbd)
          {
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))
@@ -1041,7 +1039,7 @@ static void process_controller(int retro_port, int i)
             }
          }
          else
-         if (i == RETRO_DEVICE_ID_JOYPAD_RIGHT && SHOWKEY == -1)
+         if (i == RETRO_DEVICE_ID_JOYPAD_RIGHT && !retro_vkbd)
          {
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
             && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))
@@ -1066,17 +1064,17 @@ static void process_controller(int retro_port, int i)
          }
       }
    }
-   else if (i != turbo_fire_button) // Buttons
+   else if (i != turbo_fire_button) /* Buttons */
    {
       uae_button = retro_button_to_uae_button(retro_port, i);
 
-      // Alternative jump button, hijack SELECT flag
+      /* Alternative jump button, hijack Select flag */
       if (uae_button == -2)
       {
          if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
-         && !jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT] && SHOWKEY == -1)
+         && !jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT] && !retro_vkbd)
          {
-            // Skip RetroPad face button handling if keymapped
+            /* Skip RetroPad face button handling if keymapped */
             if (uae_devices[retro_port] == RETRO_DEVICE_JOYPAD
             && mapper_keys[i]
             && (i == RETRO_DEVICE_ID_JOYPAD_A
@@ -1094,7 +1092,7 @@ static void process_controller(int retro_port, int i)
          && !input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP)
          && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT])
          {
-            // Skip RetroPad face button handling if keymapped
+            /* Skip RetroPad face button handling if keymapped */
             if (uae_devices[retro_port] == RETRO_DEVICE_JOYPAD
             && mapper_keys[i]
             && (i == RETRO_DEVICE_ID_JOYPAD_A
@@ -1108,13 +1106,13 @@ static void process_controller(int retro_port, int i)
             jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT] = 0;
          }
       }
-      // Normal button
+      /* Normal button */
       else if (uae_button != -1)
       {
          if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
-         && !jflag[retro_port_uae][i] && SHOWKEY == -1)
+         && !jflag[retro_port_uae][i] && !retro_vkbd)
          {
-            // Skip RetroPad face button handling if keymapped
+            /* Skip RetroPad face button handling if keymapped */
             if ((uae_devices[retro_port] == RETRO_DEVICE_JOYPAD
               || uae_devices[retro_port] == RETRO_DEVICE_UAE_ANALOG)
             && mapper_keys[i]
@@ -1123,7 +1121,7 @@ static void process_controller(int retro_port, int i)
              || i == RETRO_DEVICE_ID_JOYPAD_X
              || i == RETRO_DEVICE_ID_JOYPAD_Y
             ))
-               ;// no-op
+               ;/* no-op */
             else
             {
                retro_joystick_button(retro_port_uae, uae_button, 1);
@@ -1135,7 +1133,7 @@ static void process_controller(int retro_port, int i)
          if (!input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, i)
          && jflag[retro_port_uae][i] && !mapper_flag[retro_port][i])
          {
-            // Skip RetroPad face button handling if keymapped
+            /* Skip RetroPad face button handling if keymapped */
             if ((uae_devices[retro_port] == RETRO_DEVICE_JOYPAD
               || uae_devices[retro_port] == RETRO_DEVICE_UAE_ANALOG)
             && mapper_keys[i]
@@ -1144,7 +1142,7 @@ static void process_controller(int retro_port, int i)
              || i == RETRO_DEVICE_ID_JOYPAD_X
              || i == RETRO_DEVICE_ID_JOYPAD_Y
             ))
-               ;// no-op
+               ;/* no-op */
             else
             {
                retro_joystick_button(retro_port_uae, uae_button, 0);
@@ -1161,7 +1159,7 @@ static void process_turbofire(int retro_port, int i)
    int retro_port_uae = opt_joyport_order[retro_port] - 49;
    int retro_fire_button = RETRO_DEVICE_ID_JOYPAD_B;
 
-   // Face button rotate correction for statusbar flag
+   /* Face button rotate correction for statusbar flag */
    if ((uae_devices[retro_port] == RETRO_DEVICE_JOYPAD && (opt_retropad_options == 1 || opt_retropad_options == 3))
     || (uae_devices[retro_port] == RETRO_DEVICE_UAE_CD32PAD && (opt_cd32pad_options == 1 || opt_cd32pad_options == 3)))
       retro_fire_button = RETRO_DEVICE_ID_JOYPAD_Y;
@@ -1220,7 +1218,7 @@ static void process_key(int disable_physical_cursor_keys)
          {
             retro_key_down(keyboard_translation[i]);
             retro_key_up(keyboard_translation[i]);
-            SHIFTON = -SHIFTON;
+            retro_capslock = !retro_capslock;
             retro_key_state_old[i] = 1;
          }
          else if (!retro_key_state[i] && retro_key_state_old[i])
@@ -1254,10 +1252,10 @@ static void process_key(int disable_physical_cursor_keys)
          if (retro_key_state[i] && !retro_key_state_old[i])
          {
             /* Skip keydown if VKBD is active */
-            if (SHOWKEY == 1)
+            if (retro_vkbd)
                continue;
 
-            if (SHIFTON == 1)
+            if (retro_capslock)
                retro_key_down(keyboard_translation[RETROK_LSHIFT]);
 
             retro_key_down(keyboard_translation[i]);
@@ -1268,7 +1266,7 @@ static void process_key(int disable_physical_cursor_keys)
             retro_key_up(keyboard_translation[i]);
             retro_key_state_old[i] = 0;
 
-            if (SHIFTON == 1)
+            if (retro_capslock)
                retro_key_up(keyboard_translation[RETROK_LSHIFT]);
          }
       }
@@ -1277,8 +1275,9 @@ static void process_key(int disable_physical_cursor_keys)
 
 void update_input(int disable_physical_cursor_keys)
 {
-   // RETRO    B   Y   SLT STA UP  DWN LFT RGT A   X   L   R   L2  R2  L3  R3  LR  LL  LD  LU  RR  RL  RD  RU
-   // INDEX    0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15  16  17  18  19  20  21  22  23
+   /* RETRO    B   Y   SLT STA UP  DWN LFT RGT A   X   L   R   L2  R2  L3  R3  LR  LL  LD  LU  RR  RL  RD  RU
+    * INDEX    0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15  16  17  18  19  20  21  22  23
+    */
 
    static long now = 0;
    static long last_vkey_pressed_time = 0;
@@ -1330,7 +1329,7 @@ void update_input(int disable_physical_cursor_keys)
          if (vkey_pressed == -1 && last_vkey_pressed >= 0 && last_vkey_pressed != vkey_sticky1 && last_vkey_pressed != vkey_sticky2)
             retro_key_up(last_vkey_pressed);
 
-         if (SHIFTON == 1)
+         if (retro_capslock)
             retro_key_up(keyboard_translation[RETROK_LSHIFT]);
       }
 
@@ -1392,7 +1391,7 @@ void update_input(int disable_physical_cursor_keys)
    
 
    /* The check for kbt[i] here prevents the hotkey from generating key events */
-   /* SHOWKEY check is now in process_key() to allow certain keys while SHOWKEY */
+   /* retro_vkbd check is now in process_key() to allow certain keys while retro_vkbd */
    int processkey = 1;
    for (i = 0; i < (sizeof(kbt)/sizeof(kbt[0])); i++)
    {
@@ -1443,7 +1442,7 @@ void update_input(int disable_physical_cursor_keys)
                }
 
                /* Skip the VKBD buttons if VKBD is visible and buttons are mapped to keyboard keys */
-               if (SHOWKEY == 1)
+               if (retro_vkbd)
                {
                   switch (i)
                   {
@@ -1627,9 +1626,9 @@ void update_input(int disable_physical_cursor_keys)
    } /* for j */
 
    /* Virtual keyboard for ports 1 & 2 */
-   if (SHOWKEY == 1)
+   if (retro_vkbd)
    {
-      // Mouse acceleration
+      /* Mouse acceleration */
       const int mspeed_default = 3;
       static int mspeed;
       if (!vkflag[4])
@@ -1693,12 +1692,12 @@ void update_input(int disable_physical_cursor_keys)
          let_go_of_direction = true;
 
       if (vkey_pos_x < 0)
-         vkey_pos_x = NPLGN-1;
-      else if (vkey_pos_x > NPLGN-1)
+         vkey_pos_x = VKBDX - 1;
+      else if (vkey_pos_x > VKBDX - 1)
          vkey_pos_x = 0;
       if (vkey_pos_y < 0)
-         vkey_pos_y = NLIGN-1;
-      else if (vkey_pos_y > NLIGN-1)
+         vkey_pos_y = VKBDY - 1;
+      else if (vkey_pos_y > VKBDY - 1)
          vkey_pos_y = 0;
 
       /* Absolute pointer */
@@ -1717,16 +1716,16 @@ void update_input(int disable_physical_cursor_keys)
 #endif
          if (px >= vkbd_x_min && px <= vkbd_x_max && py >= vkbd_y_min && py <= vkbd_y_max)
          {
-            float vkey_width = (float)(vkbd_x_max - vkbd_x_min) / NPLGN;
+            float vkey_width = (float)(vkbd_x_max - vkbd_x_min) / VKBDX;
             vkey_pos_x = ((px - vkbd_x_min) / vkey_width);
 
-            float vkey_height = (float)(vkbd_y_max - vkbd_y_min) / NLIGN;
+            float vkey_height = (float)(vkbd_y_max - vkbd_y_min) / VKBDY;
             vkey_pos_y = ((py - vkbd_y_min) / vkey_height);
 
             vkey_pos_x = (vkey_pos_x < 0) ? 0 : vkey_pos_x;
-            vkey_pos_x = (vkey_pos_x > NPLGN-1) ? NPLGN-1 : vkey_pos_x;
+            vkey_pos_x = (vkey_pos_x > VKBDX - 1) ? VKBDX - 1 : vkey_pos_x;
             vkey_pos_y = (vkey_pos_y < 0) ? 0 : vkey_pos_y;
-            vkey_pos_y = (vkey_pos_y > NLIGN-1) ? NLIGN-1 : vkey_pos_y;
+            vkey_pos_y = (vkey_pos_y > VKBDY - 1) ? VKBDY - 1 : vkey_pos_y;
 
 #ifdef POINTER_DEBUG
             printf("px:%d py:%d (%d,%d) vkey:%dx%d\n", p_x, p_y, px, py, vkey_pos_x, vkey_pos_y);
@@ -1752,7 +1751,7 @@ void update_input(int disable_physical_cursor_keys)
       if (!vkflag[7] && mapper_keys[i] >= 0 && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
          vkflag[7] = 1;
-         SHIFTON = -SHIFTON;
+         retro_capslock = !retro_capslock;
       }
       else if (vkflag[7] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
@@ -1764,7 +1763,7 @@ void update_input(int disable_physical_cursor_keys)
       if (!vkflag[6] && mapper_keys[i] >= 0 && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
          vkflag[6] = 1;
-         SHOWKEYPOS = -SHOWKEYPOS;
+         retro_vkbd_position = !retro_vkbd_position;
       }
       else if (vkflag[6] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
@@ -1776,7 +1775,7 @@ void update_input(int disable_physical_cursor_keys)
       if (!vkflag[5] && mapper_keys[i] >= 0 && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
          vkflag[5] = 1;
-         SHOWKEYTRANS = -SHOWKEYTRANS;
+         retro_vkbd_transparent = !retro_vkbd_transparent;
       }
       else if (vkflag[5] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, i)))
       {
@@ -1795,65 +1794,65 @@ void update_input(int disable_physical_cursor_keys)
          else if (vkey_pressed == -2)
          {
             last_vkey_pressed = -1;
-            NPAGE = -NPAGE;
+            retro_vkbd_page = !retro_vkbd_page;
          }
          else if (vkey_pressed < -10)
          {
             last_vkey_pressed = vkey_pressed;
             last_vkey_pressed_time = now;
 
-            if (vkey_pressed == -11) // Mouse up
+            if (vkey_pressed == -11) /* Mouse up */
             {
                retro_mouse(0, 0, -3);
                mflag[0][RETRO_DEVICE_ID_JOYPAD_UP] = 1;
             }
-            else if (vkey_pressed == -12) // Mouse down
+            else if (vkey_pressed == -12) /* Mouse down */
             {
                retro_mouse(0, 0, 3);
                mflag[0][RETRO_DEVICE_ID_JOYPAD_DOWN] = 1;
             }
-            else if (vkey_pressed == -13) // Mouse left
+            else if (vkey_pressed == -13) /* Mouse left */
             {
                retro_mouse(0, -3, 0);
                mflag[0][RETRO_DEVICE_ID_JOYPAD_LEFT] = 1;
             }
-            else if (vkey_pressed == -14) // Mouse right
+            else if (vkey_pressed == -14) /* Mouse right */
             {
                retro_mouse(0, 3, 0);
                mflag[0][RETRO_DEVICE_ID_JOYPAD_RIGHT] = 1;
             }
-            else if (vkey_pressed == -15) // LMB
+            else if (vkey_pressed == -15) /* LMB */
             {
                retro_mouse_button(0, 0, 1);
                mflag[0][RETRO_DEVICE_ID_JOYPAD_B] = 1;
             }
-            else if (vkey_pressed == -16) // RMB
+            else if (vkey_pressed == -16) /* RMB */
             {
                retro_mouse_button(0, 1, 1);
                mflag[0][RETRO_DEVICE_ID_JOYPAD_A] = 1;
             }
-            else if (vkey_pressed == -17) // MMB
+            else if (vkey_pressed == -17) /* MMB */
             {
                retro_mouse_button(0, 2, 1);
                mflag[0][RETRO_DEVICE_ID_JOYPAD_Y] = 1;
             }
-            else if (vkey_pressed == -18) // Toggle joystick/mouse
+            else if (vkey_pressed == -18) /* Toggle joystick/mouse */
             {
                emu_function(EMU_MOUSE_TOGGLE);
             }
-            else if (vkey_pressed == -19) // Toggle turbo fire
+            else if (vkey_pressed == -19) /* Toggle turbo fire */
             {
                emu_function(EMU_TURBO_FIRE_TOGGLE);
             }
-            else if (vkey_pressed == -20) // Reset
+            else if (vkey_pressed == -20) /* Reset */
             {
                emu_function(EMU_RESET);
             }
-            else if (vkey_pressed == -21) // Toggle statusbar
+            else if (vkey_pressed == -21) /* Toggle statusbar */
             {
                emu_function(EMU_STATUSBAR);
             }
-            else if (vkey_pressed == -22) // Toggle aspect ratio
+            else if (vkey_pressed == -22) /* Toggle aspect ratio */
             {
                emu_function(EMU_ASPECT_RATIO_TOGGLE);
             }
@@ -1864,13 +1863,13 @@ void update_input(int disable_physical_cursor_keys)
             {
                retro_key_down(vkey_pressed);
                retro_key_up(vkey_pressed);
-               SHIFTON = -SHIFTON;
+               retro_capslock = !retro_capslock;
                last_vkey_pressed = -1;
             }
             else
             {
                last_vkey_pressed = vkey_pressed;
-               if (SHIFTON == 1)
+               if (retro_capslock)
                   retro_key_down(keyboard_translation[RETROK_LSHIFT]);
 
                if (!vkey_sticky)
@@ -1893,13 +1892,13 @@ void update_input(int disable_physical_cursor_keys)
          {
             mspeed = mspeed_default;
 
-            if (vkey_pressed == -11) // Mouse up
+            if (vkey_pressed == -11) /* Mouse up */
                mflag[0][RETRO_DEVICE_ID_JOYPAD_UP] = 0;
-            else if (vkey_pressed == -12) // Mouse down
+            else if (vkey_pressed == -12) /* Mouse down */
                mflag[0][RETRO_DEVICE_ID_JOYPAD_DOWN] = 0;
-            else if (vkey_pressed == -13) // Mouse left
+            else if (vkey_pressed == -13) /* Mouse left */
                mflag[0][RETRO_DEVICE_ID_JOYPAD_LEFT] = 0;
-            else if (vkey_pressed == -14) // Mouse right
+            else if (vkey_pressed == -14) /* Mouse right */
                mflag[0][RETRO_DEVICE_ID_JOYPAD_RIGHT] = 0;
          }
       }
@@ -1911,13 +1910,13 @@ void update_input(int disable_physical_cursor_keys)
             last_vkey_pressed_time = now;
          }
 
-         if (vkey_pressed == -11) // Mouse up
+         if (vkey_pressed == -11) /* Mouse up */
             retro_mouse(0, 0, -mspeed);
-         else if (vkey_pressed == -12) // Mouse down
+         else if (vkey_pressed == -12) /* Mouse down */
             retro_mouse(0, 0, mspeed);
-         else if (vkey_pressed == -13) // Mouse left
+         else if (vkey_pressed == -13) /* Mouse left */
             retro_mouse(0, -mspeed, 0);
-         else if (vkey_pressed == -14) // Mouse right
+         else if (vkey_pressed == -14) /* Mouse right */
             retro_mouse(0, mspeed, 0);
       }
 
@@ -1935,7 +1934,9 @@ void update_input(int disable_physical_cursor_keys)
          vkey_sticky = 0;
       }
    }
-   //printf("vkey:%d sticky:%d sticky1:%d sticky2:%d, now:%d last:%d\n", vkey_pressed, vkey_sticky, vkey_sticky1, vkey_sticky2, now, last_press_time_button);
+#if 0
+   printf("vkey:%d sticky:%d sticky1:%d sticky2:%d, now:%d last:%d\n", vkey_pressed, vkey_sticky, vkey_sticky1, vkey_sticky2, now, last_press_time_button);
+#endif
 }
 
 void retro_poll_event()
@@ -2014,13 +2015,13 @@ void retro_poll_event()
    int retro_port;
    for (retro_port = 0; retro_port <= 3; retro_port++)
    {
-      if (MOUSEMODE == 1)
+      if (retro_mousemode)
          continue;
 
       switch (uae_devices[retro_port])
       {
          case RETRO_DEVICE_JOYPAD:
-            for (i = 0; i < 16; i++) // All buttons
+            for (i = 0; i < 16; i++) /* All buttons */
             {
                if (i == RETRO_DEVICE_ID_JOYPAD_B
                 || i == RETRO_DEVICE_ID_JOYPAD_Y
@@ -2038,7 +2039,7 @@ void retro_poll_event()
             break;
 
          case RETRO_DEVICE_UAE_ANALOG:
-            for (i = 0; i < 16; i++) // All buttons
+            for (i = 0; i < 16; i++) /* All buttons */
             {
                if (i == RETRO_DEVICE_ID_JOYPAD_B
                 || i == RETRO_DEVICE_ID_JOYPAD_Y
@@ -2052,7 +2053,7 @@ void retro_poll_event()
             break;
 
          case RETRO_DEVICE_UAE_CD32PAD:
-            for (i = 0; i < 16; i++) // All buttons
+            for (i = 0; i < 16; i++) /* All buttons */
             {
                if (i == RETRO_DEVICE_ID_JOYPAD_B
                 || i == RETRO_DEVICE_ID_JOYPAD_Y
@@ -2073,7 +2074,7 @@ void retro_poll_event()
             break;
 
          case RETRO_DEVICE_UAE_JOYSTICK:
-            for (i = 0; i < 9; i++) // All buttons up to A
+            for (i = 0; i < 9; i++) /* All buttons up to A */
             {
                if (i == RETRO_DEVICE_ID_JOYPAD_B
                 || i == RETRO_DEVICE_ID_JOYPAD_Y
@@ -2091,14 +2092,14 @@ void retro_poll_event()
       }
    }
 
-   // Mouse control
+   /* Mouse control */
    uae_mouse_l[0] = uae_mouse_r[0] = uae_mouse_m[0] = 0;
    uae_mouse_l[1] = uae_mouse_r[1] = uae_mouse_m[0] = 0;
    uae_mouse_x[0] = uae_mouse_y[0] = 0;
    uae_mouse_x[1] = uae_mouse_y[1] = 0;
 
-   // Joypad buttons only with digital mouse mode and virtual keyboard hidden
-   if (MOUSEMODE == 1 && SHOWKEY == -1)
+   /* Joypad buttons only with digital mouse mode and virtual keyboard hidden */
+   if (retro_mousemode && !retro_vkbd)
    {
       for (j = 0; j < 2; j++)
       {
@@ -2117,8 +2118,8 @@ void retro_poll_event()
       }
    }
 
-   // Real mouse buttons only when virtual keyboard hidden
-   if (SHOWKEY == -1)
+   /* Real mouse buttons only when virtual keyboard hidden */
+   if (!retro_vkbd)
    {
       if (!uae_mouse_l[0] && !uae_mouse_r[0])
       {
@@ -2127,7 +2128,7 @@ void retro_poll_event()
          uae_mouse_m[0] = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE);
       }
 
-      // Second real mouse buttons only when enabled
+      /* Second real mouse buttons only when enabled */
       if (opt_multimouse && !uae_mouse_l[1] && !uae_mouse_r[1])
       {
          uae_mouse_l[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
@@ -2136,12 +2137,12 @@ void retro_poll_event()
       }
    }
 
-   // Joypad movement only with digital mouse mode or analog joystick, and virtual keyboard hidden
-   if ((MOUSEMODE == 1 || uae_devices[0] == RETRO_DEVICE_UAE_ANALOG || uae_devices[1] == RETRO_DEVICE_UAE_ANALOG) && SHOWKEY == -1)
+   /* Joypad movement only with digital mouse mode or analog joystick, and virtual keyboard hidden */
+   if ((retro_mousemode || uae_devices[0] == RETRO_DEVICE_UAE_ANALOG || uae_devices[1] == RETRO_DEVICE_UAE_ANALOG) && !retro_vkbd)
    {
       for (j = 0; j < 2; j++)
       {
-         // Digital mouse speed modifiers
+         /* Digital mouse speed modifiers */
          if (dpadmouse_pressed[j] == 0)
             dpadmouse_speed[j] = opt_dpadmouse_speed;
 
@@ -2150,7 +2151,7 @@ void retro_poll_event()
          if (mouse_speed[j] & MOUSE_SPEED_SLOWER)
             dpadmouse_speed[j] = dpadmouse_speed[j] - 4;
 
-         // Digital mouse acceleration
+         /* Digital mouse acceleration */
          if (dpadmouse_pressed[j] == 1)
             if (now - dpadmouse_press[j] > 200)
             {
@@ -2158,7 +2159,7 @@ void retro_poll_event()
                dpadmouse_press[j] = now;
             }
 
-         // Digital mouse speed limits
+         /* Digital mouse speed limits */
          if (dpadmouse_speed[j] < 3) dpadmouse_speed[j] = 2;
          if (dpadmouse_speed[j] > 13) dpadmouse_speed[j] = 14;
 
@@ -2171,7 +2172,7 @@ void retro_poll_event()
          else if (input_state_cb(j, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))
             uae_mouse_y[j] -= dpadmouse_speed[j];
 
-         // Acceleration timestamps
+         /* Acceleration timestamps */
          if ((uae_mouse_x[j] != 0 || uae_mouse_y[j] != 0) && dpadmouse_pressed[j] == 0)
          {
             dpadmouse_press[j] = now;
@@ -2185,8 +2186,8 @@ void retro_poll_event()
       }
    }
 
-   // Left analog movement
-   // Analog joystick is prioritized over mouse and keymappings
+   /* Left analog movement */
+   /* Analog joystick is prioritized over mouse and keymappings */
    if (uae_devices[0] == RETRO_DEVICE_UAE_ANALOG || uae_devices[1] == RETRO_DEVICE_UAE_ANALOG)
    {
       for (j = 0; j < 2; j++)
@@ -2206,7 +2207,7 @@ void retro_poll_event()
          if (abs(analog_left[1]) > analog_deadzone)
             retro_joystick_analog(j, 1, analog_left[1]);
 
-         // Statusbar flags
+         /* Statusbar flags */
          if (analog_left[1] < analog_deadzone && !aflag[j][RETRO_DEVICE_ID_JOYPAD_UP])
             aflag[j][RETRO_DEVICE_ID_JOYPAD_UP] = 1;
          if (analog_left[1] > -1 && aflag[j][RETRO_DEVICE_ID_JOYPAD_UP])
@@ -2228,12 +2229,12 @@ void retro_poll_event()
             aflag[j][RETRO_DEVICE_ID_JOYPAD_RIGHT] = 0;
       }
    }
-   // Analog mouse is secondary
+   /* Analog mouse is secondary */
    else if (opt_analogmouse == 1 || opt_analogmouse == 3)
    {
       for (j = 0; j < 2; j++)
       {
-         // No keymappings and mousing at the same time
+         /* No keymappings and mousing at the same time */
          if (!uae_mouse_x[j] && !uae_mouse_y[j] && (!mapper_keys[16] && !mapper_keys[17] && !mapper_keys[18] && !mapper_keys[19]))
          {
             analog_left[0] = (input_state_cb(j, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X));
@@ -2245,7 +2246,7 @@ void retro_poll_event()
                analog_left[1] = 0;
             }
 
-            // Analog stick speed modifiers
+            /* Analog stick speed modifiers */
             mouse_multiplier = 1;
             if (mouse_speed[j] & MOUSE_SPEED_FASTER)
                mouse_multiplier = mouse_multiplier * MOUSE_SPEED_FAST;
@@ -2269,12 +2270,12 @@ void retro_poll_event()
       }
    }
 
-   // Right analog movement only for mouse
+   /* Right analog movement only for mouse */
    if (opt_analogmouse == 2 || opt_analogmouse == 3)
    {
       for (j = 0; j < 2; j++)
       {
-         // No keymappings and mousing at the same time
+         /* No keymappings and mousing at the same time */
          if (!uae_mouse_x[j] && !uae_mouse_y[j] && (!mapper_keys[20] && !mapper_keys[21] && !mapper_keys[22] && !mapper_keys[23]))
          {
             analog_right[0] = (input_state_cb(j, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X));
@@ -2286,7 +2287,7 @@ void retro_poll_event()
                analog_right[1] = 0;
             }
 
-            // Analog stick speed modifiers
+            /* Analog stick speed modifiers */
             mouse_multiplier = 1;
             if (mouse_speed[j] & MOUSE_SPEED_FASTER)
                mouse_multiplier = mouse_multiplier * MOUSE_SPEED_FAST;
@@ -2310,8 +2311,8 @@ void retro_poll_event()
       }
    }
 
-   // Real mouse movement only when virtual keyboard hidden
-   if (SHOWKEY == -1)
+   /* Real mouse movement only when virtual keyboard hidden */
+   if (!retro_vkbd)
    {
       if (!uae_mouse_x[0] && !uae_mouse_y[0])
       {
@@ -2325,7 +2326,7 @@ void retro_poll_event()
          }
       }
 
-      // Second real mouse movement only when enabled
+      /* Second real mouse movement only when enabled */
       if (opt_multimouse && !uae_mouse_x[1] && !uae_mouse_y[1])
       {
          mouse_x[1] = input_state_cb(1, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
@@ -2339,10 +2340,10 @@ void retro_poll_event()
       }
    }
 
-   // Ports 1 & 2
+   /* Ports 1 & 2 */
    for (j = 0; j < 2; j++)
    {
-      // Mouse buttons to UAE
+      /* Mouse buttons to UAE */
       if (!mouse_lmb[j] && uae_mouse_l[j])
       {
          mouse_lmb[j] = 1;
@@ -2382,7 +2383,7 @@ void retro_poll_event()
          retro_mouse_button(j, 2, 0);
       }
 
-      // Mouse movements to UAE
+      /* Mouse movements to UAE */
       if (uae_mouse_y[j] < 0 && !mflag[j][RETRO_DEVICE_ID_JOYPAD_UP])
          mflag[j][RETRO_DEVICE_ID_JOYPAD_UP] = 1;
       if (uae_mouse_y[j] > -1 && mflag[j][RETRO_DEVICE_ID_JOYPAD_UP] && !vkflag[4])

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -95,7 +95,7 @@ extern unsigned int video_config;
 extern unsigned int video_config_aspect;
 extern unsigned int zoom_mode_id;
 extern unsigned int opt_zoom_mode_id;
-extern bool retro_request_av_info_update;
+extern bool request_update_av_info;
 extern bool request_reset_drawing;
 extern int opt_statusbar;
 extern int opt_statusbar_position;
@@ -175,7 +175,7 @@ void emu_function(int function)
             video_config_aspect = PUAE_VIDEO_NTSC;
          else if (video_config_aspect == PUAE_VIDEO_NTSC)
             video_config_aspect = PUAE_VIDEO_PAL;
-         retro_request_av_info_update = true;
+         request_update_av_info = true;
          break;
       case EMU_ZOOM_MODE_TOGGLE:
          if (zoom_mode_id == 0 && opt_zoom_mode_id == 0)
@@ -184,7 +184,7 @@ void emu_function(int function)
             zoom_mode_id = 0;
          else if (zoom_mode_id == 0)
             zoom_mode_id = opt_zoom_mode_id;
-         retro_request_av_info_update = true;
+         request_update_av_info = true;
          break;
       case EMU_TURBO_FIRE_TOGGLE:
          if (turbo_fire_button_disabled == -1 && turbo_fire_button == -1)

--- a/libretro/retro_disk_control.c
+++ b/libretro/retro_disk_control.c
@@ -53,7 +53,7 @@ extern bool retro_disk_set_image_index(unsigned index);
 extern char full_path[RETRO_PATH_MAX];
 extern void display_current_image(const char *image, bool inserted);
 
-// Return the directory name of filename 'filename'.
+/* Return the directory name of filename 'filename' */
 char* dirname_int(const char* filename)
 {
 	if (filename == NULL)
@@ -66,60 +66,60 @@ char* dirname_int(const char* filename)
 		return strleft(filename, len - strlen(right));
 	
 #ifdef _WIN32
-	// Alternative search for windows beceause it also support the UNIX seperator
+	/* Alternative search for windows beceause it also support the UNIX seperator */
 	if ((right = strrchr(filename, RETRO_PATH_SEPARATOR_ALT[0])) != NULL)
 		return strleft(filename, len - strlen(right));
 #endif
 	
-	// Not found
+	/* Not found */
 	return NULL;
 }
 
 char* m3u_search_file(const char* basedir, const char* dskName)
 {
-	// Verify if this item is an absolute pathname (or the file is in working dir)
+	/* Verify if this item is an absolute pathname (or the file is in working dir) */
 	if (file_exists(dskName))
 	{
-		// Copy and return
+		/* Copy and return */
 		char* result = calloc(strlen(dskName) + 1, sizeof(char));
 		strcpy(result, dskName);
 		return result;
 	}
 	
-	// If basedir was provided
+	/* If basedir was provided */
 	if(basedir != NULL)
 	{
-		// Join basedir and dskName
+		/* Join basedir and dskName */
 		char* dskPath = calloc(RETRO_PATH_MAX, sizeof(char));
 		path_join(dskPath, basedir, dskName);
 
-		// Verify if this item is a relative filename (append it to the m3u path)
+		/* Verify if this item is a relative filename (append it to the m3u path) */
 		if (file_exists(dskPath))
 		{
-			// Return
+			/* Return */
 			return dskPath;
 		}
 		free(dskPath);
 	}
 	
-	// File not found
+	/* File not found */
 	return NULL;
 }
 
 void dc_reset(dc_storage* dc)
 {
-	// Verify
+	/* Verify */
 	if(dc == NULL)
 		return;
 	
-	// Clean the command
+	/* Clean the command */
 	if(dc->command)
 	{
 		free(dc->command);
 		dc->command = NULL;
 	}
 
-	// Clean the struct
+	/* Clean the struct */
 	for(unsigned i=0; i < dc->count; i++)
 	{
 		if (dc->files[i])
@@ -140,7 +140,7 @@ void dc_reset(dc_storage* dc)
 
 dc_storage* dc_create(void)
 {
-	// Initialize the struct
+	/* Initialize the struct */
 	dc_storage* dc = NULL;
 	
 	if((dc = malloc(sizeof(dc_storage))) != NULL)
@@ -163,17 +163,17 @@ dc_storage* dc_create(void)
 
 bool dc_add_file_int(dc_storage* dc, char* filename, char* label)
 {
-	// Verify
+	/* Verify */
 	if (dc == NULL)
 		return false;
 
 	if (!filename || (*filename == '\0'))
 		return false;
 
-	// If max size is not exceeded...
+	/* If max size is not exceeded */
 	if(dc->count < DC_MAX_SIZE)
 	{
-		// Add the file
+		/* Add the file */
 		dc->count++;
 		dc->files[dc->count-1]  = filename;
 		dc->labels[dc->count-1] = label;
@@ -186,18 +186,18 @@ bool dc_add_file_int(dc_storage* dc, char* filename, char* label)
 
 bool dc_add_file(dc_storage* dc, const char* filename, const char* label)
 {
-	// Verify
+	/* Verify */
 	if(dc == NULL)
 		return false;
 
 	if (!filename || (*filename == '\0'))
 		return false;
 
-	// Copy and return
+	/* Copy and return */
 	char *filename_int = calloc(strlen(filename) + 1, sizeof(char));
 	strcpy(filename_int, filename);
 
-	char *label_int = NULL; // NULL is a valid label
+	char *label_int = NULL; /* NULL is a valid label */
 	if (!(!label || (*label == '\0')))
 	{
 		label_int = calloc(strlen(label) + 1, sizeof(char));
@@ -215,14 +215,14 @@ bool dc_remove_file(dc_storage* dc, int index)
     if (index < 0 || index >= dc->count)
         return false;
 
-    // "If ptr is a null pointer, no action occurs"
+    /* "If ptr is a null pointer, no action occurs" */
     free(dc->files[index]);
     dc->files[index] = NULL;
     free(dc->labels[index]);
     dc->labels[index] = NULL;
     dc->types[index] = DC_IMAGE_TYPE_NONE;
 
-    // Shift all entries after index one slot up
+    /* Shift all entries after index one slot up */
     if (index != dc->count - 1)
     {
         memmove(dc->files + index, dc->files + index + 1, (dc->count - 1 - index) * sizeof(dc->files[0]));
@@ -242,7 +242,7 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
     if (index < 0 || index >= dc->count)
         return false;
 
-    // "If ptr is a null pointer, no action occurs"
+    /* "If ptr is a null pointer, no action occurs" */
     free(dc->files[index]);
     dc->files[index] = NULL;
     free(dc->labels[index]);
@@ -257,14 +257,14 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
     {
         dc->replace = false;
 
-        // Eject all floppy drives
+        /* Eject all floppy drives */
         for (unsigned i = 0; i < 4; i++)
             changed_prefs.floppyslots[i].df[0] = 0;
 
         char full_path_replace[RETRO_PATH_MAX] = {0};
         strcpy(full_path_replace, (char*)filename);
 
-        // Confs & hard drive images will replace full_path and requires restarting
+        /* Confs & hard drive images will replace full_path and requires restarting */
         if (strendswith(full_path_replace, "uae")
          || strendswith(full_path_replace, "hdf")
          || strendswith(full_path_replace, "hdz")
@@ -276,7 +276,7 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
             return false;
         }
 
-        // ZIP
+        /* ZIP */
         else if (strendswith(full_path_replace, "zip"))
         {
             char zip_basename[RETRO_PATH_MAX] = {0};
@@ -289,7 +289,7 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
             path_mkdir(zip_path);
             zip_uncompress(full_path_replace, zip_path, NULL);
 
-            // Default to directory mode
+            /* Default to directory mode */
             int zip_mode = 0;
             snprintf(full_path_replace, sizeof(full_path_replace), "%s", zip_path);
 
@@ -307,14 +307,14 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
                 if (zip_dirp->d_name[0] == '.' || strendswith(zip_dirp->d_name, "m3u") || zip_mode > 1)
                     continue;
 
-                // Multi file mode, generate playlist
+                /* Multi file mode, generate playlist */
                 if (dc_get_image_type(zip_dirp->d_name) == DC_IMAGE_TYPE_FLOPPY)
                 {
                     zip_mode = 1;
                     zip_m3u_num++;
                     snprintf(zip_m3u_list[zip_m3u_num-1], RETRO_PATH_MAX, "%s", zip_dirp->d_name);
                 }
-                // Single file image mode
+                /* Single file image mode */
                 else if (dc_get_image_type(zip_dirp->d_name) == DC_IMAGE_TYPE_CD
                       || dc_get_image_type(zip_dirp->d_name) == DC_IMAGE_TYPE_HD)
                 {
@@ -326,15 +326,15 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
 
             switch (zip_mode)
             {
-                case 0: // Extracted path
+                case 0: /* Extracted path */
                     dc_reset(dc);
                     strcpy(full_path, (char*)filename);
                     display_current_image(full_path, true);
                     return true;
                     break;
-                case 2: // Single image
+                case 2: /* Single image */
                     break;
-                case 1: // Generated playlist
+                case 1: /* Generated playlist */
                     if (zip_m3u_num == 1)
                     {
                         snprintf(full_path_replace, sizeof(full_path_replace), "%s%s%s", zip_path, DIR_SEP_STR, zip_m3u_list[0]);
@@ -352,24 +352,24 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
             }
         }
 
-        // M3U replace
+        /* M3U replace */
         if (strendswith(full_path_replace, "m3u"))
         {
-            // Parse the M3U file
+            /* Parse the M3U file */
             dc_parse_m3u(dc, full_path_replace, retro_save_directory);
 
-            // Some debugging
+            /* Some debugging */
             log_cb(RETRO_LOG_INFO, "M3U parsed, %d file(s) found\n", dc->count);
-            //for (unsigned i = 0; i < dc->count; i++)
-                //log_cb(RETRO_LOG_INFO, "File %d: %s\n", i+1, dc->files[i]);
+            for (unsigned i = 0; i < dc->count; i++)
+                log_cb(RETRO_LOG_DEBUG, "File %d: %s\n", i+1, dc->files[i]);
 
-            // Insert first disk
+            /* Insert first disk */
             retro_disk_set_image_index(0);
 
-            // Trick frontend to return to index 0 after successful "append" does +1
+            /* Trick frontend to return to index 0 after successful "append" does +1 */
             dc->replace = true;
 
-            // Append rest of the disks to the config if M3U is a MultiDrive-M3U
+            /* Append rest of the disks to the config if M3U is a MultiDrive-M3U */
             if (strstr(full_path_replace, "(MD)") != NULL)
             {
                 for (unsigned i = 1; i < dc->count; i++)
@@ -379,8 +379,8 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
                         log_cb(RETRO_LOG_INFO, "Disk (%d) inserted in drive DF%d: '%s'\n", i+1, i, dc->files[i]);
                         strcpy(changed_prefs.floppyslots[i].df, dc->files[i]);
 
-                        // By default only DF0: is enabled, so floppyXtype needs to be set on the extra drives
-                        changed_prefs.floppyslots[i].dfxtype = 0; // 0 = 3.5" DD
+                        /* By default only DF0: is enabled, so floppyXtype needs to be set on the extra drives */
+                        changed_prefs.floppyslots[i].dfxtype = 0; /* 0 = 3.5" DD */
                     }
                     else
                     {
@@ -391,7 +391,7 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
                 }
             }
         }
-        // Single append
+        /* Single append */
         else
         {
             char image_label[RETRO_PATH_MAX];
@@ -419,7 +419,7 @@ static bool dc_add_m3u_save_disk(
 	char save_disk_path[RETRO_PATH_MAX]       = {0};
 	char volume_name[31]                      = {0};
 	
-	// Verify
+	/* Verify */
 	if(dc == NULL)
 		return false;
 
@@ -429,51 +429,51 @@ static bool dc_add_m3u_save_disk(
 	if(save_dir == NULL)
 		return false;
 	
-	// It seems that we don't want to use "string/stdstring.h"
-	// or "file/file_path.h" functions here, so this will be ugly...
+	/* It seems that we don't want to use "string/stdstring.h"
+	 * or "file/file_path.h" functions here, so this will be ugly */
 	
-	// Get m3u file name
+	/* Get m3u file name */
 	m3u_file_name = path_get_basename(m3u_file);
 	
 	if (!m3u_file_name || (*m3u_file_name == '\0'))
 		return false;
 	
-	// Get m3u file name without extension
+	/* Get m3u file name without extension */
 	remove_file_extension(
 			m3u_file_name, m3u_file_name_no_ext, sizeof(m3u_file_name_no_ext));
 	
 	if (!m3u_file_name_no_ext || (*m3u_file_name_no_ext == '\0'))
 		return false;
 	
-	// Construct save disk file name
+	/* Construct save disk file name */
 	snprintf(save_disk_file_name, RETRO_PATH_MAX, "%s.save%u.adf",
 			m3u_file_name_no_ext, index);
 	
-	// Construct save disk path
+	/* Construct save disk path */
 	path_join(save_disk_path, save_dir, save_disk_file_name);
 	
-	// Check whether save disk already exists
-	// Note: If a disk already exists, we should be
-	// able to support changing the volume label if
-	// it differs from 'disk_name'. This is quite
-	// fiddly, however - perhaps it can be added later...
+	/* Check whether save disk already exists
+	 * Note: If a disk already exists, we should be
+	 * able to support changing the volume label if
+	 * it differs from 'disk_name'. This is quite
+	 * fiddly, however - perhaps it can be added later... */
 	save_disk_exists = file_exists(save_disk_path);
 	
-	// ...if not, create a new one
+	/* ...if not, create a new one */
 	if (!save_disk_exists)
 	{
-		// Get volume name
-		// > If disk_name is NULL or empty/EMPTY,
-		//   no volume name is set
+		/* Get volume name 
+		 * > If disk_name is NULL or empty/EMPTY,
+		 *   no volume name is set */
 		if (disk_name && (*disk_name != '\0'))
 		{
 			if(strncasecmp(disk_name, "empty", strlen("empty")))
 			{
 				char *scrub_pointer = NULL;
 				
-				// Ensure volume name is valid
-				// > Must be <= 30 characters
-				// > Cannot contain '/' or ':'
+				/* Ensure volume name is valid
+				 * > Must be <= 30 characters
+				 * > Cannot contain '/' or ':' */
 				strncpy(volume_name, disk_name, sizeof(volume_name) - 1);
 				
 				while((scrub_pointer = strpbrk(volume_name, "/:")))
@@ -481,15 +481,14 @@ static bool dc_add_m3u_save_disk(
 			}
 		}
 		
-		// Create save disk
+		/* Create save disk */
 		save_disk_exists = disk_creatediskfile(
 				save_disk_path, 0, DRV_35_DD,
 				(volume_name[0] == '\0') ? NULL : volume_name,
 				false, false, NULL);
 	}
 	
-	// If save disk exists/was created, add it to
-	// the list
+	/* If save disk exists/was created, add it to the list */
 	if (save_disk_exists)
 	{
 		char save_disk_label[64] = {0};
@@ -511,7 +510,7 @@ static bool dc_add_m3u_disk(
 {
 	char *disk_file_path = NULL;
 	
-	// Verify
+	/* Verify */
 	if(dc == NULL)
 		return false;
 	
@@ -521,22 +520,22 @@ static bool dc_add_m3u_disk(
 	if(disk_file == NULL)
 		return false;
 	
-	// Search the file (absolute, relative to m3u)
+	/* Search the file (absolute, relative to m3u) */
 	if ((disk_file_path = m3u_search_file(m3u_base_dir, disk_file)) != NULL)
 	{
 		char disk_label[RETRO_PATH_MAX] = {0};
 		
-		// If a label is provided, use it
+		/* If a label is provided, use it */
 		if (usr_disk_label_set)
 		{
-			// Note that label may intentionally be left blank
+			/* Note that label may intentionally be left blank */
 			if (usr_disk_label && (*usr_disk_label != '\0'))
 				strncpy(
 						disk_label, usr_disk_label, sizeof(disk_label) - 1);
 		}
 		else
 		{
-			// Otherwise, use file name without extension as label
+			/* Otherwise, use file name without extension as label */
 			const char *file_name = path_get_basename(disk_file_path);
 			
 			if (!(!file_name || (*file_name == '\0')))
@@ -546,7 +545,7 @@ static bool dc_add_m3u_disk(
 			}
 		}
 
-		// ZIP
+		/* ZIP */
 		if (strendswith(disk_file_path, "zip"))
 		{
 			char zip_basename[RETRO_PATH_MAX];
@@ -562,7 +561,7 @@ static bool dc_add_m3u_disk(
 			snprintf(disk_file_path, RETRO_PATH_MAX, "%s%s%s", zip_path, DIR_SEP_STR, lastfile);
 		}
 		
-		// Add the file to the list
+		/* Add the file to the list */
 		dc_add_file_int(
 				dc, disk_file_path,
 				(disk_label[0] == '\0') ? NULL : my_strdup(disk_label));
@@ -575,7 +574,7 @@ static bool dc_add_m3u_disk(
 
 void dc_parse_m3u(dc_storage* dc, const char* m3u_file, const char* save_dir)
 {
-	// Verify
+	/* Verify */
 	if(dc == NULL)
 		return;
 	
@@ -584,48 +583,48 @@ void dc_parse_m3u(dc_storage* dc, const char* m3u_file, const char* save_dir)
 
 	FILE* fp = NULL;
 
-	// Try to open the file
+	/* Try to open the file */
 	if ((fp = fopen(m3u_file, "r")) == NULL)
 		return;
 
-	// Reset
+	/* Reset */
 	dc_reset(dc);
 	
-	// Get the m3u base dir for resolving relative path
+	/* Get the m3u base dir for resolving relative path */
 	char* basedir = dirname_int(m3u_file);
 	
-	// Read the lines while there is line to read and we have enough space
+	/* Read the lines while there is line to read and we have enough space */
 	unsigned int save_disk_index = 0;
 	char buffer[2048];
 	while ((dc->count <= DC_MAX_SIZE) && (fgets(buffer, sizeof(buffer), fp) != NULL))
 	{
 		char* string = trimwhitespace(buffer);
 		
-		// If it's a m3u special key or a file
+		/* If it's a m3u special key or a file */
 		if (strstartswith(string, M3U_SPECIAL_COMMAND))
 		{
 			dc->command = strright(string, strlen(string) - strlen(M3U_SPECIAL_COMMAND));
 		}
 		else if (strstartswith(string, M3U_SAVEDISK))
 		{
-			// Get volume name
+			/* Get volume name */
 			char* disk_name = strright(string, strlen(string) - strlen(M3U_SAVEDISK));
 			
-			// Add save disk, creating it if necessary
+			/* Add save disk, creating it if necessary */
 			if (dc_add_m3u_save_disk(
 					dc, m3u_file, save_dir,
 					disk_name, save_disk_index))
 				save_disk_index++;
 			
-			// Clean up
+			/* Clean up */
 			if (disk_name != NULL)
 				free(disk_name);
 		}
 		else if (!strstartswith(string, COMMENT))
 		{
-			// Path format:
-			//    FILE_NAME|FILE_LABEL
-			// Delimiter + FILE_LABEL is optional
+			/* Path format:
+			 *    FILE_NAME|FILE_LABEL
+			 * Delimiter + FILE_LABEL is optional */
 			char file_name[RETRO_PATH_MAX]  = {0};
 			char file_label[RETRO_PATH_MAX] = {0};
 			char* delim_ptr                 = strchr(string, M3U_PATH_DELIM);
@@ -633,25 +632,25 @@ void dc_parse_m3u(dc_storage* dc, const char* m3u_file, const char* save_dir)
 			
 			if (delim_ptr)
 			{
-				// Not going to use strleft()/strright() here,
-				// since these functions allocate new strings,
-				// which we don't want to do...
+				/* Not going to use strleft()/strright() here,
+				 * since these functions allocate new strings,
+				 * which we don't want to do... */
 				
-				// Get FILE_NAME segment
+				/* Get FILE_NAME segment */
 				size_t len = (size_t)(1 + delim_ptr - string);
 				if (len > 0)
 					strncpy(
 							file_name, string,
 							((len < RETRO_PATH_MAX ? len : RETRO_PATH_MAX) * sizeof(char)) - 1);
 				
-				// Get FILE_LABEL segment
+				/* Get FILE_LABEL segment */
 				delim_ptr++;
 				if (*delim_ptr != '\0')
 					strncpy(
 							file_label, delim_ptr, sizeof(file_label) - 1);
 
-				// Note: If delimiter is present but FILE_LABEL
-				// is omitted, label is intentionally left blank
+				/* Note: If delimiter is present but FILE_LABEL
+				 * is omitted, label is intentionally left blank */
 				label_set = true;
 			}
 			else
@@ -665,17 +664,17 @@ void dc_parse_m3u(dc_storage* dc, const char* m3u_file, const char* save_dir)
 		}
 	}
 	
-	// If basedir was provided
+	/* If basedir was provided */
 	if(basedir != NULL)
 		free(basedir);
 
-	// Close the file 
+	/* Close the file */
 	fclose(fp);
 }
 
 void dc_free(dc_storage* dc)
 {
-	// Clean the struct
+	/* Clean the struct */
 	dc_reset(dc);
 	free(dc);
 	dc = NULL;
@@ -684,11 +683,11 @@ void dc_free(dc_storage* dc)
 
 enum dc_image_type dc_get_image_type(const char* filename)
 {
-	// Missing file
+	/* Missing file */
 	if (!filename || (*filename == '\0'))
 	   return DC_IMAGE_TYPE_NONE;
 
-	// Floppy image
+	/* Floppy image */
 	if (strendswith(filename, "adf") ||
 	    strendswith(filename, "adz") ||
 	    strendswith(filename, "fdi") ||
@@ -697,7 +696,7 @@ enum dc_image_type dc_get_image_type(const char* filename)
 	    strendswith(filename, "zip"))
 	   return DC_IMAGE_TYPE_FLOPPY;
 
-	// CD image
+	/* CD image */
 	if (strendswith(filename, "cue") ||
 	    strendswith(filename, "ccd") ||
 	    strendswith(filename, "nrg") ||
@@ -705,18 +704,18 @@ enum dc_image_type dc_get_image_type(const char* filename)
 	    strendswith(filename, "iso"))
 	   return DC_IMAGE_TYPE_CD;
 
-	// HD image
+	/* HD image */
 	if (strendswith(filename, "hdf") ||
 	    strendswith(filename, "hdz") ||
 	    path_is_directory(filename))
 	   return DC_IMAGE_TYPE_HD;
 
-	// WHDLoad
+	/* WHDLoad */
 	if (strendswith(filename, "lha") ||
 	    strendswith(filename, "slave") ||
 	    strendswith(filename, "info"))
 	   return DC_IMAGE_TYPE_WHDLOAD;
 
-	// Fallback
+	/* Fallback */
 	return DC_IMAGE_TYPE_UNKNOWN;
 }

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -25,23 +25,23 @@
 #define DC_MAX_SIZE 20
 
 enum dc_image_type {
-	DC_IMAGE_TYPE_NONE = 0,
-	DC_IMAGE_TYPE_FLOPPY,
-	DC_IMAGE_TYPE_CD,
-	DC_IMAGE_TYPE_HD,
-	DC_IMAGE_TYPE_WHDLOAD,
-	DC_IMAGE_TYPE_UNKNOWN
+   DC_IMAGE_TYPE_NONE = 0,
+   DC_IMAGE_TYPE_FLOPPY,
+   DC_IMAGE_TYPE_CD,
+   DC_IMAGE_TYPE_HD,
+   DC_IMAGE_TYPE_WHDLOAD,
+   DC_IMAGE_TYPE_UNKNOWN
 };
 
 struct dc_storage {
-	char* command;
-	char* files[DC_MAX_SIZE];
-	char* labels[DC_MAX_SIZE];
-	enum dc_image_type types[DC_MAX_SIZE];
-	unsigned count;
-	int index;
-	bool eject_state;
-	bool replace;
+   char* command;
+   char* files[DC_MAX_SIZE];
+   char* labels[DC_MAX_SIZE];
+   enum dc_image_type types[DC_MAX_SIZE];
+   unsigned count;
+   int index;
+   bool eject_state;
+   bool replace;
 };
 
 typedef struct dc_storage dc_storage;

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -21,8 +21,7 @@
 
 #include <stdbool.h>
 
-//*****************************************************************************
-// Disk control structure and functions
+/* Disk control structure and functions */
 #define DC_MAX_SIZE 20
 
 enum dc_image_type {

--- a/libretro/retro_files.c
+++ b/libretro/retro_files.c
@@ -25,7 +25,7 @@
 #include <file/file_path.h>
 #endif
 
-// Verify if file exists
+/* Verify if file exists */
 bool file_exists(const char *filename)
 {
 	struct stat buf;
@@ -54,7 +54,7 @@ const char *path_get_basename(const char* path)
 	if (!path || (*path == '\0'))
 		return NULL;
 
-	// Search for path separator
+	/* Search for path separator */
 	basename = strrchr(path, RETRO_PATH_SEPARATOR[0]);
 #ifdef _WIN32
 	if (!basename)
@@ -64,8 +64,8 @@ const char *path_get_basename(const char* path)
 	if (!(!basename || (*basename == '\0')))
 		return basename + 1;
 
-	// > If path contains no separator, then the
-	//   path itself is the basename
+	/* > If path contains no separator, then the
+	 *   path itself is the basename */
 	return path;
 }
 

--- a/libretro/retro_files.h
+++ b/libretro/retro_files.h
@@ -22,13 +22,12 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-//*****************************************************************************
-// File helpers functions
+/* File helpers functions */
 #define RETRO_PATH_MAX 512
 
 #ifdef _WIN32
 #define RETRO_PATH_SEPARATOR   		"\\"
-// Windows also support the unix path separator
+/* Windows also support the unix path separator */
 #define RETRO_PATH_SEPARATOR_ALT   	"/"
 #else
 #define RETRO_PATH_SEPARATOR   		"/"
@@ -36,9 +35,9 @@
 
 void path_join(char* out, const char* basedir, const char* filename);
 bool file_exists(const char *filename);
-// Have to be careful with naming to avoid conflicts with
-// 'file_path.h'
-// NOTE: Why can't we use 'file_path.h' functions directly...?
+/* Have to be careful with naming to avoid conflicts with
+ * 'file_path.h'
+ * NOTE: Why can't we use 'file_path.h' functions directly...? */
 const char *path_get_basename(const char* path);
 void remove_file_extension(const char* path, char* path_no_ext, size_t len);
 

--- a/libretro/retro_strings.c
+++ b/libretro/retro_strings.c
@@ -23,32 +23,32 @@
 #include <stdlib.h>
 #include <string.h>
 
-// Note: This function returns a pointer to a substring_left of the original string.
-// If the given string was allocated dynamically, the caller must not overwrite
-// that pointer with the returned value, since the original pointer must be
-// deallocated using the same allocator with which it was allocated.  The return
-// value must NOT be deallocated using free() etc.
+/* Note: This function returns a pointer to a substring_left of the original string.
+ * If the given string was allocated dynamically, the caller must not overwrite
+ * that pointer with the returned value, since the original pointer must be
+ * deallocated using the same allocator with which it was allocated.  The return
+ * value must NOT be deallocated using free() etc. */
 char* trimwhitespace(char *str)
 {
   char *end;
 
-  // Trim leading space
+  /* Trim leading space */
   while(isspace((unsigned char)*str)) str++;
 
-  if(*str == 0)  // All spaces?
+  if(*str == 0) /* All spaces? */
     return str;
 
-  // Trim trailing space
+  /* Trim trailing space */
   end = str + strlen(str) - 1;
   while(end > str && isspace((unsigned char)*end)) end--;
 
-  // Write new null terminator character
+  /* Write new null terminator character */
   end[1] = '\0';
 
   return str;
 }
 
-// Returns a substring of 'str' that contains the 'len' leftmost characters of 'str'.
+/* Returns a substring of 'str' that contains the 'len' leftmost characters of 'str' */
 char* strleft(const char* str, int len)
 {
 	char* result = calloc(len + 1, sizeof(char));
@@ -56,7 +56,7 @@ char* strleft(const char* str, int len)
 	return result;
 }
 
-// Returns a substring of 'str' that contains the 'len' rightmost characters of 'str'.
+/* Returns a substring of 'str' that contains the 'len' rightmost characters of 'str' */
 char* strright(const char* str, int len)
 {
 	int pos = strlen(str) - len;
@@ -65,7 +65,7 @@ char* strright(const char* str, int len)
 	return result;
 }
 
-// Returns true if 'str' starts with 'start'
+/* Returns true if 'str' starts with 'start' */
 bool strstartswith(const char* str, const char* start)
 {
 	if (strlen(str) >= strlen(start))
@@ -75,7 +75,7 @@ bool strstartswith(const char* str, const char* start)
 	return false;
 }
 
-// Returns true if 'str' ends with 'end'
+/* Returns true if 'str' ends with 'end' */
 bool strendswith(const char* str, const char* end)
 {
 	if (strlen(str) >= strlen(end))

--- a/libretro/retro_strings.h
+++ b/libretro/retro_strings.h
@@ -21,8 +21,7 @@
 
 #include <stdbool.h>
 
-//*****************************************************************************
-// String helpers functions
+/* String helpers functions */
 char* trimwhitespace(char *str);
 char* strleft(const char* str, int len);
 char* strright(const char* str, int len);

--- a/libretro/vkbd.c
+++ b/libretro/vkbd.c
@@ -2,10 +2,11 @@
 #include "vkbd_def.h"
 #include "graph.h"
 
-extern int NPAGE;
-extern int SHOWKEYPOS;
-extern int SHOWKEYTRANS;
-extern int SHIFTON;
+bool retro_vkbd = false;
+bool retro_vkbd_page = false;
+bool retro_vkbd_position = false;
+bool retro_vkbd_transparent = true;
+extern bool retro_capslock;
 extern int vkflag[9];
 extern unsigned int video_config_geometry;
 extern unsigned int opt_vkbd_theme;
@@ -19,45 +20,45 @@ int RGBc(int r, int g, int b)
       return RGB565(r, g, b);
 }
 
-void print_virtual_kbd(unsigned short int *pixels)
+void print_vkbd(unsigned short int *pixels)
 {
    int x, y;
    bool shifted;
-   int page             = (NPAGE == -1) ? 0 : NPLGN * NLIGN;
-   uint16_t *pix        = &pixels[0];
+   int page              = (retro_vkbd_page) ? VKBDX * VKBDY : 0;
+   uint16_t *pix         = &pixels[0];
 
-   int XKEY             = 0;
-   int YKEY             = 0;
-   int XTEXT            = 0;
-   int YTEXT            = 0;
-   int XOFFSET          = 0;
-   int XPADDING         = 0;
-   int YOFFSET          = 0;
-   int YPADDING         = 0;
-   int XKEYSPACING      = 1;
-   int YKEYSPACING      = 1;
-   int ALPHA            = opt_vkbd_alpha;
-   int BKG_ALPHA        = ALPHA;
-   int BKG_PADDING_X    = 0;
-   int BKG_PADDING_Y    = 4;
-   int BKG_COLOR        = 0;
-   int BKG_COLOR_NORMAL = 0;
-   int BKG_COLOR_ALT    = 0;
-   int BKG_COLOR_EXTRA  = 0;
-   int BKG_COLOR_SEL    = 0;
-   int BKG_COLOR_ACTIVE = 0;
-   int BKG_COLOR_BORDER = 0;
-   int FONT_MAX         = 4;
-   int FONT_WIDTH       = 1;
-   int FONT_HEIGHT      = 1;
-   int FONT_COLOR       = 0;
-   int FONT_COLOR_NORMAL= 0;
-   int FONT_COLOR_SEL   = 0;
+   int XKEY              = 0;
+   int YKEY              = 0;
+   int XTEXT             = 0;
+   int YTEXT             = 0;
+   int XOFFSET           = 0;
+   int XPADDING          = 0;
+   int YOFFSET           = 0;
+   int YPADDING          = 0;
+   int XKEYSPACING       = 1;
+   int YKEYSPACING       = 1;
+   int ALPHA             = opt_vkbd_alpha;
+   int BKG_ALPHA         = ALPHA;
+   int BKG_PADDING_X     = 0;
+   int BKG_PADDING_Y     = 4;
+   int BKG_COLOR         = 0;
+   int BKG_COLOR_NORMAL  = 0;
+   int BKG_COLOR_ALT     = 0;
+   int BKG_COLOR_EXTRA   = 0;
+   int BKG_COLOR_SEL     = 0;
+   int BKG_COLOR_ACTIVE  = 0;
+   int BKG_COLOR_BORDER  = 0;
+   int FONT_MAX          = 4;
+   int FONT_WIDTH        = 1;
+   int FONT_HEIGHT       = 1;
+   int FONT_COLOR        = 0;
+   int FONT_COLOR_NORMAL = 0;
+   int FONT_COLOR_SEL    = 0;
 
    switch (opt_vkbd_theme)
    {
       default:
-      case 0: // Classic
+      case 0: /* Classic */
          BKG_COLOR_NORMAL  = RGBc(216, 209, 201);
          BKG_COLOR_ALT     = RGBc(159, 154, 150);
          BKG_COLOR_EXTRA   = RGBc(143, 140, 129);
@@ -67,7 +68,7 @@ void print_virtual_kbd(unsigned short int *pixels)
          FONT_COLOR_SEL    = RGBc(250, 250, 250);
          break;
 
-      case 1: // CD32
+      case 1: /* CD32 */
          BKG_COLOR_NORMAL  = RGBc( 64,  64,  64);
          BKG_COLOR_ALT     = RGBc( 32,  32,  32);
          BKG_COLOR_EXTRA   = RGBc( 16,  16,  16);
@@ -77,7 +78,7 @@ void print_virtual_kbd(unsigned short int *pixels)
          FONT_COLOR_SEL    = RGBc( 10,  10,  10);
          break;
 
-      case 2: // Dark
+      case 2: /* Dark */
          BKG_COLOR_NORMAL  = RGBc( 32,  32,  32);
          BKG_COLOR_ALT     = RGBc( 48,  48,  48);
          BKG_COLOR_EXTRA   = RGBc( 16,  16,  16);
@@ -87,7 +88,7 @@ void print_virtual_kbd(unsigned short int *pixels)
          FONT_COLOR_SEL    = RGBc( 10,  10,  10);
          break;
 
-      case 3: // Light
+      case 3: /* Light */
          BKG_COLOR_NORMAL  = RGBc(220, 220, 220);
          BKG_COLOR_ALT     = RGBc(188, 188, 188);
          BKG_COLOR_EXTRA   = RGBc(172, 172, 172);
@@ -102,7 +103,7 @@ void print_virtual_kbd(unsigned short int *pixels)
    {
       if(video_config_geometry & PUAE_VIDEO_DOUBLELINE)
       {
-         // PUAE_VIDEO_HIRES_DOUBLELINE
+         /* PUAE_VIDEO_HIRES_DOUBLELINE */
          FONT_WIDTH        = 2;
          FONT_HEIGHT       = 2;
          XKEYSPACING       = 2;
@@ -110,54 +111,54 @@ void print_virtual_kbd(unsigned short int *pixels)
          XOFFSET           = 0;
          YPADDING          = 10;
          YOFFSET           = 0;
-         if (SHOWKEYPOS == 1 && zoomed_height > (retroh + (YPADDING * 3) - (zoomed_height / 2)))
+         if (retro_vkbd_position && zoomed_height > (retroh + (YPADDING * 3) - (zoomed_height / 2)))
             YOFFSET = -zoomed_height + retroh - (zoomed_height / 2) + 5;
          else
             YOFFSET = -(YPADDING);
       }
       else
       {
-         // PUAE_VIDEO_HIRES
+         /* PUAE_VIDEO_HIRES */
          FONT_WIDTH        = 2;
          XKEYSPACING       = 2;
          XOFFSET           = 0;
          YPADDING          = 6;
          BKG_PADDING_Y     = -1;
          YOFFSET           = 0;
-         if (SHOWKEYPOS == 1 && zoomed_height > (retroh + (YPADDING * 3) - (zoomed_height / 2)))
+         if (retro_vkbd_position && zoomed_height > (retroh + (YPADDING * 3) - (zoomed_height / 2)))
             YOFFSET = -zoomed_height + retroh - (zoomed_height / 2) + 5;
          else
             YOFFSET = -(YPADDING * 2);
       }
 
-      // PUAE_VIDEO_SUPERHIRES
+      /* PUAE_VIDEO_SUPERHIRES */
       if (video_config_geometry & PUAE_VIDEO_SUPERHIRES)
       {
-         FONT_WIDTH *= 2;
-         XOFFSET *= 2;
-         XPADDING *= 2;
-         XKEYSPACING *= 2;
+         FONT_WIDTH       *= 2;
+         XOFFSET          *= 2;
+         XPADDING         *= 2;
+         XKEYSPACING      *= 2;
       }
    }
    else
    {
-      // PUAE_VIDEO_LORES
-      BKG_PADDING_X     = -1;
-      BKG_PADDING_Y     = -1;
+      /* PUAE_VIDEO_LORES */
+      BKG_PADDING_X        = -1;
+      BKG_PADDING_Y        = -1;
 
-      XOFFSET           = 0;
-      YPADDING          = 6;
-      YOFFSET           = 0;
-      if (SHOWKEYPOS == 1 && zoomed_height > (retroh + (YPADDING * 3) - (zoomed_height / 2)))
+      XOFFSET              = 0;
+      YPADDING             = 6;
+      YOFFSET              = 0;
+      if (retro_vkbd_position && zoomed_height > (retroh + (YPADDING * 3) - (zoomed_height / 2)))
          YOFFSET = -zoomed_height + retroh - (zoomed_height / 2) + 5;
       else
          YOFFSET = -(YPADDING * 2);
    }
 
-   int XSIDE = (zoomed_width - ((XPADDING > 0) ? XPADDING * 2 : 0)) / NPLGN;
-   int YSIDE = (retroh - (zoomed_height / 2) - 15) / NLIGN;
-   int XBASEKEY = (XPADDING > 0) ? XPADDING : 0;
-   int YBASEKEY = (zoomed_height - (NLIGN * YSIDE)) - (YPADDING / 2);
+   int XSIDE     = (zoomed_width - ((XPADDING > 0) ? XPADDING * 2 : 0)) / VKBDX;
+   int YSIDE     = (retroh - (zoomed_height / 2) - 15) / VKBDY;
+   int XBASEKEY  = (XPADDING > 0) ? XPADDING : 0;
+   int YBASEKEY  = (zoomed_height - (VKBDY * YSIDE)) - (YPADDING / 2);
    int XBASETEXT = (XPADDING > 0) ? XPADDING : 0;
    if (video_config_geometry & PUAE_VIDEO_SUPERHIRES)
       XBASETEXT += 12;
@@ -167,18 +168,18 @@ void print_virtual_kbd(unsigned short int *pixels)
       XBASETEXT += 4;
    int YBASETEXT = YBASEKEY + ((video_config_geometry & PUAE_VIDEO_NTSC) ? 4 : 5);
    if (FONT_WIDTH == 1)
-      XOFFSET = (zoomed_width - (XSIDE * NPLGN)) / 2;
+      XOFFSET    = (zoomed_width - (XSIDE * VKBDX)) / 2;
    else
-      XOFFSET = (zoomed_width - (XSIDE * NPLGN)) / 4;
+      XOFFSET    = (zoomed_width - (XSIDE * VKBDX)) / 4;
 
    /* Coordinates */
    vkbd_x_min = XOFFSET + XBASEKEY + XKEYSPACING;
    vkbd_x_max = XOFFSET + zoomed_width - XBASEKEY - XKEYSPACING;
    vkbd_y_min = YOFFSET + YBASEKEY + YKEYSPACING;
-   vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * NLIGN);
+   vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * VKBDY);
 
    /* Opacity */
-   BKG_ALPHA = (SHOWKEYTRANS == -1) ? 255 : ALPHA;
+   BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : 255;
 
    /* Alternate color keys */
    int alt_keys[] =
@@ -198,32 +199,32 @@ void print_virtual_kbd(unsigned short int *pixels)
 
    /* Key label shifted */
    shifted = false;
-   if (SHIFTON == 1 || vkey_sticky1 == AK_LSH || vkey_sticky2 == AK_LSH || vkey_sticky1 == AK_RSH || vkey_sticky2 == AK_RSH)
+   if (retro_capslock || vkey_sticky1 == AK_LSH || vkey_sticky2 == AK_LSH || vkey_sticky1 == AK_RSH || vkey_sticky2 == AK_RSH)
       shifted = true;
    if (vkflag[4] == 1 && (vkey_pressed == AK_LSH || vkey_pressed == AK_RSH))
       shifted = true;
 
    /* Key layout */
-   for (x = 0; x < NPLGN; x++)
+   for (x = 0; x < VKBDX; x++)
    {
-      for (y = 0; y < NLIGN; y++)
+      for (y = 0; y < VKBDY; y++)
       {
          /* Default key color */
          BKG_COLOR = BKG_COLOR_NORMAL;
 
          /* Reset key color */
-         if (MVk[(y * NPLGN) + x].val == -20)
+         if (vkeys[(y * VKBDX) + x].value == -20)
             BKG_COLOR = RGBc(128, 0, 0);
          else
          {
             /* Alternate key color */
             for (int alt_key = 0; alt_key < alt_keys_len; ++alt_key)
-                if (alt_keys[alt_key] == MVk[(y * NPLGN) + x + page].val)
+                if (alt_keys[alt_key] == vkeys[(y * VKBDX) + x + page].value)
                     BKG_COLOR = BKG_COLOR_ALT;
 
             /* Extra key color */
             for (int extra_key = 0; extra_key < extra_keys_len; ++extra_key)
-                if (extra_keys[extra_key] == MVk[(y * NPLGN) + x + page].val)
+                if (extra_keys[extra_key] == vkeys[(y * VKBDX) + x + page].value)
                     BKG_COLOR = BKG_COLOR_EXTRA;
          }
 
@@ -237,14 +238,14 @@ void print_virtual_kbd(unsigned short int *pixels)
          FONT_COLOR = FONT_COLOR_NORMAL;
 
          /* Sticky + CapsLock + pressed colors */
-         if ((vkey_sticky1 == MVk[(y * NPLGN) + x + page].val
-          ||  vkey_sticky2 == MVk[(y * NPLGN) + x + page].val
-          ||   (SHIFTON==1 && MVk[(y * NPLGN) + x + page].val==AK_CAPSLOCK)
-          || (vkflag[8]==1 && MVk[(y * NPLGN) + x + page].val==AK_RET))
-          && BKG_COLOR != BKG_COLOR_EXTRA && MVk[(y * NPLGN) + x + page].val != -20)
+         if (  (vkey_sticky1 == vkeys[(y * VKBDX) + x + page].value
+          ||    vkey_sticky2 == vkeys[(y * VKBDX) + x + page].value
+          || (retro_capslock && vkeys[(y * VKBDX) + x + page].value == AK_CAPSLOCK)
+          ||      (vkflag[8] && vkeys[(y * VKBDX) + x + page].value == AK_RET))
+          && BKG_COLOR != BKG_COLOR_EXTRA && vkeys[(y * VKBDX) + x + page].value != -20)
          {
             FONT_COLOR = FONT_COLOR_NORMAL;
-            BKG_COLOR = BKG_COLOR_ACTIVE;
+            BKG_COLOR  = BKG_COLOR_ACTIVE;
          }
 
          /* Key background */
@@ -256,21 +257,21 @@ void print_virtual_kbd(unsigned short int *pixels)
          /* Key text shadow */
          if (pix_bytes == 4)
             Draw_text32((uint32_t *)pix, (FONT_COLOR_SEL == RGBc(250, 250, 250) ? XTEXT+FONT_WIDTH : XTEXT-FONT_WIDTH), (FONT_COLOR_SEL == RGBc(250, 250, 250) ? YTEXT+FONT_HEIGHT : YTEXT-FONT_HEIGHT), (FONT_COLOR_SEL == RGBc(250, 250, 250) ? RGBc(80, 80, 80) : RGBc(50, 50, 50)), BKG_COLOR, 100, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-               (!shifted) ? MVk[(y * NPLGN) + x + page].norml : MVk[(y * NPLGN) + x + page].shift);
+               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          else
             Draw_text(pix, (FONT_COLOR_SEL == RGBc(250, 250, 250) ? XTEXT+FONT_WIDTH : XTEXT-FONT_WIDTH), (FONT_COLOR_SEL == RGBc(250, 250, 250) ? YTEXT+FONT_HEIGHT : YTEXT-FONT_HEIGHT), (FONT_COLOR_SEL == RGBc(250, 250, 250) ? RGBc(80, 80, 80) : RGBc(50, 50, 50)), BKG_COLOR, 100, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-               (!shifted) ? MVk[(y * NPLGN) + x + page].norml : MVk[(y * NPLGN) + x + page].shift);
+               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
 
          /* Key text */
          if (pix_bytes == 4)
          {
             Draw_text32((uint32_t *)pix, XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, 220, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-               (!shifted) ? MVk[(y * NPLGN) + x + page].norml : MVk[(y * NPLGN) + x + page].shift);
+               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          }
          else
          {
             Draw_text(pix, XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, 220, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-               (!shifted) ? MVk[(y * NPLGN) + x + page].norml : MVk[(y * NPLGN) + x + page].shift);
+               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          }
       }
    }
@@ -282,12 +283,12 @@ void print_virtual_kbd(unsigned short int *pixels)
    YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
 
    /* Opacity */
-   BKG_ALPHA = (SHOWKEYTRANS == -1) ? 250 : 220;
+   BKG_ALPHA = (retro_vkbd_transparent) ? 220 : 250;
 
    /* Pressed key color */
-   if (vkflag[4] == 1 && (MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].val == vkey_sticky1 || MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].val == vkey_sticky2))
-      ; // no-op
-   else if (vkflag[4] == 1)
+   if (vkflag[4] && (vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].value == vkey_sticky1 || vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].value == vkey_sticky2))
+      ; /* no-op */
+   else if (vkflag[4])
       BKG_COLOR_SEL = BKG_COLOR_ACTIVE;
    else
       FONT_COLOR = FONT_COLOR_SEL;
@@ -302,12 +303,12 @@ void print_virtual_kbd(unsigned short int *pixels)
    if (pix_bytes == 4)
    {
       Draw_text32((uint32_t *)pix, XTEXT, YTEXT, FONT_COLOR, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-         (!shifted) ? MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].norml : MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].shift);
+         (!shifted) ? vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].normal : vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift);
    }
    else
    {
       Draw_text(pix, XTEXT, YTEXT, FONT_COLOR, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-         (!shifted) ? MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].norml : MVk[(vkey_pos_y * NPLGN) + vkey_pos_x + page].shift);
+         (!shifted) ? vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].normal : vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift);
    }
 
 #ifdef POINTER_DEBUG
@@ -321,6 +322,6 @@ void print_virtual_kbd(unsigned short int *pixels)
 int check_vkey(int x, int y)
 {
    /* Check which key is pressed */
-   int page = (NPAGE == -1) ? 0 : NPLGN * NLIGN;
-   return MVk[(y * NPLGN) + x + page].val;
+   int page = (retro_vkbd_page) ? VKBDX * VKBDY : 0;
+   return vkeys[(y * VKBDX) + x + page].value;
 }

--- a/libretro/vkbd_def.h
+++ b/libretro/vkbd_def.h
@@ -4,14 +4,14 @@
 #include "keyboard.h"
 
 typedef struct {
-	char norml[NLETT];
-	char shift[NLETT];
-	int val;	
-} Mvk;
+	char normal[9];
+	char shift[9];
+	int value;	
+} retro_vkeys;
 
-Mvk MVk[NPLGN * NLIGN * 2] = {
+retro_vkeys vkeys[VKBDX * VKBDY * 2] = {
 
-   // -11
+   /* -11 */
    { {10,'L'},{10,'L'},-15 },
    { {10,'R'},{10,'R'},-16 },
    { {10,30},{10,30},-11 },
@@ -22,9 +22,9 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "TRBF","TRBF",-19 },
    { "ASPR","ASPR",-22 },
    { "STBR","STBR",-21 },
-   { {17}  ,{17}  ,-20 }, // Reset
+   { {17}  ,{17}  ,-20 }, /* Reset */
 
-   // 0 PG1
+   /* 0 PG1 */
    { "Esc" ,"Esc" ,AK_ESC },
    { "F1"  ,"F1"  ,AK_F1 },
    { "F2"  ,"F2"  ,AK_F2 },
@@ -37,7 +37,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "F9"  ,"F9"  ,AK_F9 },
    { "F10" ,"F10" ,AK_F10 },
 
-   // 11
+   /* 11 */
    { "`"   ,"~"   ,AK_BACKQUOTE },
    { "1"   ,"!"   ,AK_1 },
    { "2"   ,"@"   ,AK_2 },
@@ -50,7 +50,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "9"   ,"("   ,AK_9 },
    { "0"   ,")"   ,AK_0 },
 
-   // 22
+   /* 22 */
    { {11}  ,{11}  ,AK_TAB },
    { "Q"   ,"Q"   ,AK_Q },
    { "W"   ,"W"   ,AK_W },
@@ -63,7 +63,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "O"   ,"O"   ,AK_O },
    { "P"   ,"P"   ,AK_P },
 
-   // 33
+   /* 33 */
    { "Ctrl","Ctrl",AK_CTRL },
    { "A"   ,"A"   ,AK_A },
    { "S"   ,"S"   ,AK_S },
@@ -76,7 +76,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "L"   ,"L"   ,AK_L },
    { ";"   ,":"   ,AK_SEMICOLON },
 
-   // 44
+   /* 44 */
    { "CapsLock","CapsLock",AK_CAPSLOCK },
    { "Z"   ,"Z"   ,AK_Z },
    { "X"   ,"X"   ,AK_X },
@@ -89,7 +89,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "."   ,">"   ,AK_PERIOD },
    { "/"   ,"?"   ,AK_SLASH },
 
-   // 55
+   /* 55 */
    { {12}  ,{12}  ,AK_LSH },
    { "-"   ,"_"   ,AK_MINUS },
    { "="   ,"+"   ,AK_EQUAL },
@@ -102,13 +102,13 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { {30}  ,{30}  ,AK_UP },
    { "Help","Help",AK_HELP },
 
-   // 66
+   /* 66 */
    { "Alt" ,"Alt" ,AK_LALT },
    { {14}  ,{14}  ,AK_LAMI },
    { {18}  ,{18}  ,AK_SPC },
    { {13}  ,{13}  ,AK_RAMI },
    { "Alt" ,"Alt" ,AK_RALT },
-   { {15}  ,{15}  ,-2 }, // Numpad
+   { {15}  ,{15}  ,-2 }, /* Numpad */
    { {25}  ,{25}  ,AK_BS },
    { {16}  ,{16}  ,AK_RET },
    { {27}  ,{27}  ,AK_LF },
@@ -117,7 +117,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
 
 
 
-   // -11
+   /* -11 */
    { {10,'L'},{10,'L'},-15 },
    { {10,'R'},{10,'R'},-16 },
    { {10,30},{10,30},-11 },
@@ -128,9 +128,9 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "TRBF","TRBF",-19 },
    { "ASPR","ASPR",-22 },
    { "STBR","STBR",-21 },
-   { {17}  ,{17}  ,-20 }, // Reset
+   { {17}  ,{17}  ,-20 }, /* Reset */
 
-   // 0 PG2
+   /* 0 PG2 */
    { "Esc" ,"Esc" ,AK_ESC },
    { "F1"  ,"F1"  ,AK_F1 },
    { "F2"  ,"F2"  ,AK_F2 },
@@ -143,7 +143,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "F9"  ,"F9"  ,AK_F9 },
    { "F10" ,"F10" ,AK_F10 },
 
-   // 11
+   /* 11 */
    { "`"     ,"~"    ,AK_BACKQUOTE },
    { {15,'1'},"End"  ,AK_NP1 },
    { {15,'2'},{15,28},AK_NP2 },
@@ -156,7 +156,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { {15,'9'},"PgUp" ,AK_NP9 },
    { {15,'0'},"Ins"  ,AK_NP0 },
 
-   // 22
+   /* 22 */
    { {11}  ,{11}  ,AK_TAB },
    { "Q"   ,"Q"   ,AK_Q },
    { "W"   ,"W"   ,AK_W },
@@ -169,7 +169,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "O"   ,"O"   ,AK_O },
    { "P"   ,"P"   ,AK_P },
 
-   // 33
+   /* 33 */
    { "Ctrl","Ctrl",AK_CTRL },
    { "A"   ,"A"   ,AK_A },
    { "S"   ,"S"   ,AK_S },
@@ -182,7 +182,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "L"   ,"L"   ,AK_L },
    { ";"   ,":"   ,AK_SEMICOLON },
 
-   // 44
+   /* 44 */
    { "CapsLock","CapsLock",AK_CAPSLOCK },
    { "Z"   ,"Z"   ,AK_Z },
    { "X"   ,"X"   ,AK_X },
@@ -195,7 +195,7 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { "."   ,">"   ,AK_PERIOD },
    { "/"   ,"?"   ,AK_SLASH },
 
-   // 55
+   /* 55 */
    { {12}  ,{12}  ,AK_LSH },
    { {15,'-'},{15,'-'},AK_NPSUB },
    { {15,'+'},{15,'+'},AK_NPADD },
@@ -208,13 +208,13 @@ Mvk MVk[NPLGN * NLIGN * 2] = {
    { {15,30} ,{15,30},AK_NP8 },
    { "Help","Help",AK_HELP },
 
-   // 66
+   /* 66 */
    { "Alt" ,"Alt" ,AK_LALT },
    { {14}  ,{14}  ,AK_LAMI },
    { {18}  ,{18}  ,AK_SPC },
    { {13}  ,{13}  ,AK_RAMI },
    { "Alt" ,"Alt" ,AK_RALT },
-   { {15}  ,{15}  ,-2 }, // Numpad
+   { {15}  ,{15}  ,-2 }, /* Numpad */
    { {25}  ,{25}  ,AK_BS },
    { {15,16},{15,16},AK_ENT },
    { {15,27},{15,27},AK_NP4 },

--- a/libretro/vkbd_def.h
+++ b/libretro/vkbd_def.h
@@ -4,9 +4,9 @@
 #include "keyboard.h"
 
 typedef struct {
-	char normal[9];
-	char shift[9];
-	int value;	
+   char normal[9];
+   char shift[9];
+   int value;
 } retro_vkeys;
 
 retro_vkeys vkeys[VKBDX * VKBDY * 2] = {

--- a/retrodep/debug.c
+++ b/retrodep/debug.c
@@ -1,0 +1,815 @@
+/*
+ * UAE - The Un*x Amiga Emulator
+ *
+ * Debugger
+ *
+ * (c) 1995 Bernd Schmidt
+ * (c) 2006 Toni Wilen
+ *
+ */
+
+#include "sysconfig.h"
+#include "sysdeps.h"
+
+#include <ctype.h>
+#include <signal.h>
+
+#include "options.h"
+#include "uae.h"
+#include "sources/src/include/memory_uae.h"
+#include "custom.h"
+#include "newcpu.h"
+#include "cpu_prefetch.h"
+#include "debug.h"
+#include "cia.h"
+#include "xwin.h"
+#include "identify.h"
+#include "audio.h"
+#include "disk.h"
+#include "savestate.h"
+#include "autoconf.h"
+#include "filesys.h"
+#include "akiko.h"
+#include "inputdevice.h"
+#include "crc32.h"
+#include "cpummu.h"
+#include "rommgr.h"
+#include "inputrecord.h"
+#include "calc.h"
+#include "cpummu.h"
+#include "cpummu030.h"
+#include "misc.h"
+
+/* internal members */
+int debugger_active;
+static uaecptr skipaddr_start, skipaddr_end;
+static int skipaddr_doskip;
+static uae_u32 skipins;
+static int do_skip;
+#ifdef SAVESTATE
+static int debug_rewind;
+#endif
+static int memwatch_enabled, memwatch_triggered;
+static uae_u16 sr_bpmask, sr_bpvalue;
+int debugging;
+int exception_debugging;
+int no_trace_exceptions;
+int debug_copper = 0;
+int debug_dma = 0;
+int debug_sprite_mask = 0xff;
+int debug_illegal = 0;
+uae_u64 debug_illegal_mask;
+static int debug_mmu_mode;
+
+static uaecptr processptr;
+static uae_char *processname;
+
+static uaecptr debug_copper_pc;
+
+extern int audio_channel_mask;
+extern int inputdevice_logging;
+extern void my_trim (TCHAR *s);
+
+#ifdef MMUEMU
+int safe_addr (uaecptr addr, int size);
+#endif
+
+#define console_out               printf
+#define console_flush()           fflush( stdout )
+#define console_get( input, len ) fgets( input, len, stdin )
+#define console_out_f printf
+
+void deactivate_debugger (void)
+{
+}
+
+void activate_debugger (void)
+{
+}
+
+int firsthist = 0;
+int lasthist = 0;
+static struct regstruct history[MAX_HIST];
+
+static TCHAR help[] = {};
+
+void debug_help (void)
+{
+}
+
+static int debug_linecounter;
+#define MAX_LINECOUNTER 1000
+
+static int debug_out (const TCHAR *format, ...)
+{
+	return 1;
+}
+
+#ifdef MMUEMU
+uae_u32 get_byte_debug (uaecptr addr)
+{
+	return 0xff;
+}
+
+uae_u32 get_word_debug (uaecptr addr)
+{
+	return 0xffff;
+}
+
+uae_u32 get_long_debug (uaecptr addr)
+{
+	return 0xffffffff;
+}
+
+uae_u32 get_iword_debug (uaecptr addr)
+{
+	return 0xffff;
+}
+
+uae_u32 get_ilong_debug (uaecptr addr)
+{
+	return 0xffffffff;
+}
+
+int safe_addr (uaecptr addr, int size)
+{
+	return 0;
+}
+#endif
+
+static bool iscancel (int counter)
+{
+	return true;
+}
+
+static bool isoperator(TCHAR **cp)
+{
+	return false;
+}
+
+static void ignore_ws (TCHAR **c)
+{
+}
+static TCHAR peekchar (TCHAR **c)
+{
+	return **c;
+}
+static TCHAR readchar (TCHAR **c)
+{
+	return 0;
+}
+static TCHAR next_char (TCHAR **c)
+{
+	return 0;
+}
+static TCHAR peek_next_char (TCHAR **c)
+{
+	return 0;
+}
+static int more_params (TCHAR **c)
+{
+	return 0;
+}
+
+static uae_u32 readint (TCHAR **c);
+static uae_u32 readhex (TCHAR **c);
+
+static int readregx (TCHAR **c, uae_u32 *valp)
+{
+	return 0;
+}
+
+static bool readbinx (TCHAR **c, uae_u32 *valp)
+{
+	return true;
+}
+
+static bool readhexx (TCHAR **c, uae_u32 *valp)
+{
+	return true;
+}
+
+static bool readintx (TCHAR **c, uae_u32 *valp)
+{
+	return true;
+}
+
+
+static int checkvaltype2 (TCHAR **c, uae_u32 *val, TCHAR def)
+{
+	return 0;
+}
+
+static int readsize (int val, TCHAR **c)
+{
+	return 0;
+}
+
+static int checkvaltype (TCHAR **cp, uae_u32 *val, int *size, TCHAR def)
+{
+	return 0;
+}
+
+
+static uae_u32 readnum (TCHAR **c, int *size, TCHAR def)
+{
+	return 0;
+}
+
+static uae_u32 readint (TCHAR **c)
+{
+	return 0;
+}
+static uae_u32 readhex (TCHAR **c)
+{
+	return 0;
+}
+#if 0
+static uae_u32 readbin (TCHAR **c)
+{
+	return 0;
+}
+#endif
+static uae_u32 readint_2 (TCHAR **c, int *size)
+{
+	return 0;
+}
+static uae_u32 readhex_2 (TCHAR **c, int *size)
+{
+	return 0;
+}
+
+static int next_string (TCHAR **c, TCHAR *out, int max, int forceupper)
+{
+	return 0;
+}
+
+static void converter (TCHAR **c)
+{
+}
+
+int notinrom (void)
+{
+	return 0;
+}
+
+static uae_u32 lastaddr (void)
+{
+	return currprefs.chipmem_size;
+}
+
+static uaecptr nextaddr2 (uaecptr addr, uaecptr *next)
+{
+	return addr;
+}
+
+static uaecptr nextaddr (uaecptr addr, uaecptr last, uaecptr *end)
+{
+	return addr;
+}
+
+uaecptr dumpmem2 (uaecptr addr, TCHAR *out, int osize)
+{
+	return addr;
+}
+
+static void dumpmem (uaecptr addr, uaecptr *nxmem, int lines)
+{
+}
+
+static void dump_custom_regs (int aga)
+{
+}
+
+static void dump_vectors (uaecptr addr)
+{
+}
+
+static void disassemble_wait (FILE *file, unsigned long insn)
+{
+}
+
+#define NR_COPPER_RECORDS 100000
+/* Record copper activity for the debugger.  */
+struct cop_rec
+{
+	int hpos, vpos;
+	uaecptr addr;
+};
+static struct cop_rec *cop_record[2];
+static int nr_cop_records[2], curr_cop_set;
+
+#define NR_DMA_REC_HPOS 256
+#define NR_DMA_REC_VPOS 1000
+static struct dma_rec *dma_record[2];
+static int dma_record_toggle;
+
+void record_dma_reset (void)
+{
+}
+
+void record_copper_reset (void)
+{
+}
+
+STATIC_INLINE uae_u32 ledcolor (uae_u32 c, uae_u32 *rc, uae_u32 *gc, uae_u32 *bc, uae_u32 *a)
+{
+	return 0;
+}
+
+STATIC_INLINE void putpixel (uae_u8 *buf, int bpp, int x, xcolnr c8)
+{
+}
+
+#define lc(x) ledcolor (x, xredcolors, xgreencolors, xbluecolors, NULL);
+void debug_draw_cycles (uae_u8 *buf, int bpp, int line, int width, int height, uae_u32 *xredcolors, uae_u32 *xgreencolors, uae_u32 *xbluescolors)
+{
+}
+
+void record_dma_event (int evt, int hpos, int vpos)
+{
+}
+
+struct dma_rec *record_dma (uae_u16 reg, uae_u16 dat, uae_u32 addr, int hpos, int vpos, int type)
+{
+	struct dma_rec *dr;
+	return dr;
+}
+
+static void decode_dma_record (int hpos, int vpos, int toggle, bool logfile)
+{
+}
+void log_dma_record (void)
+{
+}
+
+void record_copper (uaecptr addr, int hpos, int vpos)
+{
+}
+
+static struct cop_rec *find_copper_records (uaecptr addr)
+{
+	return 0;
+}
+
+/* simple decode copper by Mark Cox */
+static void decode_copper_insn (FILE* file, unsigned long insn, unsigned long addr)
+{
+}
+
+static uaecptr decode_copperlist (FILE* file, uaecptr address, int nolines)
+{
+	return address;
+}
+
+static int copper_debugger (TCHAR **c)
+{
+	return 0;
+}
+
+#define MAX_CHEAT_VIEW 100
+struct trainerstruct {
+	uaecptr addr;
+	int size;
+};
+
+static struct trainerstruct *trainerdata;
+static int totaltrainers;
+
+static void clearcheater(void)
+{
+}
+static int addcheater(uaecptr addr, int size)
+{
+	return 0;
+}
+static void listcheater(int mode, int size)
+{
+}
+
+static void deepcheatsearch (TCHAR **c)
+{
+}
+
+/* cheat-search by Toni Wilen (originally by Holger Jakob) */
+static void cheatsearch (TCHAR **c)
+{
+}
+
+struct breakpoint_node bpnodes[BREAKPOINT_TOTAL];
+static addrbank **debug_mem_banks;
+static addrbank *debug_mem_area;
+struct memwatch_node mwnodes[MEMWATCH_TOTAL];
+static struct memwatch_node mwhit;
+
+static uae_u8 *illgdebug, *illghdebug;
+static int illgdebug_break;
+
+static void illg_free (void)
+{
+	xfree (illgdebug);
+	illgdebug = NULL;
+	xfree (illghdebug);
+	illghdebug = NULL;
+}
+
+static void illg_init (void)
+{
+}
+
+/* add special custom register check here */
+static void illg_debug_check (uaecptr addr, int rwi, int size, uae_u32 val)
+{
+}
+
+static void illg_debug_do (uaecptr addr, int rwi, int size, uae_u32 val)
+{
+}
+
+static int debug_mem_off (uaecptr addr)
+{
+	return 0;
+}
+
+struct smc_item {
+	uae_u32 addr;
+	uae_u8 cnt;
+};
+
+static int smc_size, smc_mode;
+static struct smc_item *smc_table;
+
+static void smc_free (void)
+{
+}
+
+static void initialize_memwatch (int mode);
+static void smc_detect_init (TCHAR **c)
+{
+}
+
+#define SMC_MAXHITS 8
+static void smc_detector (uaecptr addr, int rwi, int size, uae_u32 *valp)
+{
+}
+
+uae_u8 *save_debug_memwatch (int *len, uae_u8 *dstptr)
+{
+	return 0;
+}
+
+uae_u8 *restore_debug_memwatch (uae_u8 *src)
+{
+	return 0;
+}
+
+void restore_debug_memwatch_finish (void)
+{
+}
+
+static int memwatch_func (uaecptr addr, int rwi, int size, uae_u32 *valp)
+{
+	return 1;
+}
+
+static int mmu_hit (uaecptr addr, int size, int rwi, uae_u32 *v);
+
+static uae_u32 REGPARAM2 mmu_lget (uaecptr addr)
+{
+	return 0;
+}
+static uae_u32 REGPARAM2 mmu_wget (uaecptr addr)
+{
+	return 0;
+}
+static uae_u32 REGPARAM2 mmu_bget (uaecptr addr)
+{
+	return 0;
+}
+static void REGPARAM2 mmu_lput (uaecptr addr, uae_u32 v)
+{
+}
+static void REGPARAM2 mmu_wput (uaecptr addr, uae_u32 v)
+{
+}
+static void REGPARAM2 mmu_bput (uaecptr addr, uae_u32 v)
+{
+}
+
+static uae_u32 REGPARAM2 debug_lget (uaecptr addr)
+{
+	return 0;
+}
+static uae_u32 REGPARAM2 mmu_lgeti (uaecptr addr)
+{
+	return 0;
+}
+static uae_u32 REGPARAM2 mmu_wgeti (uaecptr addr)
+{
+	return 0;
+}
+
+static uae_u32 REGPARAM2 debug_wget (uaecptr addr)
+{
+	return 0;
+}
+static uae_u32 REGPARAM2 debug_bget (uaecptr addr)
+{
+	return 0;
+}
+static uae_u32 REGPARAM2 debug_lgeti (uaecptr addr)
+{
+	return 0;
+}
+static uae_u32 REGPARAM2 debug_wgeti (uaecptr addr)
+{
+	return 0;
+}
+static void REGPARAM2 debug_lput (uaecptr addr, uae_u32 v)
+{
+}
+static void REGPARAM2 debug_wput (uaecptr addr, uae_u32 v)
+{
+}
+static void REGPARAM2 debug_bput (uaecptr addr, uae_u32 v)
+{
+}
+static int REGPARAM2 debug_check (uaecptr addr, uae_u32 size)
+{
+	return 0;
+}
+static uae_u8 *REGPARAM2 debug_xlate (uaecptr addr)
+{
+	return 0;
+}
+
+uae_u16 debug_wputpeekdma (uaecptr addr, uae_u32 v)
+{
+	return 0;
+}
+uae_u16 debug_wgetpeekdma (uaecptr addr, uae_u32 v)
+{
+	return 0;
+}
+
+#if 0
+void debug_putlpeek (uaecptr addr, uae_u32 v)
+{
+}
+#endif
+void debug_wputpeek (uaecptr addr, uae_u32 v)
+{
+}
+void debug_bputpeek (uaecptr addr, uae_u32 v)
+{
+}
+void debug_bgetpeek (uaecptr addr, uae_u32 v)
+{
+}
+void debug_wgetpeek (uaecptr addr, uae_u32 v)
+{
+}
+void debug_lgetpeek (uaecptr addr, uae_u32 v)
+{
+}
+
+struct membank_store
+{
+	addrbank *addr;
+	addrbank store;
+};
+
+static struct membank_store *membank_stores;
+
+static int deinitialize_memwatch (void)
+{
+	return 0;
+}
+
+static void initialize_memwatch (int mode)
+{
+}
+
+int debug_bankchange (int mode)
+{
+	return -1;
+}
+
+static TCHAR *getsizechar (int size)
+{
+	return "";
+}
+
+void memwatch_dump2 (TCHAR *buf, int bufsize, int num)
+{
+}
+
+static void memwatch_dump (int num)
+{
+}
+
+static void memwatch (TCHAR **c)
+{
+}
+
+static void writeintomem (TCHAR **c)
+{
+}
+
+static uae_u8 *dump_xlate (uae_u32 addr)
+{
+	return 0;
+}
+
+static void memory_map_dump_2 (int log)
+{
+}
+void memory_map_dump (void)
+{
+}
+
+STATIC_INLINE uaecptr BPTR2APTR (uaecptr addr)
+{
+	return addr << 2;
+}
+
+static void print_task_info (uaecptr node)
+{
+}
+
+static void show_exec_tasks (void)
+{
+}
+
+static uaecptr get_base (const uae_char *name, int offset)
+{
+	return 0xffffffff;
+}
+
+static TCHAR *getfrombstr(uaecptr pp)
+{
+	return "";
+}
+
+static void show_exec_lists (TCHAR *t)
+{
+}
+
+static uaecptr nextpc;
+
+int instruction_breakpoint (TCHAR **c)
+{
+	return 1;
+}
+
+static int process_breakpoint(TCHAR **c)
+{
+	return 1;
+}
+
+static void savemem (TCHAR **cc)
+{
+}
+
+static void searchmem (TCHAR **cc)
+{
+}
+
+static int staterecorder (TCHAR **cc)
+{
+	return 0;
+}
+
+static int debugtest_modes[DEBUGTEST_MAX];
+static const TCHAR *debugtest_names[] = {
+	_T("Blitter"), _T("Keyboard"), _T("Floppy")
+};
+
+void debugtest (enum debugtest_item di, const TCHAR *format, ...)
+{
+}
+
+static void debugtest_set (TCHAR **inptr)
+{
+}
+
+static void debug_sprite (TCHAR **inptr)
+{
+}
+
+static void disk_debug (TCHAR **inptr)
+{
+}
+
+static void find_ea (TCHAR **inptr)
+{
+}
+
+static void m68k_modify (TCHAR **inptr)
+{
+}
+
+static uaecptr nxdis, nxmem;
+
+static bool debug_line (TCHAR *input)
+{
+	return false;
+}
+
+static void debug_1 (void)
+{
+}
+
+static void addhistory (void)
+{
+}
+
+void debug (void)
+{
+}
+
+const TCHAR *debuginfo (int mode)
+{
+	return "";
+}
+
+void mmu_disasm (uaecptr pc, int lines)
+{
+}
+
+static int mmu_logging;
+
+#define MMU_PAGE_SHIFT 16
+
+struct mmudata {
+	uae_u32 flags;
+	uae_u32 addr;
+	uae_u32 len;
+	uae_u32 remap;
+	uae_u32 p_addr;
+};
+
+static struct mmudata *mmubanks;
+static uae_u32 mmu_struct, mmu_callback, mmu_regs;
+static uae_u32 mmu_fault_bank_addr, mmu_fault_addr;
+static int mmu_fault_size, mmu_fault_rw;
+static int mmu_slots;
+static struct regstruct mmur;
+
+struct mmunode {
+	struct mmudata *mmubank;
+	struct mmunode *next;
+};
+static struct mmunode **mmunl;
+extern struct regstruct mmu_backup_regs;
+
+#define MMU_READ_U (1 << 0)
+#define MMU_WRITE_U (1 << 1)
+#define MMU_READ_S (1 << 2)
+#define MMU_WRITE_S (1 << 3)
+#define MMU_READI_U (1 << 4)
+#define MMU_READI_S (1 << 5)
+
+#define MMU_MAP_READ_U (1 << 8)
+#define MMU_MAP_WRITE_U (1 << 9)
+#define MMU_MAP_READ_S (1 << 10)
+#define MMU_MAP_WRITE_S (1 << 11)
+#define MMU_MAP_READI_U (1 << 12)
+#define MMU_MAP_READI_S (1 << 13)
+
+void mmu_do_hit (void)
+{
+}
+
+static void mmu_do_hit_pre (struct mmudata *md, uaecptr addr, int size, int rwi, uae_u32 v)
+{
+}
+
+static int mmu_hit (uaecptr addr, int size, int rwi, uae_u32 *v)
+{
+	return 0;
+}
+
+#ifdef JIT
+static void mmu_free_node(struct mmunode *mn)
+{
+}
+
+static void mmu_free(void)
+{
+}
+#endif
+
+static int getmmubank(struct mmudata *snptr, uaecptr p)
+{
+	return 0;
+}
+
+int mmu_init(int mode, uaecptr parm, uaecptr parm2)
+{
+	return 1;
+}
+
+void debug_parser (const TCHAR *cmd, TCHAR *out, uae_u32 outsize)
+{
+}

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -79,7 +79,7 @@ void retro_mouse_button(int port, int button, int state)
 /* --- joystick input --- */
 void retro_joystick(int port, int axis, int state)
 {
-    // disable mouse in normal ports, joystick/mouse inverted
+    /* Disable mouse in normal ports, joystick/mouse inverted */
     if (port < 2)
     {
         int m_port = (port == 0) ? 1 : 0;
@@ -90,7 +90,7 @@ void retro_joystick(int port, int axis, int state)
 
 void retro_joystick_analog(int port, int axis, int state)
 {
-    // disable mouse in normal ports, joystick/mouse inverted
+    /* Disable mouse in normal ports, joystick/mouse inverted */
     if (port < 2)
     {
         int m_port = (port == 0) ? 1 : 0;
@@ -101,7 +101,7 @@ void retro_joystick_analog(int port, int axis, int state)
 
 void retro_joystick_button(int port, int button, int state)
 {
-    // disable mouse in normal ports, joystick/mouse inverted
+    /* Disable mouse in normal ports, joystick/mouse inverted */
     if (port < 2)
     {
         int m_port = (port == 0) ? 1 : 0;
@@ -139,15 +139,15 @@ void retro_renderSound(short* samples, int sampleCount)
 
 void retro_flush_screen (struct vidbuf_description *gfxinfo, int ystart, int yend)
 {
-   // These values must be cached here, since the
-   // source variables will be reset before the frame
-   // ends and control is returned to the frontend
+   /* These values must be cached here, since the
+    * source variables will be reset before the frame
+    * ends and control is returned to the frontend */
    retro_thisframe_first_drawn_line = thisframe_first_drawn_line;
    retro_thisframe_last_drawn_line  = thisframe_last_drawn_line;
    retro_min_diwstart               = min_diwstart;
    retro_max_diwstop                = max_diwstop;
 
-   // Flag that we should end the frame, return out of retro_run
+   /* Flag that we should end the frame, return out of retro_run */
    libretro_frame_end = 1;
 }
 
@@ -183,7 +183,7 @@ int graphics_init(void) {
 
 #ifdef ENABLE_LOG_SCREEN
 	currprefs.gfx_height = 256;
-	currprefs.gfx_linedbl = 0;	//disable line doubling
+	currprefs.gfx_linedbl = 0;
 #else
 	currprefs.gfx_size_win.height = defaulth;
 #endif	
@@ -193,7 +193,9 @@ int graphics_init(void) {
 #else
 	pixbuf = (unsigned short int*) &retro_bmp[0];
 #endif
-	//printf("graphics init: pixbuf=%p color_mode=%d width=%d height=%d\n", pixbuf, currprefs.color_mode, currprefs.gfx_size_win.width, currprefs.gfx_size_win.height);
+#if 0
+	printf("graphics init: pixbuf=%p color_mode=%d width=%d height=%d\n", pixbuf, currprefs.color_mode, currprefs.gfx_size_win.width, currprefs.gfx_size_win.height);
+#endif
 	if (pixbuf == NULL) {
 		printf("Error: not enough memory to initialize screen buffer!\n");
 		return -1;
@@ -239,8 +241,8 @@ int mousehack_allowed (void)
 
 int graphics_setup(void)
 {
-	//32bit mode
-	//Rw, Gw, Bw,   Rs, Gs, Bs,   Aw, As, Avalue, swap
+	/* 32bit mode
+	 *                   Rw,Gw,Bw,Rs, Gs,Bs,Aw,As,Avalue,swap */
 	if (pix_bytes == 2)
 		alloc_colors64k (5, 6, 5, 11, 5, 0, 0, 0, 0, 0); 
 	else
@@ -304,7 +306,9 @@ int check_prefs_changed_gfx (void)
     gfxvidinfo.height_allocated         = currprefs.gfx_size_win.height;
     gfxvidinfo.rowbytes                 = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes;
 
-    //printf("check_prefs_changed_gfx: %d:%d, res:%d vres:%d\n", changed_prefs.gfx_size_win.width, changed_prefs.gfx_size_win.height, changed_prefs.gfx_resolution, changed_prefs.gfx_vresolution);
+#if 0
+    printf("check_prefs_changed_gfx: %d:%d, res:%d vres:%d\n", changed_prefs.gfx_size_win.width, changed_prefs.gfx_size_win.height, changed_prefs.gfx_resolution, changed_prefs.gfx_vresolution);
+#endif
     return 1;
 }
 
@@ -764,7 +768,9 @@ void clearallkeys (void)
 
 void keyboard_settrans (void)
 {
-    //inputdevice_setkeytranslation (keytrans, kbmaps);
+#if 0
+    inputdevice_setkeytranslation (keytrans, kbmaps);
+#endif
 }
 
 
@@ -806,11 +812,11 @@ int sensible_strcmp(char *a, char *b)
    for (i = 0; a[i] == b[i]; i++)
       if (a[i] == '\0')
          return 0;
-   // Replace " " (32) with "/" (47) when comparing for more natural sorting, such as:
-   // 1. Turrican
-   // 2. Turrican II
-   // 3. Turrican III
-   // Because "/" (47) is bigger than "," (44) and "." (46), and it is not used in filenames
+   /* Replace " " (32) with "/" (47) when comparing for more natural sorting, such as:
+    * 1. Turrican
+    * 2. Turrican II
+    * 3. Turrican III
+    * Because "/" (47) is bigger than "," (44) and "." (46), and it is not used in filenames */
    if (a[i] == 32)
       return (47 < (unsigned char)b[i]) ? -1 : 1;
    if (b[i] == 32)

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -11,7 +11,7 @@
 #include "hrtimer.h"
 
 #include "inputdevice.h"
-void inputdevice_release_all_keys (void);
+void inputdevice_release_all_keys(void);
 extern int mouse_port[NORMAL_JPORTS];
 
 #include "drawing.h"
@@ -31,20 +31,11 @@ extern int defaulth;
 extern int libretro_runloop_active;
 extern int libretro_frame_end;
 
-unsigned short int clut[] = {
-	0x0000,  /* full background transparency */
-	0x0200,  /* background semi transparent */
-	0x06FF,  /* opaque + light orange */
-	0x06AA,  /* opaque + dark orange  */
-} ;
-
 unsigned short int* pixbuf = NULL;
-
 extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
 void retro_audio_batch_cb(const int16_t *data, size_t frames);
 
 int prefs_changed = 0;
-int vsync_enabled = 0;
 int opt_scrw = 0;
 int opt_scrh = 0;
 unsigned long stat_value = 0;
@@ -126,12 +117,12 @@ void retro_joystick_button(int port, int button, int state)
 /* --- keyboard input --- */
 void retro_key_down(int key)
 {
-	inputdevice_do_keyboard (key, 1);
+	inputdevice_do_keyboard(key, 1);
 }
 
 void retro_key_up(int key)
 {
-	inputdevice_do_keyboard (key, 0);
+	inputdevice_do_keyboard(key, 0);
 }
 
 
@@ -141,7 +132,7 @@ void retro_renderSound(short* samples, int sampleCount)
     if ((sampleCount < 1) || !libretro_runloop_active)
         return;
 #if 0
-    for(int i=0; i<sampleCount; i+=2)
+    for (int i=0; i<sampleCount; i+=2)
     {
         retro_audio_cb(samples[i], samples[i+1]);
     }
@@ -244,9 +235,8 @@ int is_fullscreen (void)
 
 int is_vsync (void)
 {
-    return vsync_enabled;
+    return 0;
 }
-
 
 int mousehack_allowed (void)
 {

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -754,6 +754,36 @@ void setcapslockstate (int state)
 {
 }
 
+#if 0
+static struct uae_input_device_kbr_default keytrans_amiga[] = {
+    { -1, {{0}} }
+};
+
+static struct uae_input_device_kbr_default keytrans_pc1[] = {
+    { -1, {{0, 0}} }
+};
+
+static struct uae_input_device_kbr_default *keytrans[] = {
+    keytrans_amiga,
+    keytrans_pc1,
+    keytrans_pc1
+};
+
+static int *kbmaps[] = {
+};
+
+void clearallkeys (void)
+{
+    inputdevice_updateconfig (&changed_prefs, &currprefs);
+}
+#endif
+
+void keyboard_settrans (void)
+{
+    //inputdevice_setkeytranslation (keytrans, kbmaps);
+}
+
+
 /********************************************************************
     Misc fuctions
 *********************************************************************/

--- a/retrodep/retroglue.c
+++ b/retrodep/retroglue.c
@@ -23,11 +23,10 @@ extern int mouse_port[NORMAL_JPORTS];
 #include "retro_files.h"
 #include "file/file_path.h"
 extern unsigned int uae_devices[4];
-extern unsigned int inputdevice_finalized;
+bool inputdevice_finalized = false;
 
 extern int defaultw;
 extern int defaulth;
-
 extern int libretro_runloop_active;
 extern int libretro_frame_end;
 
@@ -36,9 +35,6 @@ extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
 void retro_audio_batch_cb(const int16_t *data, size_t frames);
 
 int prefs_changed = 0;
-int opt_scrw = 0;
-int opt_scrh = 0;
-unsigned long stat_value = 0;
 
 int retro_thisframe_first_drawn_line;
 int retro_thisframe_last_drawn_line;
@@ -191,8 +187,6 @@ int graphics_init(void) {
 #else
 	currprefs.gfx_size_win.height = defaulth;
 #endif	
-	opt_scrw = currprefs.gfx_size_win.width;
-	opt_scrh = currprefs.gfx_size_win.height;
 
 #ifdef ENABLE_LOG_SCREEN
 	pixbuf = (unsigned int*) malloc(currprefs.gfx_size_win.width * 576 * pix_bytes);
@@ -501,7 +495,7 @@ int input_get_default_joystick (struct uae_input_device *uid, int num, int port,
     uid[2].enabled = 1;
     uid[3].enabled = 1;
 
-    inputdevice_finalized = 1;
+    inputdevice_finalized = true;
 
     currprefs.input_analog_joystick_mult = 100;
     currprefs.input_analog_joystick_offset = 0;

--- a/retrodep/sounddep/sound.c
+++ b/retrodep/sounddep/sound.c
@@ -102,8 +102,10 @@ int init_sound (void)
     sample_handler =  sample16s_handler;
     sound_initialized = 1;
 
-    //init_sound_table16();
-    //scaled_sample_evtime = (unsigned long)(MAXHPOS_PAL * MAXVPOS_PAL * VBLANK_HZ_PAL + rate - 1) / DEFAULT_SOUND_FREQ;
+#if 0
+    init_sound_table16();
+    scaled_sample_evtime = (unsigned long)(MAXHPOS_PAL * MAXVPOS_PAL * VBLANK_HZ_PAL + rate - 1) / DEFAULT_SOUND_FREQ;
+#endif
 
 #ifdef DRIVESOUND
 	driveclick_init();

--- a/retrodep/sounddep/sound.h
+++ b/retrodep/sounddep/sound.h
@@ -52,7 +52,6 @@ void restart_sound_buffer (void);
 
 #define PUT_SOUND_BYTE(b) do { *(uae_u8 *)sndbufpt = b; sndbufpt = (uae_u16 *)(((uae_u8 *)sndbufpt) + 1); } while (0)
 #define PUT_SOUND_WORD(b) do { *(uae_u16 *)sndbufpt = b; sndbufpt = (uae_u16 *)(((uae_u8 *)sndbufpt) + 2); } while (0)
-//#define PUT_SOUND_WORD(b) PUT_SOUND_BYTE(b << 8); PUT_SOUND_BYTE(b >> 8)
 
 #define PUT_SOUND_WORD_LEFT(b) PUT_SOUND_WORD(b)
 #define PUT_SOUND_WORD_RIGHT(b) PUT_SOUND_WORD(b)

--- a/retrodep/target.h
+++ b/retrodep/target.h
@@ -22,7 +22,10 @@
 #  define OPTIONSFILENAME "uaerc"
 # endif
 #endif
-//#define OPTIONS_IN_HOME
+
+#if 0
+#define OPTIONS_IN_HOME
+#endif
 
 #define DEFPRTNAME "lpr"
 #define DEFSERNAME "/dev/ttyS1"
@@ -56,4 +59,3 @@
 #define DEFSERNAME "null"
 
 #endif
-

--- a/retrodep/threaddep/thread.c
+++ b/retrodep/threaddep/thread.c
@@ -9,121 +9,112 @@
   * This handles initialization when using named semaphores.
   * Idea stolen from SDL.
   */
+
+#include "sysconfig.h"
+#include "sysdeps.h"
+#include "thread.h"
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <process.h>
 
-#include "sysconfig.h"
-#include "sysdeps.h"
-
-#include "thread.h"
 void uae_sem_init (uae_sem_t * event, int manual_reset, int initial_state)
 {
-        if(*event) {
-                if (initial_state)
-                        SetEvent (*event);
-                else
-                        ResetEvent (*event);
-        } else {
-                *event = CreateEvent (NULL, manual_reset, initial_state, NULL);
-        }
+   if(*event) {
+      if (initial_state)
+         SetEvent (*event);
+      else
+         ResetEvent (*event);
+   } else {
+      *event = CreateEvent (NULL, manual_reset, initial_state, NULL);
+   }
 }
 
 void uae_sem_wait (uae_sem_t * event)
 {
-        WaitForSingleObject (*event, INFINITE);
+   WaitForSingleObject (*event, INFINITE);
 }
 
 void uae_sem_post (uae_sem_t * event)
 {
-        SetEvent (*event);
+   SetEvent (*event);
 }
 
 int uae_sem_trywait (uae_sem_t * event)
 {
-        return WaitForSingleObject (*event, 0) == WAIT_OBJECT_0 ? 0 : -1;
+   return WaitForSingleObject (*event, 0) == WAIT_OBJECT_0 ? 0 : -1;
 }
 
 void uae_sem_destroy (uae_sem_t * event)
 {
-        if (*event) {
-                CloseHandle (*event);
-                *event = NULL;
-        }
+   if (*event) {
+      CloseHandle (*event);
+      *event = NULL;
+   }
 }
-
-
 
 typedef unsigned (__stdcall *BEGINTHREADEX_FUNCPTR)(void *);
 
 struct thparms
 {
-        void *(*f)(void*);
-        void *arg;
+   void *(*f)(void*);
+   void *arg;
 };
 
 static unsigned __stdcall thread_init (void *f)
 {
-        struct thparms *thp = (struct thparms*)f;
-        void *(*fp)(void*) = thp->f;
-        void *arg = thp->arg;
+   struct thparms *thp = (struct thparms*)f;
+   void *(*fp)(void*) = thp->f;
+   void *arg = thp->arg;
 
-        xfree (f);
-
-
-                fp (arg);
-
-
-
-        return 0;
+   xfree (f);
+   fp (arg);
+   return 0;
 }
 
 void uae_end_thread (uae_thread_id *tid)
 {
-        if (tid) {
-                CloseHandle (*tid);
-                *tid = NULL;
-        }
+   if (tid) {
+      CloseHandle (*tid);
+      *tid = NULL;
+   }
 }
 
 int uae_start_thread (const TCHAR *name, void *(*f)(void *), void *arg, uae_thread_id *tid)
 {
-        HANDLE hThread;
-        int result = 1;
-        unsigned foo;
-        struct thparms *thp;
+   HANDLE hThread;
+   int result = 1;
+   unsigned foo;
+   struct thparms *thp;
 
-        thp = xmalloc (struct thparms, 1);
-        thp->f = f;
-        thp->arg = arg;
-        hThread = (HANDLE)_beginthreadex (NULL, 0, thread_init, thp, 0, &foo);
-        if (hThread) {
-                if (name) {
-                        //write_log (_T("Thread '%s' started (%d)\n"), name, hThread);
-                        
-                                SetThreadPriority (hThread, THREAD_PRIORITY_HIGHEST);
-                        
-                }
-        } else {
-                result = 0;
-                write_log (_T("Thread '%s' failed to start!?\n"), name ? name : _T("<unknown>"));
-        }
-        if (tid)
-                *tid = hThread;
-        else
-                CloseHandle (hThread);
-        return result;
+   thp = xmalloc (struct thparms, 1);
+   thp->f = f;
+   thp->arg = arg;
+   hThread = (HANDLE)_beginthreadex (NULL, 0, thread_init, thp, 0, &foo);
+   if (hThread) {
+      if (name) {
+         /* write_log (_T("Thread '%s' started (%d)\n"), name, hThread); */
+            SetThreadPriority (hThread, THREAD_PRIORITY_HIGHEST);
+      }
+   } else {
+      result = 0;
+      write_log (_T("Thread '%s' failed to start!?\n"), name ? name : _T("<unknown>"));
+   }
+   if (tid)
+      *tid = hThread;
+   else
+      CloseHandle (hThread);
+   return result;
 }
 
 int uae_start_thread_fast (void *(*f)(void *), void *arg, uae_thread_id *tid)
 {
-        int v = uae_start_thread (NULL, f, arg, tid);
-        if (*tid) {
-                 SetThreadPriority (*tid, THREAD_PRIORITY_HIGHEST);
-                
-        }
-        return v;
+   int v = uae_start_thread (NULL, f, arg, tid);
+   if (*tid) {
+      SetThreadPriority (*tid, THREAD_PRIORITY_HIGHEST);
+   }
+   return v;
 }
 
 DWORD_PTR cpu_affinity = 1, cpu_paffinity = 1;
@@ -131,28 +122,24 @@ DWORD_PTR cpu_affinity = 1, cpu_paffinity = 1;
 void uae_set_thread_priority (int pri)
 {
 #ifndef __LIBRETRO__
-    if (!SetThreadPriority (GetCurrentThread(), THREAD_PRIORITY_HIGHEST))
-        SetThreadPriority (GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+   if (!SetThreadPriority (GetCurrentThread(), THREAD_PRIORITY_HIGHEST))
+      SetThreadPriority (GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
 #endif
 }
 
-#else
-
-#include "sysconfig.h"
-#include "sysdeps.h"
+#else /* _WIN32 */
 
 #ifdef WIIU
+
 #include <wiiu_pthread.h>
 #include <wiiu/os/semaphore.h>
 
-#else
+#else /* WIIU */
+
 #include <pthread.h>
 #include <semaphore.h>
 
-#include "thread.h"
-
 #ifdef USE_NAMED_SEMAPHORES
-
 int uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value)
 {
     char name[32];
@@ -169,9 +156,7 @@ int uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value)
     }
     return result;
 }
-
 #else
-
 int uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value)
 {
 	if (!sem || (sem && sem->sem))
@@ -179,7 +164,7 @@ int uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value)
 	sem->sem = (sem_t*)calloc(1, sizeof(sem_t));
 	return sem_init (sem->sem, pshared, value);
 }
+#endif /* USE_NAMED_SEMAPHORES */
 
-#endif
 #endif
 #endif

--- a/retrodep/threaddep/thread.h
+++ b/retrodep/threaddep/thread.h
@@ -6,8 +6,8 @@
   * Copyright 1997 Bernd Schmidt
   * Copyright 2004 Richard Drummond
   */
-#ifdef _WIN32
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 typedef HANDLE uae_sem_t;
 typedef HANDLE uae_thread_id;
@@ -29,10 +29,11 @@ STATIC_INLINE void uae_wait_thread (uae_thread_id tid)
     WaitForSingleObject (tid, INFINITE);
     CloseHandle (tid);
 }
-#else //win32
+
+#else /* WIN32 */
 
 #ifdef WIIU
-//FIXME: write using wiiu semaphore
+/* FIXME: write using wiiu semaphore */
 #warning WIIU bad Hack rewrite me 
 
 #define TESTSEM 1
@@ -63,7 +64,6 @@ STATIC_INLINE int uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value)
 STATIC_INLINE int uae_sem_destroy (uae_sem_t *sem)
 {
 #ifdef TESTSEM
-
 	if ( sem->sem ) {
 		free(sem->sem);
 	}
@@ -76,8 +76,6 @@ STATIC_INLINE int uae_sem_destroy (uae_sem_t *sem)
 STATIC_INLINE int uae_sem_post (uae_sem_t *sem)
 {
 #ifdef TESTSEM
-
-
 	int retval;
 
 	if ( ! sem->sem ) {
@@ -90,16 +88,14 @@ STATIC_INLINE int uae_sem_post (uae_sem_t *sem)
 		printf("sem_post() failed");
 	}
 	return retval;
-
 #else
-return -1;
+    return -1;
 #endif
 }
 
 STATIC_INLINE int uae_sem_wait (uae_sem_t *sem)
 {
 #ifdef TESTSEM
-
 	int retval;
 
 	if ( ! sem->sem ) {
@@ -112,9 +108,8 @@ STATIC_INLINE int uae_sem_wait (uae_sem_t *sem)
 		printf("sem_wait() failed");
 	}
 	return retval;
-
 #else
-return -1;
+    return -1;
 #endif
 }
 
@@ -133,7 +128,7 @@ STATIC_INLINE int uae_sem_trywait (uae_sem_t *sem)
 	}
 	return retval;
 #else
-return -1;
+    return -1;
 #endif
 }
 
@@ -146,23 +141,20 @@ STATIC_INLINE int uae_sem_getvalue (uae_sem_t *sem, int *sval)
 	}
         return OSGetSemaphoreCount (sem->sem);
 #else
-return -1;
+    return -1;
 #endif
 }
 
-
-#else // WIIU
+#else /* WIIU */
 
 #include <pthread.h>
 #include <semaphore.h>
-
 
 typedef struct {
     sem_t *sem;
 } uae_sem_t;
 
 #ifndef USE_NAMED_SEMAPHORES
-
 int uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value);
 
 STATIC_INLINE int uae_sem_destroy (uae_sem_t *sem)
@@ -217,8 +209,7 @@ STATIC_INLINE int uae_sem_getvalue (uae_sem_t *sem, int *sval)
 {
     return sem->sem == 0 ? -1 : sem_getvalue (sem->sem, sval);
 }
-
-#endif
+#endif /* USE_NAMED_SEMAPHORES */
 
 #endif
 
@@ -248,9 +239,7 @@ STATIC_INLINE void uae_kill_thread (uae_thread_id* thread)
 	pthread_detach(*thread);
 }
 
-
 #define UAE_THREAD_EXIT pthread_exit(0)
-
 #define uae_set_thread_priority(pri)
 
 #endif

--- a/sources/src/custom.c
+++ b/sources/src/custom.c
@@ -77,7 +77,7 @@
 
 #ifdef __LIBRETRO__
 #include "libretro-core.h"
-extern bool retro_request_av_info_update;
+extern bool request_update_av_info;
 extern bool retro_av_info_change_timing;
 extern bool retro_av_info_is_ntsc;
 #endif
@@ -3238,9 +3238,9 @@ void compute_framesync (void)
 	);
 
 #ifdef __LIBRETRO__
-	retro_request_av_info_update = true;
-	retro_av_info_change_timing  = true;
-	retro_av_info_is_ntsc        = isntsc;
+	request_update_av_info      = true;
+	retro_av_info_change_timing = true;
+	retro_av_info_is_ntsc       = isntsc;
 #endif
 
 	config_changed = 1;

--- a/sources/src/custom.c
+++ b/sources/src/custom.c
@@ -76,7 +76,6 @@
 #endif
 
 #ifdef __LIBRETRO__
-#include "libretro-core.h"
 extern bool request_update_av_info;
 extern bool retro_av_info_change_timing;
 extern bool retro_av_info_is_ntsc;

--- a/sources/src/drawing.c
+++ b/sources/src/drawing.c
@@ -52,7 +52,7 @@
 
 #ifdef __LIBRETRO__
 #include "libretro-core.h"
-extern int STATUSON;
+extern bool retro_statusbar;
 extern void retro_set_led(unsigned);
 static unsigned led_on_prev = 0;
 static unsigned led_on = 0;
@@ -3462,7 +3462,7 @@ void finish_drawing_frame (void)
 	draw_frame2 ();
 
 #ifdef __LIBRETRO__
-	if (STATUSON == 1)
+	if (retro_statusbar)
 		print_statusbar();
 #endif
 	if (currprefs.leds_on_screen) {

--- a/sources/src/inputdevice.c
+++ b/sources/src/inputdevice.c
@@ -5342,7 +5342,9 @@ void inputdevice_updateconfig_internal (const struct uae_prefs *srcprrefs, struc
 {
 	int i;
 
+#ifndef __LIBRETRO__
 	keyboard_default = keyboard_default_table[currprefs.input_keyboard_type];
+#endif
 
 	copyjport (srcprrefs, dstprefs, 0);
 	copyjport (srcprrefs, dstprefs, 1);
@@ -5371,7 +5373,12 @@ void inputdevice_updateconfig_internal (const struct uae_prefs *srcprrefs, struc
 		mice[i].enabled = 0;
 	}
 
+#ifndef __LIBRETRO__
 	compatibility_copy (dstprefs, true);
+#else
+	compatibility_copy (dstprefs, false);
+#endif
+
 	joysticks = dstprefs->joystick_settings[dstprefs->input_selected_setting];
 	mice = dstprefs->mouse_settings[dstprefs->input_selected_setting];
 	keyboards = dstprefs->keyboard_settings[dstprefs->input_selected_setting];
@@ -5485,7 +5492,9 @@ void inputdevice_default_prefs (struct uae_prefs *p)
 	p->input_autofire_linecnt = 600;
 	p->input_keyboard_type = 0;
 
+#ifndef __LIBRETRO__
 	keyboard_default = keyboard_default_table[p->input_keyboard_type];
+#endif
 	inputdevice_default_kb_all (p);
 }
 

--- a/sources/src/statusline.c
+++ b/sources/src/statusline.c
@@ -15,9 +15,9 @@
 
 #ifdef __LIBRETRO__
 #include "libretro-core.h"
+extern bool retro_statusbar;
 extern int opt_statusbar;
 extern int opt_statusbar_position;
-extern int LEDON;
 static int num_multip = 1;
 #endif
 
@@ -166,7 +166,7 @@ static void write_tdnumber (uae_u8 *buf, int bpp, int x, int y, int num, uae_u32
 
 void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u32 *rc, uae_u32 *gc, uae_u32 *bc, uae_u32 *alpha)
 {
-    if (LEDON == -1)
+    if (!retro_statusbar)
         return;
 
     totalwidth = zoomed_width;


### PR DESCRIPTION
New:
- Filepath tag `(CE)` for forcing Cycle-exact (core option does nothing)
- Reduced `RETRO_ENVIRONMENT_SET_GEOMETRY` calls with Zoom Mode

Horizontal centering changes:
- Added hacks for:
  - North & South (slightly not centered)
  - Zool (menu jumps left & right)
- Fixed offset:
  - Toki (not centered)

Please report any regressions!


Cleanups:
- Changed `// Comments` to `/* Comments */`
- Reorganized and renamed libretro variables for better readability
- Simplified hotkey mapper
- Removed debugger & internal keymap = core sized reduced ~110kB
- Minor statusbar pixel adjustments
- Separated horizontal + vertical centering functions


