### PR TITLE
Ubuntu 20.10 build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ else
    CFLAGS += -O3
 endif
 
-CFLAGS += -D__LIBRETRO__ -DINLINE="inline" -std=gnu99
+CFLAGS += -fcommon -D__LIBRETRO__ -DINLINE="inline" -std=gnu99
 
 include Makefile.common
 

--- a/retrodep/memory.c
+++ b/retrodep/memory.c
@@ -18,7 +18,9 @@
 #ifndef __CELLOS_LV2__
 #ifndef _WIN32
 #ifndef VITA
+#ifdef __APPLE__
 #include <sys/sysctl.h>
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
Ubuntu 20.10 and others have upgraded to GCC 10 and/or Linux 5.5 or newer kernels breaking the build:

- GCC 10.x defaults to -fno-common which breaks the build: add -fcommon to Makefile / CFLAGS to enforce pre GCC 10 behavior ( more info: https://gcc.gnu.org/gcc-10/porting_to.html )
- sysctl system call was removed in Linux 5.5 and Ubuntu 20.10 ships with 5.8 kernel; wrap sysctl in retrodep/memory.c to ifdef __APPLE ( more info https://man7.org/linux/man-pages/man2/sysctl.2.html )

Looks like sysctl(mib, 2, &totalphys64, &len, NULL, 0); syscall is only used inside #ifdef __APPLE__ block in retrodep/memory.c. It feels pretty safe to wrap #include <sys/sysctl.h> to #ifdef __APPLE__ to make this problem disappear. 

sources/src/od-generic/memory.c has similar sysctl construct, but since it appears not to be used when compiling on Ubuntu 20.10, I didn't touch it.

Caveat emptor - these changes sort of sweep the problem under the rug. But at least in the interim these fixes allow compiling lr-uae on Ubuntu 20.10 and other distros with recent kernels / toolchain.



