### PR TITLE
VKBD Optimisations

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -59,7 +59,7 @@ int opt_statusbar_position = 0;
 int opt_statusbar_position_old = 0;
 int opt_statusbar_position_offset = 0;
 unsigned int opt_vkbd_theme = 0;
-unsigned int opt_vkbd_alpha = 204;
+libretro_graph_alpha_t opt_vkbd_alpha = GRAPH_ALPHA_75;
 bool opt_keyrah_keypad = false;
 bool opt_keyboard_pass_through = false;
 bool opt_multimouse = false;
@@ -781,33 +781,18 @@ void retro_set_environment(retro_environment_t cb)
          "0"
       },
       {
-         "puae_vkbd_alpha",
+         "puae_vkbd_transparency",
          "Video > Virtual KBD Transparency",
          "Keyboard transparency can be toggled with RetroPad A.",
          {
-            { "0%", NULL },
-            { "5%", NULL },
-            { "10%", NULL },
-            { "15%", NULL },
-            { "20%", NULL },
-            { "25%", NULL },
-            { "30%", NULL },
-            { "35%", NULL },
-            { "40%", NULL },
-            { "45%", NULL },
-            { "50%", NULL },
-            { "55%", NULL },
-            { "60%", NULL },
-            { "65%", NULL },
-            { "70%", NULL },
-            { "75%", NULL },
-            { "80%", NULL },
-            { "85%", NULL },
-            { "90%", NULL },
-            { "95%", NULL },
+            { "0%",   NULL },
+            { "25%",  NULL },
+            { "50%",  NULL },
+            { "75%",  NULL },
+            { "100%", NULL },
             { NULL, NULL },
          },
-         "20%"
+         "25%"
       },
       {
          "puae_gfx_colors",
@@ -1777,11 +1762,20 @@ static void update_variables(void)
       opt_vkbd_theme = atoi(var.value);
    }
 
-   var.key = "puae_vkbd_alpha";
+   var.key = "puae_vkbd_transparency";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      opt_vkbd_alpha = 255 - (255 * atoi(var.value) / 100);
+      if (!strcmp(var.value, "0%"))
+         opt_vkbd_alpha = GRAPH_ALPHA_100;
+      else if (!strcmp(var.value, "25%"))
+         opt_vkbd_alpha = GRAPH_ALPHA_75;
+      else if (!strcmp(var.value, "50%"))
+         opt_vkbd_alpha = GRAPH_ALPHA_50;
+      else if (!strcmp(var.value, "75%"))
+         opt_vkbd_alpha = GRAPH_ALPHA_25;
+      else if (!strcmp(var.value, "100%"))
+         opt_vkbd_alpha = GRAPH_ALPHA_0;
    }
 
    var.key = "puae_cpu_compatibility";
@@ -3206,6 +3200,9 @@ void retro_deinit(void)
    /* Clean ZIP temp */
    if (!string_is_empty(retro_temp_directory) && path_is_directory(retro_temp_directory))
       remove_recurse(retro_temp_directory);
+
+   /* Free buffers used by libretro-graph */
+   LibretroGraphFree();
 
    /* 'Reset' troublesome static variables */
    pix_bytes_initialized = false;

--- a/libretro/libretro-graph.h
+++ b/libretro/libretro-graph.h
@@ -7,25 +7,35 @@ typedef struct
    int dx, dy;
 } box;
 
-extern void DrawFBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color, unsigned int alpha);
-extern void DrawFBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color, unsigned int alpha);
+typedef enum {
+   GRAPH_ALPHA_0 = 0,
+   GRAPH_ALPHA_25,
+   GRAPH_ALPHA_50,
+   GRAPH_ALPHA_75,
+   GRAPH_ALPHA_100
+} libretro_graph_alpha_t;
 
-extern void DrawBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-extern void DrawBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
+void DrawFBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color, libretro_graph_alpha_t alpha);
+void DrawFBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color, libretro_graph_alpha_t alpha);
 
-extern void DrawPointBmp(unsigned short *buffer, int x, int y, unsigned short color);
+void DrawBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
 
-extern void DrawHlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-extern void DrawHlineBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
-extern void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawPointBmp(unsigned short *buffer, int x, int y, unsigned short color);
 
-extern void DrawVlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-extern void DrawlineBmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color);
+void DrawHlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawHlineBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
+void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
 
-extern void Draw_string(unsigned short *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, unsigned short int fg, unsigned short int bg, unsigned int alpha);
-extern void Draw_string32(uint32_t *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, uint32_t fg, uint32_t bg, unsigned int alpha);
+void DrawVlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawlineBmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color);
 
-extern void Draw_text(unsigned short *buffer, int x, int y, unsigned short fgcol, unsigned short int bgcol, unsigned int alpha, int scalex, int scaley, int max, char *string, ...);
-extern void Draw_text32(uint32_t *buffer, int x, int y, uint32_t fgcol, uint32_t bgcol, unsigned int alpha, int scalex, int scaley, int max, char *string, ...);
+void Draw_string(unsigned short *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, unsigned short int fg, unsigned short int bg, libretro_graph_alpha_t alpha, bool draw_bg);
+void Draw_string32(uint32_t *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, uint32_t fg, uint32_t bg, libretro_graph_alpha_t alpha, bool draw_bg);
+
+void Draw_text(unsigned short *buffer, int x, int y, unsigned short fgcol, unsigned short int bgcol, libretro_graph_alpha_t alpha, bool draw_bg, int scalex, int scaley, int max, char *string, ...);
+void Draw_text32(uint32_t *buffer, int x, int y, uint32_t fgcol, uint32_t bgcol, libretro_graph_alpha_t alpha, bool draw_bg, int scalex, int scaley, int max, char *string, ...);
+
+void LibretroGraphFree(void);
 
 #endif /* LIBRETRO_GRAPH_H */

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -667,55 +667,55 @@ void print_statusbar(void)
    /* Statusbar output */
    if (pix_bytes == 4)
    {
-      DrawFBoxBmp32((uint32_t *)retro_bmp, 0, BOX_Y, BOX_WIDTH, BOX_HEIGHT, 0, 255);
+      DrawFBoxBmp32((uint32_t *)retro_bmp, 0, BOX_Y, BOX_WIDTH, BOX_HEIGHT, 0, GRAPH_ALPHA_100);
 
       if (imagename_timer > 0)
       {
-         Draw_text32((uint32_t *)retro_bmp, TEXT_X, TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, TEXT_LENGTH, statusbar_text);
+         Draw_text32((uint32_t *)retro_bmp, TEXT_X, TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, TEXT_LENGTH, statusbar_text);
          return;
       }
 
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE1,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE1);
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT1,   TEXT_Y, JOY1_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT1);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE1,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE1);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT1,   TEXT_Y, JOY1_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT1);
 
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE2,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE2);
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT2,   TEXT_Y, JOY2_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT2);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE2,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE2);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT2,   TEXT_Y, JOY2_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT2);
 
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE3,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE3);
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT3,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT3);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE3,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE3);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT3,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT3);
 
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE4,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE4);
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT4,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT4);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYMODE4,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE4);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_JOYPORT4,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT4);
 
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_RESOLUTION, TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, RESOLUTION);
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_MEMORY,     TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, MEMORY);
-      Draw_text32((uint32_t *)retro_bmp, TEXT_X_MODEL,      TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, MODEL);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_RESOLUTION, TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, RESOLUTION);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_MEMORY,     TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, MEMORY);
+      Draw_text32((uint32_t *)retro_bmp, TEXT_X_MODEL,      TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, MODEL);
    }
    else
    {
-      DrawFBoxBmp(retro_bmp, 0, BOX_Y, BOX_WIDTH, BOX_HEIGHT, 0, 255);
+      DrawFBoxBmp(retro_bmp, 0, BOX_Y, BOX_WIDTH, BOX_HEIGHT, 0, GRAPH_ALPHA_100);
 
       if (imagename_timer > 0)
       {
-         Draw_text(retro_bmp, TEXT_X, TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, TEXT_LENGTH, statusbar_text);
+         Draw_text(retro_bmp, TEXT_X, TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, TEXT_LENGTH, statusbar_text);
          return;
       }
 
-      Draw_text(retro_bmp, TEXT_X_JOYMODE1,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE1);
-      Draw_text(retro_bmp, TEXT_X_JOYPORT1,   TEXT_Y, JOY1_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT1);
+      Draw_text(retro_bmp, TEXT_X_JOYMODE1,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE1);
+      Draw_text(retro_bmp, TEXT_X_JOYPORT1,   TEXT_Y, JOY1_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT1);
 
-      Draw_text(retro_bmp, TEXT_X_JOYMODE2,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE2);
-      Draw_text(retro_bmp, TEXT_X_JOYPORT2,   TEXT_Y, JOY2_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT2);
+      Draw_text(retro_bmp, TEXT_X_JOYMODE2,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE2);
+      Draw_text(retro_bmp, TEXT_X_JOYPORT2,   TEXT_Y, JOY2_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT2);
 
-      Draw_text(retro_bmp, TEXT_X_JOYMODE3,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE3);
-      Draw_text(retro_bmp, TEXT_X_JOYPORT3,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT3);
+      Draw_text(retro_bmp, TEXT_X_JOYMODE3,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE3);
+      Draw_text(retro_bmp, TEXT_X_JOYPORT3,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT3);
 
-      Draw_text(retro_bmp, TEXT_X_JOYMODE4,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE4);
-      Draw_text(retro_bmp, TEXT_X_JOYPORT4,   TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT4);
+      Draw_text(retro_bmp, TEXT_X_JOYMODE4,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYMODE4);
+      Draw_text(retro_bmp, TEXT_X_JOYPORT4,   TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, JOYPORT4);
 
-      Draw_text(retro_bmp, TEXT_X_RESOLUTION, TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, RESOLUTION);
-      Draw_text(retro_bmp, TEXT_X_MEMORY,     TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, MEMORY);
-      Draw_text(retro_bmp, TEXT_X_MODEL,      TEXT_Y, FONT_COLOR, 0, 255, FONT_WIDTH, FONT_HEIGHT, 10, MODEL);
+      Draw_text(retro_bmp, TEXT_X_RESOLUTION, TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, RESOLUTION);
+      Draw_text(retro_bmp, TEXT_X_MEMORY,     TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, MEMORY);
+      Draw_text(retro_bmp, TEXT_X_MODEL,      TEXT_Y, FONT_COLOR, 0, GRAPH_ALPHA_100, true, FONT_WIDTH, FONT_HEIGHT, 10, MODEL);
    }
 }
 

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -11,7 +11,7 @@ extern bool retro_capslock;
 extern int vkflag[10];
 extern unsigned int video_config_geometry;
 extern unsigned int opt_vkbd_theme;
-extern unsigned int opt_vkbd_alpha;
+extern libretro_graph_alpha_t opt_vkbd_alpha;
 
 int RGBc(int r, int g, int b)
 {
@@ -25,36 +25,36 @@ void print_vkbd(unsigned short int *pixels)
 {
    int x, y;
    bool shifted;
-   int page              = (retro_vkbd_page) ? VKBDX * VKBDY : 0;
-   uint16_t *pix         = &pixels[0];
+   int page                          = (retro_vkbd_page) ? VKBDX * VKBDY : 0;
+   uint16_t *pix                     = &pixels[0];
 
-   int XKEY              = 0;
-   int YKEY              = 0;
-   int XTEXT             = 0;
-   int YTEXT             = 0;
-   int XOFFSET           = 0;
-   int XPADDING          = 0;
-   int YOFFSET           = 0;
-   int YPADDING          = 0;
-   int XKEYSPACING       = 1;
-   int YKEYSPACING       = 1;
-   int ALPHA             = opt_vkbd_alpha;
-   int BKG_ALPHA         = ALPHA;
-   int BKG_PADDING_X     = 0;
-   int BKG_PADDING_Y     = 4;
-   int BKG_COLOR         = 0;
-   int BKG_COLOR_NORMAL  = 0;
-   int BKG_COLOR_ALT     = 0;
-   int BKG_COLOR_EXTRA   = 0;
-   int BKG_COLOR_SEL     = 0;
-   int BKG_COLOR_ACTIVE  = 0;
-   int FONT_MAX          = 4;
-   int FONT_WIDTH        = 1;
-   int FONT_HEIGHT       = 1;
-   int FONT_COLOR        = 0;
-   int FONT_COLOR_NORMAL = 0;
-   int FONT_COLOR_SEL    = 0;
-   int FONT_ALPHA        = 0;
+   int XKEY                          = 0;
+   int YKEY                          = 0;
+   int XTEXT                         = 0;
+   int YTEXT                         = 0;
+   int XOFFSET                       = 0;
+   int XPADDING                      = 0;
+   int YOFFSET                       = 0;
+   int YPADDING                      = 0;
+   int XKEYSPACING                   = 1;
+   int YKEYSPACING                   = 1;
+   libretro_graph_alpha_t ALPHA      = opt_vkbd_alpha;
+   libretro_graph_alpha_t BKG_ALPHA  = ALPHA;
+   int BKG_PADDING_X                 = 0;
+   int BKG_PADDING_Y                 = 4;
+   int BKG_COLOR                     = 0;
+   int BKG_COLOR_NORMAL              = 0;
+   int BKG_COLOR_ALT                 = 0;
+   int BKG_COLOR_EXTRA               = 0;
+   int BKG_COLOR_SEL                 = 0;
+   int BKG_COLOR_ACTIVE              = 0;
+   int FONT_MAX                      = 4;
+   int FONT_WIDTH                    = 1;
+   int FONT_HEIGHT                   = 1;
+   int FONT_COLOR                    = 0;
+   int FONT_COLOR_NORMAL             = 0;
+   int FONT_COLOR_SEL                = 0;
+   libretro_graph_alpha_t FONT_ALPHA = 0;
 
    switch (opt_vkbd_theme)
    {
@@ -180,10 +180,20 @@ void print_vkbd(unsigned short int *pixels)
    vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * VKBDY);
 
    /* Opacity */
-   BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : 255;
-   FONT_ALPHA = 255 - BKG_ALPHA;
-   FONT_ALPHA = (FONT_ALPHA < 60) ? 60 : FONT_ALPHA;
-   FONT_ALPHA = (FONT_ALPHA > 120) ? 120 : FONT_ALPHA;
+   BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
+   switch (BKG_ALPHA)
+   {
+      case GRAPH_ALPHA_0:
+      case GRAPH_ALPHA_25:
+      case GRAPH_ALPHA_50:
+         FONT_ALPHA = GRAPH_ALPHA_50;
+         break;
+      case GRAPH_ALPHA_75:
+      case GRAPH_ALPHA_100:
+      default:
+         FONT_ALPHA = GRAPH_ALPHA_25;
+         break;
+   }
 
    /* Alternate color keys */
    int alt_keys[] =
@@ -216,7 +226,7 @@ void print_vkbd(unsigned short int *pixels)
       {
          /* Default key color */
          BKG_COLOR = BKG_COLOR_NORMAL;
-         BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : 255;
+         BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
 
          /* Reset key color */
          if (vkeys[(y * VKBDX) + x].value == -20)
@@ -252,7 +262,20 @@ void print_vkbd(unsigned short int *pixels)
          {
             FONT_COLOR = FONT_COLOR_NORMAL;
             BKG_COLOR  = BKG_COLOR_ACTIVE;
-            BKG_ALPHA  = (BKG_ALPHA < 200) ? 200 : BKG_ALPHA;
+
+            switch (BKG_ALPHA)
+            {
+               case GRAPH_ALPHA_0:
+               case GRAPH_ALPHA_25:
+               case GRAPH_ALPHA_50:
+                  BKG_ALPHA = GRAPH_ALPHA_75;
+                  break;
+               case GRAPH_ALPHA_75:
+               case GRAPH_ALPHA_100:
+               default:
+                  /* Do nothing */
+                  break;
+            }
          }
 
          /* Key background */
@@ -271,27 +294,27 @@ void print_vkbd(unsigned short int *pixels)
                         (FONT_COLOR_SEL == RGBc(250, 250, 250) ? XTEXT+FONT_WIDTH : XTEXT-FONT_WIDTH),
                         (FONT_COLOR_SEL == RGBc(250, 250, 250) ? YTEXT+FONT_HEIGHT : YTEXT-FONT_HEIGHT),
                         (FONT_COLOR_SEL == RGBc(250, 250, 250) ? RGBc(100, 100, 100) : RGBc(50, 50, 50)),
-                        BKG_COLOR, FONT_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                        BKG_COLOR, FONT_ALPHA, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                         (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          else
             Draw_text(pix,
                       (FONT_COLOR_SEL == RGBc(250, 250, 250) ? XTEXT+FONT_WIDTH : XTEXT-FONT_WIDTH),
                       (FONT_COLOR_SEL == RGBc(250, 250, 250) ? YTEXT+FONT_HEIGHT : YTEXT-FONT_HEIGHT),
                       (FONT_COLOR_SEL == RGBc(250, 250, 250) ? RGBc(100, 100, 100) : RGBc(50, 50, 50)),
-                      BKG_COLOR, FONT_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                      BKG_COLOR, FONT_ALPHA, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                       (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
 
          /* Key text */
          if (pix_bytes == 4)
          {
             Draw_text32((uint32_t *)pix,
-                        XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, 250, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                        XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                         (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          }
          else
          {
             Draw_text(pix,
-                      XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, 250, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                      XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                       (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          }
       }
@@ -304,7 +327,8 @@ void print_vkbd(unsigned short int *pixels)
    YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
 
    /* Opacity */
-   BKG_ALPHA = (retro_vkbd_transparent) ? 220 : 250;
+   BKG_ALPHA = (retro_vkbd_transparent) ?
+         ((BKG_ALPHA == GRAPH_ALPHA_100) ? GRAPH_ALPHA_100 : GRAPH_ALPHA_75) : GRAPH_ALPHA_100;
 
    /* Pressed key color */
    if (vkflag[RETRO_DEVICE_ID_JOYPAD_B] && (vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].value == vkey_sticky1 ||
@@ -329,14 +353,14 @@ void print_vkbd(unsigned short int *pixels)
    if (pix_bytes == 4)
    {
       Draw_text32((uint32_t *)pix,
-                  XTEXT, YTEXT, FONT_COLOR, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                  XTEXT, YTEXT, FONT_COLOR, 0, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                   (!shifted) ? vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].normal
                              : vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift);
    }
    else
    {
       Draw_text(pix,
-                XTEXT, YTEXT, FONT_COLOR, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                XTEXT, YTEXT, FONT_COLOR, 0, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                 (!shifted) ? vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].normal
                            : vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift);
    }


### PR DESCRIPTION
This PR backports the VKDB optimisations from the VICE core: https://github.com/libretro/vice-libretro/pull/315

This reduces the performance overheads of rendering the VKBD by the following amounts (using default settings):

- 16 bit mode: 73%

- 32 bit mode: 78%
