### PR TITLE
Gitless build fix, gcc10 cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ else ifeq ($(platform), rpi)
 else ifeq ($(platform), classic_armv7_a7)
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
-    SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T  -Wl,--no-undefined
+    SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
     LDFLAGS += -lm -lpthread
     CFLAGS += -Ofast \
 	-flto=4 -fwhole-program -fuse-linker-plugin \
@@ -252,7 +252,7 @@ else
 ifneq ($(subplatform), 32)
    CFLAGS +=
 endif
-   PLATFLAGS += -DWIN32
+   PLATFLAGS += -DWIN32 -Wstringop-overflow=0
    TARGET := $(TARGET_NAME)_libretro.dll
    fpic := -fPIC
    SHARED := -shared -static-libgcc -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined -Wl,--gc-sections
@@ -276,7 +276,7 @@ CFLAGS += -fcommon -std=gnu99 -DINLINE="inline" -D__LIBRETRO__
 
 include Makefile.common
 
-$(info CFLAGS:$(PLATFLAGS)$(CFLAGS))
+$(info CFLAGS: $(PLATFLAGS) $(CFLAGS))
 $(info -------)
 
 OBJECTS += $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o) $(SOURCES_ASM:.S=.o)

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ else ifeq ($(platform), libnx)
    include $(DEVKITPRO)/libnx/switch_rules
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CFLAGS += -D__SWITCH__ -DHAVE_LIBNX -I$(DEVKITPRO)/libnx/include/ -specs=$(DEVKITPRO)/libnx/switch.specs
-   CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math -fPIE -ffunction-sections -fcommon
+   CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math -fPIE -ffunction-sections
    STATIC_LINKING=1
    STATIC_LINKING_LINK=1
 
@@ -151,7 +151,7 @@ else ifeq ($(platform), vita)
    COMMONFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
    COMMONFLAGS += -DHAVE_STRTOUL -DVITA
    CFLAGS += $(COMMONFLAGS)
-   PLATFLAGS += -ffast-math -march=armv7-a -mfpu=neon -mfloat-abi=hard -mword-relocations -fno-optimize-sibling-calls -fno-exceptions -fcommon
+   PLATFLAGS += -ffast-math -march=armv7-a -mfpu=neon -mfloat-abi=hard -mword-relocations -fno-optimize-sibling-calls -fno-exceptions
    STATIC_LINKING = 1
    STATIC_LINKING_LINK=1
 
@@ -272,7 +272,7 @@ ifneq ($(STATIC_LINKING), 1)
    CFLAGS += -DHAVE_7ZIP
 endif
 
-CFLAGS += -fcommon -std=gnu99 -DINLINE="inline" -D__LIBRETRO__
+CFLAGS += -std=gnu99 -DINLINE="inline" -D__LIBRETRO__
 
 include Makefile.common
 

--- a/retrodep/machdep/support.c
+++ b/retrodep/machdep/support.c
@@ -23,7 +23,7 @@
 #define LARGE_ALIGNMENT ".align 4,0x90\n"
 #endif
 
-struct flag_struct regflags;
+extern struct flag_struct regflags;
 
 #if defined(__CELLOS_LV2__) || defined(_WIN32) || defined(WIIU)
 

--- a/sources/src/cda_play.c
+++ b/sources/src/cda_play.c
@@ -10,6 +10,16 @@
 #include "sounddep/sound.h"
 #include "options.h"
 
+int cda_audio_bufsize;
+int cda_audio_volume[2];
+bool cda_audio_playing;
+bool cda_audio_active;
+int cda_audio_buffer_ids[2];
+uae_u8 *cda_audio_buffers[2];
+
+int cda_audio_num_sectors;
+int cda_audio_sectorsize;
+
 void cda_delete()
 {
     if (cda_audio_active) {

--- a/sources/src/disk.c
+++ b/sources/src/disk.c
@@ -225,7 +225,9 @@ typedef struct {
 
 static uae_u16 bigmfmbufw[0x4000 * DDHDMULT];
 static drive floppy[MAX_FLOPPY_DRIVES];
+#ifndef __LIBRETRO__
 static TCHAR dfxhistory[2][MAX_PREVIOUS_FLOPPIES][MAX_DPATH];
+#endif
 
 static uae_u8 exeheader[]={0x00,0x00,0x03,0xf3,0x00,0x00,0x00,0x00};
 static uae_u8 bootblock_ofs[]={
@@ -2508,6 +2510,9 @@ void disk_eject (int num)
 
 int DISK_history_add (const TCHAR *name, int idx, int type, int donotcheck)
 {
+#ifdef __LIBRETRO__
+	return 0;
+#else
 	int i;
 
 	if (idx >= MAX_PREVIOUS_FLOPPIES)
@@ -2558,13 +2563,18 @@ int DISK_history_add (const TCHAR *name, int idx, int type, int donotcheck)
 		_tcscpy (dfxhistory[type][i + 1], dfxhistory[type][i]);
 	_tcscpy (dfxhistory[type][0], name);
 	return 1;
+#endif
 }
 
 TCHAR *DISK_history_get (int idx, int type)
 {
+#ifdef __LIBRETRO__
+	return NULL;
+#else
 	if (idx >= MAX_PREVIOUS_FLOPPIES)
 		return NULL;
 	return dfxhistory[type][idx];
+#endif
 }
 
 static void disk_insert_2 (int num, const TCHAR *name, bool forced, bool forcedwriteprotect)

--- a/sources/src/include/a2091.h
+++ b/sources/src/include/a2091.h
@@ -11,33 +11,30 @@ extern addrbank dmaca2091_bank;
 extern uae_u8 wdregs[32];
 extern struct scsi_data *scsis[8];
 
-void a2091_init (void);
-void a2091_free (void);
-void a2091_reset (void);
+extern void a2091_init (void);
+extern void a2091_free (void);
+extern void a2091_reset (void);
 
-void a3000scsi_init (void);
-void a3000scsi_free (void);
-void a3000scsi_reset (void);
-void rethink_a2091 (void);
+extern void a3000scsi_init (void);
+extern void a3000scsi_free (void);
+extern void a3000scsi_reset (void);
+extern void rethink_a2091 (void);
 
-void wdscsi_put (uae_u8);
-uae_u8 wdscsi_get (void);
-uae_u8 wdscsi_getauxstatus (void);
-void wdscsi_sasr (uae_u8);
+extern void wdscsi_put (uae_u8);
+extern uae_u8 wdscsi_get (void);
+extern uae_u8 wdscsi_getauxstatus (void);
+extern void wdscsi_sasr (uae_u8);
 
-void scsi_hsync (void);
-
-uae_u8 wdregs[32];
-struct scsi_data *scsis[8];
+extern void scsi_hsync (void);
 
 #define WD33C93 _T("WD33C93")
 
-int a2091_add_scsi_unit (int ch, struct uaedev_config_info *ci);
-int a3000_add_scsi_unit (int ch, struct uaedev_config_info *ci);
+extern int a2091_add_scsi_unit (int ch, struct uaedev_config_info *ci);
+extern int a3000_add_scsi_unit (int ch, struct uaedev_config_info *ci);
 
-int add_scsi_hd (int ch, struct hd_hardfiledata *hfd, struct uaedev_config_info *ci, int scsi_level);
-int add_scsi_cd (int ch, int unitnum);
+extern int add_scsi_hd (int ch, struct hd_hardfiledata *hfd, struct uaedev_config_info *ci, int scsi_level);
+extern int add_scsi_cd (int ch, int unitnum);
 
-#endif // A2091
+#endif /* A2091 */
 
 #endif

--- a/sources/src/include/cda_play.h
+++ b/sources/src/include/cda_play.h
@@ -29,28 +29,28 @@ public:
 typedef struct cda_audio cda_audio;
 #endif
 
-int cda_audio_bufsize;
-int cda_audio_volume[2];
-bool cda_audio_playing;
-bool cda_audio_active;
-int cda_audio_buffer_ids[2];
-uae_u8 *cda_audio_buffers[2];
+extern int cda_audio_bufsize;
+extern int cda_audio_volume[2];
+extern bool cda_audio_playing;
+extern bool cda_audio_active;
+extern int cda_audio_buffer_ids[2];
+extern uae_u8 *cda_audio_buffers[2];
 
-int cda_audio_num_sectors;
-int cda_audio_sectorsize;
-int cda_audio_samplerate;
-bool cda_audio_internalmode;
+extern int cda_audio_num_sectors;
+extern int cda_audio_sectorsize;
+extern int cda_audio_samplerate;
+extern bool cda_audio_internalmode;
 
-int cda_audio_setvolume;
-bool cda_audio_play;
-int cda_audio_wait;
-bool cda_audio_isplaying;
+extern int cda_audio_setvolume;
+extern bool cda_audio_play;
+extern int cda_audio_wait;
+extern bool cda_audio_isplaying;
 
-void cda_new(int num_sectors, int sectorsize, int samplerate, bool internalmode);
-void cda_delete();
-void cda_setvolume(int left, int right);
-bool cda_play(int bufnum);
-void cda_wait(int bufnum);
-bool cda_isplaying(int bufnum);
+extern void cda_new(int num_sectors, int sectorsize, int samplerate, bool internalmode);
+extern void cda_delete(void);
+extern void cda_setvolume(int left, int right);
+extern bool cda_play(int bufnum);
+extern void cda_wait(int bufnum);
+extern bool cda_isplaying(int bufnum);
 
 #endif /* CDA_PLAY_H */

--- a/sources/src/include/inputdevice.h
+++ b/sources/src/include/inputdevice.h
@@ -219,16 +219,16 @@ void inputdevice_compa_clear (struct uae_prefs *prefs, int index);
 int intputdevice_compa_get_eventtype (int evt, const int **axistable);
 void inputdevice_sparecopy (struct uae_input_device *uid, int num, int sub);
 
-uae_u16 potgo_value;
-uae_u16 POTGOR (void);
-void POTGO (uae_u16 v);
-uae_u16 POT0DAT (void);
-uae_u16 POT1DAT (void);
-void JOYTEST (uae_u16 v);
-uae_u16 JOY0DAT (void);
-uae_u16 JOY1DAT (void);
-void JOYSET (int num, uae_u16 v);
-uae_u16 JOYGET (int num);
+extern uae_u16 potgo_value;
+extern uae_u16 POTGOR (void);
+extern void POTGO (uae_u16 v);
+extern uae_u16 POT0DAT (void);
+extern uae_u16 POT1DAT (void);
+extern void JOYTEST (uae_u16 v);
+extern uae_u16 JOY0DAT (void);
+extern uae_u16 JOY1DAT (void);
+extern void JOYSET (int num, uae_u16 v);
+extern uae_u16 JOYGET (int num);
 
 void inputdevice_vsync (void);
 void inputdevice_hsync (void);

--- a/sources/src/include/newcpu.h
+++ b/sources/src/include/newcpu.h
@@ -346,52 +346,52 @@ STATIC_INLINE uae_u32 next_ilongi (void)
 	return r;
 }
 
-uae_u32 (*x_prefetch)(int);
-uae_u32 (*x_prefetch_long)(int);
-uae_u32 (*x_get_byte)(uaecptr addr);
-uae_u32 (*x_get_word)(uaecptr addr);
-uae_u32 (*x_get_long)(uaecptr addr);
-void (*x_put_byte)(uaecptr addr, uae_u32 v);
-void (*x_put_word)(uaecptr addr, uae_u32 v);
-void (*x_put_long)(uaecptr addr, uae_u32 v);
-uae_u32 (*x_next_iword)(void);
-uae_u32 (*x_next_ilong)(void);
-uae_u32 (*x_get_ilong)(int);
-uae_u32 (*x_get_iword)(int);
-uae_u32 (*x_get_ibyte)(int);
+extern uae_u32 (*x_prefetch)(int);
+extern uae_u32 (*x_prefetch_long)(int);
+extern uae_u32 (*x_get_byte)(uaecptr addr);
+extern uae_u32 (*x_get_word)(uaecptr addr);
+extern uae_u32 (*x_get_long)(uaecptr addr);
+extern void (*x_put_byte)(uaecptr addr, uae_u32 v);
+extern void (*x_put_word)(uaecptr addr, uae_u32 v);
+extern void (*x_put_long)(uaecptr addr, uae_u32 v);
+extern uae_u32 (*x_next_iword)(void);
+extern uae_u32 (*x_next_ilong)(void);
+extern uae_u32 (*x_get_ilong)(int);
+extern uae_u32 (*x_get_iword)(int);
+extern uae_u32 (*x_get_ibyte)(int);
 
-uae_u32 (*x_cp_get_byte)(uaecptr addr);
-uae_u32 (*x_cp_get_word)(uaecptr addr);
-uae_u32 (*x_cp_get_long)(uaecptr addr);
-void (*x_cp_put_byte)(uaecptr addr, uae_u32 v);
-void (*x_cp_put_word)(uaecptr addr, uae_u32 v);
-void (*x_cp_put_long)(uaecptr addr, uae_u32 v);
-uae_u32 (*x_cp_next_iword)(void);
-uae_u32 (*x_cp_next_ilong)(void);
+extern uae_u32 (*x_cp_get_byte)(uaecptr addr);
+extern uae_u32 (*x_cp_get_word)(uaecptr addr);
+extern uae_u32 (*x_cp_get_long)(uaecptr addr);
+extern void (*x_cp_put_byte)(uaecptr addr, uae_u32 v);
+extern void (*x_cp_put_word)(uaecptr addr, uae_u32 v);
+extern void (*x_cp_put_long)(uaecptr addr, uae_u32 v);
+extern uae_u32 (*x_cp_next_iword)(void);
+extern uae_u32 (*x_cp_next_ilong)(void);
 
-uae_u32 (REGPARAM3 *x_cp_get_disp_ea_020)(uae_u32 base, int idx) REGPARAM;
+extern uae_u32 (REGPARAM3 *x_cp_get_disp_ea_020)(uae_u32 base, int idx) REGPARAM;
 
-void (*x_do_cycles)(unsigned long);
-void (*x_do_cycles_pre)(unsigned long);
-void (*x_do_cycles_post)(unsigned long, uae_u32);
+extern void (*x_do_cycles)(unsigned long);
+extern void (*x_do_cycles_pre)(unsigned long);
+extern void (*x_do_cycles_post)(unsigned long, uae_u32);
 
-uae_u32 REGPARAM3 x_get_disp_ea_020 (uae_u32 base, int idx) REGPARAM;
-uae_u32 REGPARAM3 x_get_disp_ea_ce020 (uae_u32 base, int idx) REGPARAM;
-uae_u32 REGPARAM3 x_get_bitfield (uae_u32 src, uae_u32 bdata[2], uae_s32 offset, int width) REGPARAM;
-void REGPARAM3 x_put_bitfield (uae_u32 dst, uae_u32 bdata[2], uae_u32 val, uae_s32 offset, int width) REGPARAM;
+extern uae_u32 REGPARAM3 x_get_disp_ea_020 (uae_u32 base, int idx) REGPARAM;
+extern uae_u32 REGPARAM3 x_get_disp_ea_ce020 (uae_u32 base, int idx) REGPARAM;
+extern uae_u32 REGPARAM3 x_get_bitfield (uae_u32 src, uae_u32 bdata[2], uae_s32 offset, int width) REGPARAM;
+extern void REGPARAM3 x_put_bitfield (uae_u32 dst, uae_u32 bdata[2], uae_u32 val, uae_s32 offset, int width) REGPARAM;
 
-void m68k_setstopped (void);
-void m68k_resumestopped (void);
+extern void m68k_setstopped (void);
+extern void m68k_resumestopped (void);
 
-uae_u32 REGPARAM3 get_disp_ea_020 (uae_u32 base, int idx) REGPARAM;
-uae_u32 REGPARAM3 get_bitfield (uae_u32 src, uae_u32 bdata[2], uae_s32 offset, int width) REGPARAM;
-void REGPARAM3 put_bitfield (uae_u32 dst, uae_u32 bdata[2], uae_u32 val, uae_s32 offset, int width) REGPARAM;
+extern uae_u32 REGPARAM3 get_disp_ea_020 (uae_u32 base, int idx) REGPARAM;
+extern uae_u32 REGPARAM3 get_bitfield (uae_u32 src, uae_u32 bdata[2], uae_s32 offset, int width) REGPARAM;
+extern void REGPARAM3 put_bitfield (uae_u32 dst, uae_u32 bdata[2], uae_u32 val, uae_s32 offset, int width) REGPARAM;
 
-void m68k_disasm_ea (uaecptr addr, uaecptr *nextpc, int cnt, uae_u32 *seaddr, uae_u32 *deaddr);
-void m68k_disasm (uaecptr addr, uaecptr *nextpc, int cnt);
-void m68k_disasm_2 (TCHAR *buf, int bufsize, uaecptr addr, uaecptr *nextpc, int cnt, uae_u32 *seaddr, uae_u32 *deaddr, int safemode);
-void sm68k_disasm (TCHAR*, TCHAR*, uaecptr addr, uaecptr *nextpc);
-int get_cpu_model (void);
+extern void m68k_disasm_ea (uaecptr addr, uaecptr *nextpc, int cnt, uae_u32 *seaddr, uae_u32 *deaddr);
+extern void m68k_disasm (uaecptr addr, uaecptr *nextpc, int cnt);
+extern void m68k_disasm_2 (TCHAR *buf, int bufsize, uaecptr addr, uaecptr *nextpc, int cnt, uae_u32 *seaddr, uae_u32 *deaddr, int safemode);
+extern void sm68k_disasm (TCHAR*, TCHAR*, uaecptr addr, uaecptr *nextpc);
+extern int get_cpu_model (void);
 
 /* Hack to stop conflict with AROS Exception function */
 #ifdef __AROS__

--- a/sources/src/main.c
+++ b/sources/src/main.c
@@ -115,7 +115,9 @@ static void hr (void)
 static void show_version (void)
 {
 	write_log (_T("PUAE %d.%d.%d (%s)\n"), UAEMAJOR, UAEMINOR, UAESUBREV, PACKAGE_COMMIT);
+#ifdef GIT_VERSION
 	write_log (_T("Git commit:%s\n"), GIT_VERSION);
+#endif
 	write_log (_T("Build date: " __DATE__ " " __TIME__ "\n"));
 }
 

--- a/sources/src/misc.c
+++ b/sources/src/misc.c
@@ -432,8 +432,6 @@ void target_fixup_options (struct uae_prefs *p)
 {
 }
 
-TCHAR start_path_data[MAX_DPATH];
-
 void fetch_path (TCHAR *name, TCHAR *out, int size)
 {
     _tcscpy (start_path_data, "./");


### PR DESCRIPTION
- Header guards for `GIT_VERSION`
  Closes #347 
- Removed the need for `-fcommon`
