### PR TITLE
Save disk hotkey, VKBD cleanups

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4124,36 +4124,27 @@ static bool retro_create_config()
                tmp_str = string_replace_substring(full_path, "\\", "\\\\");
                char tmp_str_name[RETRO_PATH_MAX];
                char tmp_str_path[RETRO_PATH_MAX];
+               snprintf(tmp_str_name, sizeof(tmp_str_name), "%s", path_basename(tmp_str));
+               path_remove_extension(tmp_str_name);
+
                if (strendswith(full_path, "slave") || strendswith(full_path, "info"))
                {
-                  snprintf(tmp_str_name, sizeof(tmp_str_name), "%s", path_basename(tmp_str));
-                  path_remove_extension(tmp_str_name);
                   path_parent_dir(tmp_str);
                   snprintf(tmp_str_path, sizeof(tmp_str_path), "%s%s", tmp_str, tmp_str_name);
                   if (!path_is_directory(tmp_str_path))
                      snprintf(tmp_str_path, sizeof(tmp_str_path), "%s", tmp_str);
                }
                if (strendswith(full_path, "lha"))
-                  fprintf(configfile, "filesystem2=ro,DH0:LHA:\"%s\",0\n", (const char*)tmp_str);
+                  fprintf(configfile, "filesystem2=ro,DH0:%s:\"%s\",0\n", tmp_str_name, tmp_str);
                else if (path_is_directory(full_path))
-                  fprintf(configfile, "filesystem2=rw,DH0:%s:\"%s\",0\n", path_basename(tmp_str), (const char*)tmp_str);
+                  fprintf(configfile, "filesystem2=rw,DH0:%s:\"%s\",0\n", tmp_str_name, tmp_str);
                else if (strendswith(full_path, "slave") || strendswith(full_path, "info"))
                   fprintf(configfile, "filesystem2=rw,DH0:%s:\"%s\",0\n", tmp_str_name, tmp_str_path);
                else
-                  fprintf(configfile, "hardfile2=rw,DH0:\"%s\",32,1,2,512,0,,uae1\n", (const char*)tmp_str);
+                  fprintf(configfile, "hardfile2=rw,DH0:\"%s\",32,1,2,512,0,,uae1\n", tmp_str);
                free(tmp_str);
                tmp_str = NULL;
 
-               /* Attach retro_system_directory as a read only hard drive for WHDLoad kickstarts/prefs/key */
-#ifdef WIN32
-               tmp_str = string_replace_substring(retro_system_directory, "\\", "\\\\");
-               fprintf(configfile, "filesystem2=ro,RASystem:RASystem:\"%s\",-128\n", (const char*)tmp_str);
-               free(tmp_str);
-               tmp_str = NULL;
-#else
-               /* Force the ending slash to make sure the path is not treated as a file */
-               fprintf(configfile, "filesystem2=ro,RASystem:RASystem:\"%s%s\",-128\n", retro_system_directory, "/");
-#endif
                /* WHDSaves HDF mode */
                if (opt_use_whdload == 2)
                {
@@ -4313,6 +4304,17 @@ static bool retro_create_config()
                      fclose(whdload_prefs);
                   }
                }
+
+               /* Attach retro_system_directory as a read only hard drive for WHDLoad kickstarts/prefs/key */
+#ifdef WIN32
+               tmp_str = string_replace_substring(retro_system_directory, "\\", "\\\\");
+               fprintf(configfile, "filesystem2=ro,RASystem:RASystem:\"%s\",-128\n", (const char*)tmp_str);
+               free(tmp_str);
+               tmp_str = NULL;
+#else
+               /* Force the ending slash to make sure the path is not treated as a file */
+               fprintf(configfile, "filesystem2=ro,RASystem:RASystem:\"%s%s\",-128\n", retro_system_directory, "/");
+#endif
             }
             else
             {

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3438,6 +3438,16 @@ static void retro_use_boot_hd(FILE** configfile)
 {
    char *tmp_str = NULL;
    char boothd_size[5] = {0};
+   char volume[10] = {0};
+   char label[10] = {0};
+
+   snprintf(label, sizeof(label), "%s", "BootHD");
+   snprintf(volume, sizeof(volume), "%s", "DH0");
+   /* Many HD installers have DH0: hardcoded as destination,
+   /* and WHDLoad + HDF launching require the use of DH0: */
+   if (dc_get_image_type(full_path) == DC_IMAGE_TYPE_WHDLOAD ||
+       dc_get_image_type(full_path) == DC_IMAGE_TYPE_HD)
+      snprintf(volume, sizeof(volume), "%s", label);
 
    snprintf(boothd_size, sizeof(boothd_size), "%dM", 0);
    if (opt_use_boot_hd > 1)
@@ -3473,14 +3483,14 @@ static void retro_use_boot_hd(FILE** configfile)
       path_join((char*)&boothd_hdf, retro_save_directory, LIBRETRO_PUAE_PREFIX ".hdf");
       if (!path_is_valid(boothd_hdf))
       {
-         log_cb(RETRO_LOG_INFO, "Boot HD image file '%s' not found, attempting to create one\n", (const char*)&boothd_hdf);
-         if (make_hdf(boothd_hdf, boothd_size, "BOOT"))
-            log_cb(RETRO_LOG_ERROR, "Unable to create Boot HD image: '%s'\n", (const char*)&boothd_hdf);
+         log_cb(RETRO_LOG_INFO, "Boot HD image file '%s' not found, attempting to create one\n", boothd_hdf);
+         if (make_hdf(boothd_hdf, boothd_size, label))
+            log_cb(RETRO_LOG_ERROR, "Unable to create Boot HD image: '%s'\n", boothd_hdf);
       }
       if (path_is_valid(boothd_hdf))
       {
          tmp_str = string_replace_substring(boothd_hdf, "\\", "\\\\");
-         fprintf(*configfile, "hardfile2=rw,BOOT:\"%s\",32,1,2,512,0,,uae0\n", (const char*)tmp_str);
+         fprintf(*configfile, "hardfile2=rw,%s:\"%s\",32,1,2,512,0,,uae0\n", volume, tmp_str);
          free(tmp_str);
          tmp_str = NULL;
       }
@@ -3489,22 +3499,22 @@ static void retro_use_boot_hd(FILE** configfile)
    else if (opt_use_boot_hd == 1)
    {
       char boothd_path[RETRO_PATH_MAX];
-      path_join((char*)&boothd_path, retro_save_directory, "BootHD");
+      path_join((char*)&boothd_path, retro_save_directory, label);
 
       if (!path_is_directory(boothd_path))
       {
-         log_cb(RETRO_LOG_INFO, "Boot HD image directory '%s' not found, attempting to create one\n", (const char*)&boothd_path);
+         log_cb(RETRO_LOG_INFO, "Boot HD image directory '%s' not found, attempting to create one\n", boothd_path);
          path_mkdir(boothd_path);
       }
       if (path_is_directory(boothd_path))
       {
          tmp_str = string_replace_substring(boothd_path, "\\", "\\\\");
-         fprintf(*configfile, "filesystem2=rw,BOOT:Boot:\"%s\",0\n", (const char*)tmp_str);
+         fprintf(*configfile, "filesystem2=rw,%s:%s:\"%s\",0\n", volume, label, tmp_str);
          free(tmp_str);
          tmp_str = NULL;
       }
       else
-         log_cb(RETRO_LOG_ERROR, "Unable to create Boot HD directory: '%s'\n", (const char*)&boothd_path);
+         log_cb(RETRO_LOG_ERROR, "Unable to create Boot HD directory: '%s'\n", boothd_path);
    }
 }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2892,7 +2892,7 @@ static void update_variables(void)
 
 /*****************************************************************************/
 /* Disk Control */
-static bool retro_disk_set_eject_state(bool ejected)
+bool retro_disk_set_eject_state(bool ejected)
 {
    if (dc)
    {
@@ -4363,6 +4363,9 @@ static bool retro_create_config()
                   {
                      if (i < 4)
                      {
+                        if (strstr(dc->labels[i], M3U_SAVEDISK_LABEL))
+                           continue;
+
                         log_cb(RETRO_LOG_INFO, "Disk (%d) inserted in drive DF%d: '%s'\n", i+1, i, dc->files[i]);
                         fprintf(configfile, "floppy%d=%s\n", i, dc->files[i]);
 
@@ -4373,6 +4376,14 @@ static bool retro_create_config()
                         log_cb(RETRO_LOG_WARN, "Too many disks for MultiDrive!\n");
                   }
                }
+            }
+
+            /* Scan for save disk 0, append if exists */
+            if (dc->count)
+            {
+               bool file_check = dc_save_disk_toggle(dc, true, false);
+               if (file_check)
+                  dc_save_disk_toggle(dc, false, false);
             }
          }
 

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -28,15 +28,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define COMMENT             "#"
-#define M3U_SPECIAL_COMMAND "#COMMAND:"
-#define M3U_SAVEDISK        "#SAVEDISK:"
-#define M3U_SAVEDISK_LABEL  "Save Disk"
-#define M3U_PATH_DELIM      '|'
-
 extern char retro_save_directory[RETRO_PATH_MAX];
 extern char retro_temp_directory[RETRO_PATH_MAX];
 extern bool retro_disk_set_image_index(unsigned index);
+extern bool retro_disk_set_eject_state(bool ejected);
 extern bool opt_floppy_multidrive;
 extern char full_path[RETRO_PATH_MAX];
 extern void display_current_image(const char *image, bool inserted);
@@ -175,12 +170,19 @@ bool dc_add_file_int(dc_storage* dc, char* filename, char* label)
 
 bool dc_add_file(dc_storage* dc, const char* filename, const char* label)
 {
+   unsigned index = 0;
+
    /* Verify */
    if (dc == NULL)
       return false;
 
    if (!filename || (*filename == '\0'))
       return false;
+
+   /* Dupecheck */
+   for (index = 0; index < dc->count; index++)
+      if (!strcmp(dc->files[index], filename))
+         return true;
 
    return dc_add_file_int(dc, my_strdup(filename),
          string_is_empty(label) ? NULL : my_strdup(label));
@@ -353,6 +355,9 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
             {
                if (i < 4)
                {
+                  if (strstr(dc->labels[i], M3U_SAVEDISK_LABEL))
+                     continue;
+
                   log_cb(RETRO_LOG_INFO, "Disk (%d) inserted in drive DF%d: '%s'\n", i+1, i, dc->files[i]);
                   strcpy(changed_prefs.floppyslots[i].df, dc->files[i]);
 
@@ -380,10 +385,11 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
    return true;
 }
 
-static bool dc_add_m3u_save_disk(
+bool dc_add_m3u_save_disk(
       dc_storage* dc,
       const char* m3u_file, const char* save_dir,
-      const char* disk_name, unsigned int index)
+      const char* disk_name, unsigned int index,
+      bool file_check)
 {
    bool save_disk_exists                     = false;
    const char *m3u_file_name                 = NULL;
@@ -412,7 +418,8 @@ static bool dc_add_m3u_save_disk(
 
    /* Get m3u file name without extension */
    snprintf(m3u_file_name_no_ext, sizeof(m3u_file_name_no_ext),
-         "%s", path_remove_extension((char*)m3u_file_name));
+         "%s", m3u_file_name);
+   path_remove_extension(m3u_file_name_no_ext);
 
    if (*m3u_file_name_no_ext == '\0')
       return false;
@@ -430,6 +437,9 @@ static bool dc_add_m3u_save_disk(
     * it differs from 'disk_name'. This is quite
     * fiddly, however - perhaps it can be added later... */
    save_disk_exists = path_is_valid(save_disk_path);
+
+   if (file_check)
+      return save_disk_exists;
 
    /* ...if not, create a new one */
    if (!save_disk_exists)
@@ -478,6 +488,55 @@ static bool dc_add_m3u_save_disk(
    }
 
    return false;
+}
+
+bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
+{
+   if (!dc)
+      return false;
+
+   bool file_exists = false;
+   if (file_check)
+   {
+      file_exists = dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, true);
+      return file_exists;
+   }
+   file_exists = dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, false);
+   if (select)
+   {
+      unsigned save_disk_index = 0;
+      unsigned index = 0;
+      char save_disk_label[64] = {0};
+
+      snprintf(save_disk_label, 64, "%s %u",
+            M3U_SAVEDISK_LABEL, 0);
+
+      /* Scan for save disk index */
+      for (index = 0; index < dc->count; index++)
+         if (!strcmp(dc->labels[index], save_disk_label))
+            save_disk_index = index;
+
+      /* Remember previous index */
+      if (dc->index != save_disk_index)
+         dc->index_prev = dc->index;
+
+      /* Switch index */
+      if (save_disk_index == dc->index)
+         dc->index = dc->index_prev;
+      else
+         dc->index = save_disk_index;
+
+      /* Cycle disk tray */
+      retro_disk_set_eject_state(true);
+      retro_disk_set_eject_state(false);
+
+      /* Widget notification */
+      snprintf(retro_message_msg, sizeof(retro_message_msg),
+               "%s (%d/%d)",
+               path_basename(dc->labels[dc->index]), dc->index+1, dc->count);
+      retro_message = true;
+   }
+   return true;
 }
 
 static bool dc_add_m3u_disk(
@@ -632,7 +691,8 @@ void dc_parse_m3u(dc_storage* dc, const char* m3u_file, const char* save_dir)
          /* Add save disk, creating it if necessary */
          if (dc_add_m3u_save_disk(
                dc, m3u_file, save_dir,
-               disk_name, save_disk_index))
+               disk_name, save_disk_index,
+               false))
             save_disk_index++;
 
          /* Clean up */

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -495,13 +495,10 @@ bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
    if (!dc)
       return false;
 
-   bool file_exists = false;
    if (file_check)
-   {
-      file_exists = dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, true);
-      return file_exists;
-   }
-   file_exists = dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, false);
+      return dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, true);
+
+   dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, false);
    if (select)
    {
       unsigned save_disk_index = 0;
@@ -532,10 +529,13 @@ bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
 
       /* Widget notification */
       snprintf(retro_message_msg, sizeof(retro_message_msg),
-               "%s (%d/%d)",
-               path_basename(dc->labels[dc->index]), dc->index+1, dc->count);
+               "%d/%d - %s",
+               dc->index+1, dc->count, path_basename(dc->labels[dc->index]));
       retro_message = true;
    }
+   else
+      log_cb(RETRO_LOG_INFO, "Save Disk 0 appended\n");
+
    return true;
 }
 

--- a/libretro/libretro-dc.h
+++ b/libretro/libretro-dc.h
@@ -21,6 +21,12 @@
 
 #include <stdbool.h>
 
+#define COMMENT             "#"
+#define M3U_SPECIAL_COMMAND "#COMMAND:"
+#define M3U_SAVEDISK        "#SAVEDISK:"
+#define M3U_SAVEDISK_LABEL  "Save Disk"
+#define M3U_PATH_DELIM      '|'
+
 /* Disk control structure and functions */
 #define DC_MAX_SIZE 20
 
@@ -44,6 +50,7 @@ struct dc_storage
    int index;
    bool eject_state;
    bool replace;
+   unsigned index_prev;
 };
 
 typedef struct dc_storage dc_storage;
@@ -56,5 +63,6 @@ void dc_reset(dc_storage* dc);
 bool dc_replace_file(dc_storage* dc, int index, const char* filename);
 bool dc_remove_file(dc_storage* dc, int index);
 enum dc_image_type dc_get_image_type(const char* filename);
+bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select);
 
 #endif /* LIBRETRO_DC_H */

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -481,7 +481,7 @@ void print_statusbar(void)
    int FONT_COLOR           = (pix_bytes == 4) ? 0xffffff : 0xffff;;
    int FONT_SLOT            = 34 * FONT_WIDTH;
 
-   int TEXT_X               = 2;
+   int TEXT_X               = 2 * FONT_WIDTH;
    int TEXT_Y               = 0;
    int TEXT_LENGTH          = (video_config & PUAE_VIDEO_DOUBLELINE) ? 100 : 43;
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -3,6 +3,7 @@
 #include "libretro-mapper.h"
 #include "libretro-graph.h"
 #include "libretro-vkbd.h"
+#include "libretro-dc.h"
 
 #include "uae_types.h"
 #include "sysconfig.h"
@@ -88,6 +89,7 @@ extern unsigned int retro_devices[RETRO_DEVICES];
 static unsigned retro_key_state[RETROK_LAST] = {0};
 static int16_t joypad_bits[RETRO_DEVICES];
 extern bool libretro_supports_bitmasks;
+extern dc_storage *dc;
 
 /* Core options */
 extern unsigned int video_config;
@@ -124,6 +126,7 @@ enum EMU_FUNCTIONS
    EMU_STATUSBAR,
    EMU_JOYMOUSE,
    EMU_RESET,
+   EMU_SAVE_DISK,
    EMU_ASPECT_RATIO,
    EMU_ZOOM_MODE,
    EMU_TURBO_FIRE,
@@ -205,6 +208,9 @@ void emu_function(int function)
          snprintf(statusbar_text, 56, "%c Turbo Fire %-42s",
                (' ' | 0x80), (retro_turbo_fire) ? "ON" : "OFF");
          imagename_timer = 50;
+         break;
+      case EMU_SAVE_DISK:
+         dc_save_disk_toggle(dc, false, true);
          break;
    }
 }
@@ -1963,9 +1969,12 @@ void update_input(int disable_physical_cursor_keys)
             {
                emu_function(EMU_RESET);
             }
-            else if (vkey_pressed == -21) /* Toggle statusbar */
+            else if (vkey_pressed == -21) /* Toggle statusbar / save disk */
             {
-               emu_function(EMU_STATUSBAR);
+               if (retro_capslock)
+                  emu_function(EMU_SAVE_DISK);
+               else
+                  emu_function(EMU_STATUSBAR);
             }
             else if (vkey_pressed == -22) /* Toggle aspect ratio / zoom mode */
             {

--- a/libretro/libretro-vkbd.h
+++ b/libretro/libretro-vkbd.h
@@ -23,7 +23,7 @@ static retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "J/M" ,"J/M" ,-18 },
    { "TRBF","TRBF",-19 },
    { "ASPR","ZOOM",-22 },
-   { "STBR","SDSK",-21 },
+   { "STBR","SVDS",-21 },
    { {17}  ,{17}  ,-20 }, /* Reset */
 
    /* 0 PG1 */
@@ -128,8 +128,8 @@ static retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { {10,29},{10,29},-14 },
    { "J/M" ,"J/M" ,-18 },
    { "TRBF","TRBF",-19 },
-   { "ASPR","ASPR",-22 },
-   { "STBR","STBR",-21 },
+   { "ASPR","ZOOM",-22 },
+   { "STBR","SVDS",-21 },
    { {17}  ,{17}  ,-20 }, /* Reset */
 
    /* 0 PG2 */

--- a/libretro/libretro-vkbd.h
+++ b/libretro/libretro-vkbd.h
@@ -23,7 +23,7 @@ static retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "J/M" ,"J/M" ,-18 },
    { "TRBF","TRBF",-19 },
    { "ASPR","ZOOM",-22 },
-   { "STBR","STBR",-21 },
+   { "STBR","SDSK",-21 },
    { {17}  ,{17}  ,-20 }, /* Reset */
 
    /* 0 PG1 */

--- a/sources/src/cfgfile.c
+++ b/sources/src/cfgfile.c
@@ -5188,6 +5188,7 @@ void default_prefs (struct uae_prefs *p, int type)
 	p->fastmem_autoconfig = true;
 
 #ifdef __LIBRETRO__
+	p->floppy_auto_ext2 = 2;
 	p->nr_floppies = 1;
 #else
 	p->nr_floppies = 2;


### PR DESCRIPTION
A new VKBD hotkey under CapsLock+Statusbar (STBR): Save Disk (SVDS)
- First press creates the disk if it does not exist, changes DC index and cycles eject
- Second press changes back to the previous disk

The created disk is automatically appended to DC at next run, but not inserted to external drives. It automatically changes to extended format if the game wants to format a non-DOS disk (Cannon Fodder).

Plus:
- BootHD corrections
- VKBD size stabilizing

