### PR TITLE
VKBD improvements, CDA+CHD fixes

### DIFF
--- a/deps/libchdr/src/chd.c
+++ b/deps/libchdr/src/chd.c
@@ -1564,6 +1564,7 @@ void chd_close(chd_file *chd)
 	}
 	else
 	{
+#if 0
 		int i;
 		/* Free the codecs */
 		for (i = 0 ; i < 4 ; i++)
@@ -1588,6 +1589,7 @@ void chd_close(chd_file *chd)
 				(*chd->codecintf[i]->free)(codec);
 			}
 		}
+#endif
 
 		/* Free the raw map */
 		if (chd->header.rawmap != NULL)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -800,13 +800,14 @@ void retro_set_environment(retro_environment_t cb)
          "Video > Virtual KBD Theme",
          "By default, the keyboard comes up with RetroPad Select.",
          {
-            { "0", "Classic" },
-            { "3", "Light" },
-            { "1", "CD32" },
-            { "2", "Dark" },
+            { "auto", "Automatic" },
+            { "beige", "Beige" },
+            { "cd32", "CD32" },
+            { "light", "Light" },
+            { "dark", "Dark" },
             { NULL, NULL },
          },
-         "0"
+         "auto"
       },
       {
          "puae_vkbd_transparency",
@@ -1798,7 +1799,11 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      opt_vkbd_theme = atoi(var.value);
+      if      (!strcmp(var.value, "auto"))  opt_vkbd_theme = 0;
+      else if (!strcmp(var.value, "beige")) opt_vkbd_theme = 1;
+      else if (!strcmp(var.value, "cd32"))  opt_vkbd_theme = 2;
+      else if (!strcmp(var.value, "dark"))  opt_vkbd_theme = 3;
+      else if (!strcmp(var.value, "light")) opt_vkbd_theme = 4;
    }
 
    var.key = "puae_vkbd_transparency";

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5933,36 +5933,3 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
    (void)enabled;
    (void)code;
 }
-
-#if defined(ANDROID) || defined(__SWITCH__) || defined(WIIU) || defined(__CELLOS_LV2__)
-#ifndef __CELLOS_LV2__
-#include <sys/timeb.h>
-#else
-#include "ps3_headers.h"
-#undef timezone
-#endif
-
-int ftime(struct timeb *tb)
-{
-    struct timeval  tv;
-    struct timezone tz;
-
-    if (gettimeofday (&tv, &tz) < 0)
-        return -1;
-
-    tb->time    = tv.tv_sec;
-    tb->millitm = (tv.tv_usec + 500) / 1000;
-
-    if (tb->millitm == 1000)
-    {
-        ++tb->time;
-        tb->millitm = 0;
-    }
-#ifndef __CELLOS_LV2__    
-    tb->timezone = tz.tz_minuteswest;
-    tb->dstflag  = tz.tz_dsttime;
-#endif
-
-    return 0;
-}
-#endif

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -1800,7 +1800,7 @@ UINT32 cdrom_read_subcode(cdrom_file *file, UINT32 lbasector, void *buffer, bool
 cdrom_file *cdrom_open(chd_file *chd)
 {
 	int i;
-	cdrom_file *file;
+	cdrom_file *file = NULL;
 	UINT32 physofs, chdofs, logofs;
 	chd_error err;
 
@@ -1855,7 +1855,7 @@ cdrom_file *cdrom_open(chd_file *chd)
 
 		physofs += file->cdtoc.tracks[i].frames;
 		chdofs  += file->cdtoc.tracks[i].frames;
-		chdofs  += file->cdtoc.tracks[i].extraframes;
+		chdofs  += file->cdtoc.tracks[i].extraframes - 1;
 		logofs  += file->cdtoc.tracks[i].frames;
 
 #if 0
@@ -2007,7 +2007,7 @@ chd_error chd_hunk_info(chd_file *cf, UINT32 hunknum, chd_codec_type *compressor
 //  read_bytes - read from the CHD at a byte level,
 //  using the cache to handle partial hunks
 //-------------------------------------------------
-UINT8 m_cache[CD_FRAME_SIZE*CD_FRAMES_PER_HUNK] = {0};
+UINT8 m_cache[CD_FRAME_SIZE*CD_FRAMES_PER_HUNK*2] = {0};
 UINT32 m_cachehunk = 0;
 
 chd_error chd_read_bytes(chd_file *chd, UINT64 offset, void *buffer, UINT32 bytes)
@@ -2077,6 +2077,7 @@ chd_error read_partial_sector(cdrom_file *file, void *dest, UINT32 lbasector, UI
 	}
 	else
 	{
+#if 0
 		// else read from the appropriate file
 		core_file *srcfile = file->fhandle[tracknum];
 
@@ -2093,6 +2094,7 @@ chd_error read_partial_sector(cdrom_file *file, void *dest, UINT32 lbasector, UI
 		core_fread(srcfile, dest, length);
 
 		needswap = file->track_info.track[tracknum].swap;
+#endif
 	}
 
 	if (needswap)

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -1594,52 +1594,38 @@ const chd_codec_type CHD_CODEC_SELF         = 1;    // copy of another hunk
 const chd_codec_type CHD_CODEC_PARENT       = 2;    // copy of a parent's hunk
 const chd_codec_type CHD_CODEC_MINI         = 3;    // legacy "mini" 8-byte repeat
 
-/* V3-V4 entry types */
+// V3-V4 entry types
 enum
 {
-	V34_MAP_ENTRY_TYPE_INVALID = 0,             /* invalid type */
-	V34_MAP_ENTRY_TYPE_COMPRESSED = 1,          /* standard compression */
-	V34_MAP_ENTRY_TYPE_UNCOMPRESSED = 2,        /* uncompressed data */
-	V34_MAP_ENTRY_TYPE_MINI = 3,                /* mini: use offset as raw data */
-	V34_MAP_ENTRY_TYPE_SELF_HUNK = 4,           /* same as another hunk in this file */
-	V34_MAP_ENTRY_TYPE_PARENT_HUNK = 5,         /* same as a hunk in the parent file */
-	V34_MAP_ENTRY_TYPE_2ND_COMPRESSED = 6       /* compressed with secondary algorithm (usually FLAC CDDA) */
+	V34_MAP_ENTRY_TYPE_INVALID = 0,             // invalid type
+	V34_MAP_ENTRY_TYPE_COMPRESSED = 1,          // standard compression
+	V34_MAP_ENTRY_TYPE_UNCOMPRESSED = 2,        // uncompressed data
+	V34_MAP_ENTRY_TYPE_MINI = 3,                // mini: use offset as raw data
+	V34_MAP_ENTRY_TYPE_SELF_HUNK = 4,           // same as another hunk in this file
+	V34_MAP_ENTRY_TYPE_PARENT_HUNK = 5,         // same as a hunk in the parent file
+	V34_MAP_ENTRY_TYPE_2ND_COMPRESSED = 6       // compressed with secondary algorithm (usually FLAC CDDA)
 };
 
-/* V5 compression types */
+// V5 compression types
 enum
 {
-	/* codec #0
-	 * these types are live when running */
-	COMPRESSION_TYPE_0 = 0,
-	/* codec #1 */
-	COMPRESSION_TYPE_1 = 1,
-	/* codec #2 */
-	COMPRESSION_TYPE_2 = 2,
-	/* codec #3 */
-	COMPRESSION_TYPE_3 = 3,
-	/* no compression; implicit length = hunkbytes */
-	COMPRESSION_NONE = 4,
-	/* same as another block in this chd */
-	COMPRESSION_SELF = 5,
-	/* same as a hunk's worth of units in the parent chd */
-	COMPRESSION_PARENT = 6,
+	// these types are live when running
+	COMPRESSION_TYPE_0 = 0,                     // codec #0
+	COMPRESSION_TYPE_1 = 1,                     // codec #1
+	COMPRESSION_TYPE_2 = 2,                     // codec #2
+	COMPRESSION_TYPE_3 = 3,                     // codec #3
+	COMPRESSION_NONE = 4,                       // no compression; implicit length = hunkbytes
+	COMPRESSION_SELF = 5,                       // same as another block in this chd
+	COMPRESSION_PARENT = 6,                     // same as a hunk's worth of units in the parent chd
 
-	/* start of small RLE run (4-bit length)
-	 * these additional pseudo-types are used for compressed encodings: */
-	COMPRESSION_RLE_SMALL,
-	/* start of large RLE run (8-bit length) */
-	COMPRESSION_RLE_LARGE,
-	/* same as the last COMPRESSION_SELF block */
-	COMPRESSION_SELF_0,
-	/* same as the last COMPRESSION_SELF block + 1 */
-	COMPRESSION_SELF_1,
-	/* same block in the parent */
-	COMPRESSION_PARENT_SELF,
-	/* same as the last COMPRESSION_PARENT block */
-	COMPRESSION_PARENT_0,
-	/* same as the last COMPRESSION_PARENT block + 1 */
-	COMPRESSION_PARENT_1
+	// these additional pseudo-types are used for compressed encodings:
+	COMPRESSION_RLE_SMALL,                      // start of small RLE run (4-bit length)
+	COMPRESSION_RLE_LARGE,                      // start of large RLE run (8-bit length)
+	COMPRESSION_SELF_0,                         // same as the last COMPRESSION_SELF block
+	COMPRESSION_SELF_1,                         // same as the last COMPRESSION_SELF block + 1
+	COMPRESSION_PARENT_SELF,                    // same block in the parent
+	COMPRESSION_PARENT_0,                       // same as the last COMPRESSION_PARENT block
+	COMPRESSION_PARENT_1                        // same as the last COMPRESSION_PARENT block + 1
 };
 
 // currently-defined codecs
@@ -2021,7 +2007,7 @@ chd_error chd_hunk_info(chd_file *cf, UINT32 hunknum, chd_codec_type *compressor
 //  read_bytes - read from the CHD at a byte level,
 //  using the cache to handle partial hunks
 //-------------------------------------------------
-UINT8 m_cache[CD_MAX_SECTOR_DATA*CD_FRAME_SIZE] = {0};
+UINT8 m_cache[CD_FRAME_SIZE*CD_FRAMES_PER_HUNK] = {0};
 UINT32 m_cachehunk = 0;
 
 chd_error chd_read_bytes(chd_file *chd, UINT64 offset, void *buffer, UINT32 bytes)

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -2,6 +2,7 @@
 #define LIBRETRO_GLUE_H
 
 #include <stdio.h>
+#include "libretro-core.h"
 
 #ifdef WITH_CHD
 /*** CHD ***/
@@ -24,6 +25,7 @@
 typedef UINT32 chd_codec_type;
 typedef UINT32 chd_metadata_tag;
 
+#if 0
 typedef struct chdcd_track_input_entry
 {
 #if 0
@@ -34,7 +36,7 @@ typedef struct chdcd_track_input_entry
 #if 0
 	astring fname;      // filename for each track
 #else
-	char* fname;
+	char fname[RETRO_PATH_MAX];
 #endif
 	UINT32 offset;      // offset in the data file for each track
 	bool swap;          // data needs to be byte swapped
@@ -50,6 +52,7 @@ typedef struct chdcd_track_input_info
 
 	chdcd_track_input_entry track[CD_MAX_TRACKS];
 } chdcd_track_input_info;
+#endif
 
 typedef struct cdrom_track_info
 {
@@ -87,7 +90,9 @@ typedef struct cdrom_file
 {
 	chd_file *          chd;                /* CHD file */
 	cdrom_toc           cdtoc;              /* TOC for the CD */
+#if 0
 	chdcd_track_input_info track_info;      /* track info */
+#endif
 	core_file *         fhandle[CD_MAX_TRACKS];/* file handle */
 } cdrom_file;
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -501,7 +501,7 @@ void print_statusbar(void)
 
    /* Video resolution */
    int TEXT_X_RESOLUTION = TEXT_X + (FONT_SLOT*4) + (FONT_WIDTH*16) - (ZOOMED_WIDTH_OFFSET/2);
-   char RESOLUTION[10] = {0};
+   unsigned char RESOLUTION[10] = {0};
    snprintf(RESOLUTION, sizeof(RESOLUTION), "%4dx%3d", zoomed_width, zoomed_height);
 
    /* Model & memory */
@@ -514,10 +514,10 @@ void print_statusbar(void)
          TEXT_X_MEMORY = -1;
    }
 
-   char MODEL[10] = {0};
-   char MEMORY[5] = {0};
+   unsigned char MODEL[10] = {0};
+   unsigned char MEMORY[5] = {0};
    float mem_size = 0;
-   mem_size = (float)(currprefs.chipmem_size / 0x80000) / 2;
+   mem_size  = (float)(currprefs.chipmem_size / 0x80000) / 2;
    mem_size += (float)(currprefs.bogomem_size / 0x40000) / 4;
    mem_size += (float)(currprefs.fastmem_size / 0x100000);
    if (TEXT_X_MEMORY > 0)
@@ -556,10 +556,10 @@ void print_statusbar(void)
    }
 
    /* Joy port indicators */
-   char JOYMODE1[5] = {0};
-   char JOYMODE2[5] = {0};
-   char JOYMODE3[5] = {0};
-   char JOYMODE4[5] = {0};
+   unsigned char JOYMODE1[5] = {0};
+   unsigned char JOYMODE2[5] = {0};
+   unsigned char JOYMODE3[5] = {0};
+   unsigned char JOYMODE4[5] = {0};
 
    unsigned char JOYPORT1[5] = {0};
    unsigned char JOYPORT2[5] = {0};

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -14,13 +14,12 @@
 #include "gui.h"
 #include "xwin.h"
 #include "disk.h"
+#include "hrtimer.h"
 
 #ifdef __CELLOS_LV2__
 #include "ps3_headers.h"
 #else
 #include <sys/types.h>
-#include <sys/time.h>
-#include <time.h>
 #endif
 
 static retro_input_state_t input_state_cb;
@@ -216,24 +215,10 @@ void emu_function(int function)
    }
 }
 
-#ifdef WIIU
-#include <features_cpu.h>
-#endif
-
 /* in milliseconds */
 long GetTicks(void)
 {
-#ifdef _ANDROID_
-   struct timespec now;
-   clock_gettime(CLOCK_MONOTONIC, &now);
-   return (now.tv_sec*1000000 + now.tv_nsec/1000)/1000;
-#elif defined(WIIU)
-   return (cpu_features_get_time_usec())/1000;
-#else
-   struct timeval tv;
-   gettimeofday (&tv, NULL);
-   return (tv.tv_sec*1000000 + tv.tv_usec)/1000;
-#endif
+   return osdep_gethrtime()/1000;
 } 
 
 static unsigned char* joystick_value_human(int val[16], int uae_device)

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -55,8 +55,9 @@ void print_vkbd(unsigned short int *pixels)
    int FONT_COLOR_NORMAL             = 0;
    int FONT_COLOR_SEL                = 0;
 
-   unsigned COLOR_BLACK = RGBc(  5,   5,   5);
-   unsigned COLOR_WHITE = RGBc(250, 250, 250);
+   unsigned COLOR_BLACK              = RGBc(  5,   5,   5);
+   unsigned COLOR_GRAY               = RGBc(125, 125, 125);
+   unsigned COLOR_WHITE              = RGBc(250, 250, 250);
 
    switch (opt_vkbd_theme)
    {
@@ -260,16 +261,16 @@ void print_vkbd(unsigned short int *pixels)
                               XTEXT+(sx*FONT_WIDTH),
                               YTEXT+(sy*FONT_HEIGHT),
                               BKG_COLOR,
-                              (FONT_COLOR == COLOR_WHITE ? COLOR_BLACK : COLOR_WHITE),
-                              GRAPH_ALPHA_100-1, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                              (FONT_COLOR == COLOR_WHITE ? COLOR_BLACK : COLOR_GRAY),
+                              GRAPH_ALPHA_75+(-sx-sy), false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
                else
                   Draw_text(pix,
                               XTEXT+(sx*FONT_WIDTH),
                               YTEXT+(sy*FONT_HEIGHT),
                               BKG_COLOR,
-                              (FONT_COLOR == COLOR_WHITE ? COLOR_BLACK : COLOR_WHITE),
-                              GRAPH_ALPHA_100-1, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                              (FONT_COLOR == COLOR_WHITE ? COLOR_BLACK : COLOR_GRAY),
+                              GRAPH_ALPHA_75+(-sx-sy), false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
             }
          }

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -3,6 +3,8 @@
 #include "keyboard.h"
 #include "libretro-vkbd.h"
 
+#include "options.h"
+
 bool retro_vkbd = false;
 bool retro_vkbd_page = false;
 bool retro_vkbd_position = false;
@@ -56,13 +58,31 @@ void print_vkbd(unsigned short int *pixels)
    int FONT_COLOR_SEL                = 0;
 
    unsigned COLOR_BLACK              = RGBc(  5,   5,   5);
-   unsigned COLOR_GRAY               = RGBc(125, 125, 125);
+   unsigned COLOR_GRAYBLACK          = RGBc( 25,  25,  25);
+   unsigned COLOR_GRAYWHITE          = RGBc(125, 125, 125);
    unsigned COLOR_WHITE              = RGBc(250, 250, 250);
 
-   switch (opt_vkbd_theme)
+   unsigned theme                    = opt_vkbd_theme;
+   if (!theme)
+   {
+      switch (currprefs.cs_compatible)
+      {
+         case CP_CD32:
+            theme = 2;
+            break;
+         case CP_CDTV:
+            theme = 3;
+            break;
+         default:
+            theme = 1;
+            break;
+      }
+   }
+
+   switch (theme)
    {
       default:
-      case 0: /* Classic */
+      case 1: /* Classic */
          BKG_COLOR_NORMAL  = RGBc(216, 209, 201);
          BKG_COLOR_ALT     = RGBc(159, 154, 150);
          BKG_COLOR_EXTRA   = RGBc(143, 140, 129);
@@ -72,7 +92,7 @@ void print_vkbd(unsigned short int *pixels)
          FONT_COLOR_SEL    = COLOR_WHITE;
          break;
 
-      case 1: /* CD32 */
+      case 2: /* CD32 */
          BKG_COLOR_NORMAL  = RGBc( 64,  64,  64);
          BKG_COLOR_ALT     = RGBc( 32,  32,  32);
          BKG_COLOR_EXTRA   = RGBc( 16,  16,  16);
@@ -82,7 +102,7 @@ void print_vkbd(unsigned short int *pixels)
          FONT_COLOR_SEL    = COLOR_BLACK;
          break;
 
-      case 2: /* Dark */
+      case 3: /* Dark */
          BKG_COLOR_NORMAL  = RGBc( 32,  32,  32);
          BKG_COLOR_ALT     = RGBc( 70,  70,  70);
          BKG_COLOR_EXTRA   = RGBc( 14,  14,  14);
@@ -92,7 +112,7 @@ void print_vkbd(unsigned short int *pixels)
          FONT_COLOR_SEL    = COLOR_BLACK;
          break;
 
-      case 3: /* Light */
+      case 4: /* Light */
          BKG_COLOR_NORMAL  = RGBc(210, 210, 210);
          BKG_COLOR_ALT     = RGBc(180, 180, 180);
          BKG_COLOR_EXTRA   = RGBc(150, 150, 150);
@@ -261,7 +281,7 @@ void print_vkbd(unsigned short int *pixels)
                               XTEXT+(sx*FONT_WIDTH),
                               YTEXT+(sy*FONT_HEIGHT),
                               BKG_COLOR,
-                              (FONT_COLOR == COLOR_WHITE ? COLOR_BLACK : COLOR_GRAY),
+                              (FONT_COLOR == COLOR_WHITE ? COLOR_GRAYBLACK : COLOR_GRAYWHITE),
                               GRAPH_ALPHA_75+(-sx-sy), false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
                else
@@ -269,7 +289,7 @@ void print_vkbd(unsigned short int *pixels)
                               XTEXT+(sx*FONT_WIDTH),
                               YTEXT+(sy*FONT_HEIGHT),
                               BKG_COLOR,
-                              (FONT_COLOR == COLOR_WHITE ? COLOR_BLACK : COLOR_GRAY),
+                              (FONT_COLOR == COLOR_WHITE ? COLOR_GRAYBLACK : COLOR_GRAYWHITE),
                               GRAPH_ALPHA_75+(-sx-sy), false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
             }

--- a/retrodep/fsdb_host.c
+++ b/retrodep/fsdb_host.c
@@ -3,9 +3,11 @@
 
 #include "libretro-core.h"
 
+#if 0
 #include <sys/time.h>
 #if !defined(_WIN32) && !defined(__CELLOS_LV2__)
 #include <sys/timeb.h>
+#endif
 #endif
 
 #ifdef __CELLOS_LV2__
@@ -60,23 +62,17 @@ bool my_utime (const TCHAR *name, struct mytimeval *tv)
 	int tolocal;
 	int days, mins, ticks;
 	struct mytimeval tv2;
-#if !defined(__CELLOS_LV2__) && !defined(WIIU) && !defined(__SWITCH__) && !defined(VITA)
-	if (!tv) {
-		struct timeb time;
-		ftime (&time);
-		tv2.tv_sec = time.time;
-		tv2.tv_usec = time.millitm * 1000;
-		tolocal = 0;
-	} else
-#else
-		tv2.tv_sec = 1;
-		tv2.tv_usec = 1000;
-		tolocal = 0;
-#endif
+	if (tv)
 	{
 		tv2.tv_sec = tv->tv_sec;
 		tv2.tv_usec = tv->tv_usec;
 		tolocal = 1;
+	}
+	else
+	{
+		tv2.tv_sec = 1;
+		tv2.tv_usec = 1000;
+		tolocal = 0;
 	}
 	timeval_to_amiga (&tv2, &days, &mins, &ticks);
 	if (setfiletime (name, days, mins, ticks, tolocal))

--- a/retrodep/gui.c
+++ b/retrodep/gui.c
@@ -59,53 +59,39 @@ void gui_cd_led (int led)
 
 static void gui_flicker_led2 (int led, int unitnum, int status)
 {
-	static int resetcounter[LED_MAX];
-	uae_s8 old;
-	uae_s8 *p;
+    static int resetcounter[LED_MAX];
+    uae_s8 old;
+    uae_s8 *p;
 
-	if (led == LED_HD)
-		p = &gui_data.hd;
-	else if (led == LED_CD)
-		p = &gui_data.cd;
-	else if (led == LED_MD)
-		p = &gui_data.md;
-	else if (led == LED_NET)
-		p = &gui_data.net;
-	else
-		return;
-	old = *p;
-	if (status < 0) {
-		if (old < 0) {
-			gui_led (led, -1);
-		} else {
-			gui_led (led, 0);
-		}
-		return;
-	}
-	if (status == 0 && old < 0) {
-		*p = 0;
-		resetcounter[led] = 0;
-		gui_led (led, 0);
-		return;
-	}
-	if (status == 0) {
-		resetcounter[led]--;
-		if (resetcounter[led] > 0)
-			return;
-	}
-#ifdef RETROPLATFORM
-	if (unitnum >= 0) {
-		if (led == LED_HD) {
-			rp_hd_activity(unitnum, status ? 1 : 0, status == 2 ? 1 : 0);
-		} else if (led == LED_CD) {
-			rp_cd_activity(unitnum, status);
-		}
-	}
-#endif
-	*p = status;
-	resetcounter[led] = 4;
-	if (old != *p)
-		gui_led (led, *p);
+    if (led == LED_HD)
+        p = &gui_data.hd;
+    else if (led == LED_CD)
+        p = &gui_data.cd;
+    else if (led == LED_MD)
+        p = &gui_data.md;
+    else if (led == LED_NET)
+        p = &gui_data.net;
+    else
+        return;
+    old = *p;
+
+    if (status == 0 && old < 0) {
+        *p = 0;
+        resetcounter[led] = 0;
+        return;
+    }
+
+    if (status == 0 && led == LED_CD && old == LED_CD_AUDIO)
+        resetcounter[led] = 0;
+
+    if (status == 0) {
+        resetcounter[led]--;
+        if (resetcounter[led] > 0)
+            return;
+    }
+    *p = status;
+
+    resetcounter[led] = 5;
 }
 
 void gui_flicker_led (int led, int unitnum, int status)
@@ -113,8 +99,10 @@ void gui_flicker_led (int led, int unitnum, int status)
     if (led < 0) {
         if (gui_data.hd >= 0)
             gui_flicker_led2(LED_HD, 0, 0);
+#if 0
         if (gui_data.cd >= 0)
             gui_flicker_led2(LED_CD, 0, 0);
+#endif
         if (gui_data.net >= 0)
             gui_flicker_led2(LED_NET, 0, 0);
         if (gui_data.md >= 0)

--- a/retrodep/gui.c
+++ b/retrodep/gui.c
@@ -81,9 +81,6 @@ static void gui_flicker_led2 (int led, int unitnum, int status)
         return;
     }
 
-    if (status == 0 && led == LED_CD && old == LED_CD_AUDIO)
-        resetcounter[led] = 0;
-
     if (status == 0) {
         resetcounter[led]--;
         if (resetcounter[led] > 0)
@@ -91,7 +88,10 @@ static void gui_flicker_led2 (int led, int unitnum, int status)
     }
     *p = status;
 
-    resetcounter[led] = 5;
+    if (led == LED_CD && status == LED_CD_AUDIO)
+        resetcounter[led] = 15;
+    else
+        resetcounter[led] = 5;
 }
 
 void gui_flicker_led (int led, int unitnum, int status)
@@ -99,10 +99,8 @@ void gui_flicker_led (int led, int unitnum, int status)
     if (led < 0) {
         if (gui_data.hd >= 0)
             gui_flicker_led2(LED_HD, 0, 0);
-#if 0
         if (gui_data.cd >= 0)
             gui_flicker_led2(LED_CD, 0, 0);
-#endif
         if (gui_data.net >= 0)
             gui_flicker_led2(LED_NET, 0, 0);
         if (gui_data.md >= 0)

--- a/retrodep/hrtimer.h
+++ b/retrodep/hrtimer.h
@@ -8,6 +8,7 @@
 
 #ifndef EUAE_OSDEP_HRTIMER_H
 #define EUAE_OSDEP_HRTIMER_H
+
 #ifdef WIIU
 #include <features_cpu.h>
 #endif
@@ -26,28 +27,18 @@
 
 #include "machdep/rpt.h"
 
-
 STATIC_INLINE frame_time_t osdep_gethrtime (void)
 {
-#ifndef _ANDROID_
-
-#ifdef WIIU
+#if defined(_ANDROID_)
+   struct timespec now;
+   clock_gettime(CLOCK_MONOTONIC, &now);
+   return (now.tv_sec*1000000 + now.tv_nsec/1000);
+#elif defined(WIIU)
    return cpu_features_get_time_usec();
 #else
    struct timeval tv;
    gettimeofday (&tv, NULL);
    return tv.tv_sec*1000000 + tv.tv_usec;
-#endif
-
-#else
-#define osd_ticks_t uae_s64
-   struct timeval    tp;
-   static osd_ticks_t start_sec1 = 0;
-
-   gettimeofday(&tp, NULL);
-   if (start_sec1==0)
-      start_sec1 = tp.tv_sec;
-   return (tp.tv_sec - start_sec1) * (osd_ticks_t) 1000000 + tp.tv_usec;
 #endif
 }
 

--- a/sources/src/akiko.c
+++ b/sources/src/akiko.c
@@ -1518,24 +1518,24 @@ static void *akiko_thread (void *null)
 			switch (b)
 			{
 			case 0x0102: // pause
-				sys_command_cd_pause (unitnum, 1);
+				sys_command_cd_pause(unitnum, 1);
 				break;
 			case 0x0103: // unpause
-				sys_command_cd_pause (unitnum, 0);
+				sys_command_cd_pause(unitnum, 0);
 				break;
 			case 0x0104: // stop
 				cdaudiostop_do ();
 				break;
 			case 0x0105: // mute change
-				sys_command_cd_volume (unitnum, cdrom_muted ? 0 : 0x7fff, cdrom_muted ? 0 : 0x7fff);
+				sys_command_cd_volume(unitnum, cdrom_muted ? 0 : 0x7fff, cdrom_muted ? 0 : 0x7fff);
 				break;
 			case 0x0111: // instant play
 				sys_command_cd_volume(unitnum, cdrom_muted ? 0 : 0x7fff, cdrom_muted ? 0 : 0x7fff);
-				cdaudioplay_do (true);
+				cdaudioplay_do(true);
 				break;
 			case 0x0110: // do_play!
-				sys_command_cd_volume (unitnum, cdrom_muted ? 0 : 0x7fff, cdrom_muted ? 0 : 0x7fff);
-				cdaudioplay_do (false);
+				sys_command_cd_volume(unitnum, cdrom_muted ? 0 : 0x7fff, cdrom_muted ? 0 : 0x7fff);
+				cdaudioplay_do(false);
 				break;
 			}
 		}
@@ -2223,18 +2223,19 @@ void restore_akiko_final(void)
 	if (!currprefs.cs_cd32cd)
 		return;
 	write_comm_pipe_u32(&requests, 0x0102, 1); // pause
+	write_comm_pipe_u32(&requests, 0x0105, 1); // set mute
 	write_comm_pipe_u32(&requests, 0x0104, 1); // stop
 	write_comm_pipe_u32(&requests, 0x0103, 1); // unpause
 	if (cdrom_playing && akiko_isaudiotrack(last_play_pos)) {
-#ifdef __LIBRETRO__
-		akiko_mute(0);
-		if (!cdrom_paused)
-#endif
 		write_comm_pipe_u32(&requests, 0x0111, 0); // play immediate
 		write_comm_pipe_u32(&requests, last_play_pos, 0);
 		write_comm_pipe_u32(&requests, last_play_end, 0);
 		write_comm_pipe_u32(&requests, 0, 1);
-		uae_sem_wait(&cda_sem);
+		if (!cdrom_paused) {
+			uae_sem_wait(&cda_sem);
+		} else {
+			write_comm_pipe_u32(&requests, 0x0102, 1); // pause
+		}
 	}
 	cd_initialized = 2;
 }
@@ -2243,8 +2244,11 @@ void restore_akiko_final(void)
 
 void akiko_mute (int muted)
 {
-	cdrom_muted = muted;
-	if (unitnum >= 0)
-		write_comm_pipe_u32 (&requests, 0x0105, 1);
+	if (muted != cdrom_muted) {
+		cdrom_muted = muted;
+		if (currprefs.cs_cd32cd && unitnum >= 0) {
+			write_comm_pipe_u32 (&requests, 0x0105, 1);
+		}
+	}
 }
 

--- a/sources/src/akiko.c
+++ b/sources/src/akiko.c
@@ -2225,11 +2225,10 @@ void restore_akiko_final(void)
 	write_comm_pipe_u32(&requests, 0x0102, 1); // pause
 	write_comm_pipe_u32(&requests, 0x0104, 1); // stop
 	write_comm_pipe_u32(&requests, 0x0103, 1); // unpause
-#ifdef __LIBRETRO__
-	if (cdrom_playing && !cdrom_paused && akiko_isaudiotrack(last_play_pos)) {
-		akiko_mute(0);
-#else
 	if (cdrom_playing && akiko_isaudiotrack(last_play_pos)) {
+#ifdef __LIBRETRO__
+		akiko_mute(0);
+		if (!cdrom_paused)
 #endif
 		write_comm_pipe_u32(&requests, 0x0111, 0); // play immediate
 		write_comm_pipe_u32(&requests, last_play_pos, 0);

--- a/sources/src/archivers/lha/lha.h
+++ b/sources/src/archivers/lha/lha.h
@@ -5,12 +5,12 @@
 #include "sysdeps.h"
 #include "zfile.h"
 
-#define SYSTIME_HAS_NO_TM
-#define NODIRECTORY
-#define FTIME
+/*#define SYSTIME_HAS_NO_TM*/
+/*#define NODIRECTORY*/
+/*#define FTIME*/
 #define NOBSTRING
 #define NOINDEX
-#define MKTIME
+/*#define MKTIME*/
 
 /* ------------------------------------------------------------------------ */
 /* LHa for UNIX    Archiver Driver											*/

--- a/sources/src/blkdev.c
+++ b/sources/src/blkdev.c
@@ -241,7 +241,11 @@ void blkdev_fix_prefs (struct uae_prefs *p)
 static bool getsem2 (int unitnum, bool dowait)
 {
 	struct blkdevstate *st = &state[unitnum];
+#ifdef _WIN32
 	if (st->sema == NULL)
+#else
+	if (st->sema.sem == NULL)
+#endif
 		uae_sem_init (&st->sema, 0, 1);
 	bool gotit = false;
 	if (dowait) {
@@ -283,7 +287,11 @@ static void sys_command_close_internal (int unitnum)
 	freesem (unitnum);
 	if (st->isopen == 0) {
 		uae_sem_destroy (&st->sema);
+#ifdef _WIN32
 		st->sema = NULL;
+#else
+		st->sema.sem = NULL;
+#endif
 	}
 }
 
@@ -291,7 +299,11 @@ static int sys_command_open_internal (int unitnum, const TCHAR *ident, unsigned 
 {
 	struct blkdevstate *st = &state[unitnum];
 	int ret = 0;
+#ifdef _WIN32
 	if (st->sema == NULL)
+#else
+	if (st->sema.sem == NULL)
+#endif
 		uae_sem_init (&st->sema, 0, 1);
 	getsem2 (unitnum, true);
 	if (st->isopen)
@@ -593,7 +605,11 @@ static void check_changes (int unitnum)
 
 	if (changed) {
 		bool wasimage = currprefs.cdslots[unitnum].name[0] != 0;
+#ifdef _WIN32
 		if (st->sema)
+#else
+		if (st->sema.sem)
+#endif
 			gotsem = getsem2 (unitnum, true);
 		st->cdimagefileinuse = changed_prefs.cdslots[unitnum].inuse;
 		_tcscpy (st->newimagefile, changed_prefs.cdslots[unitnum].name);
@@ -632,7 +648,11 @@ static void check_changes (int unitnum)
 	st->imagechangetime--;
 	if (st->imagechangetime > 0)
 		return;
+#ifdef _WIN32
 	if (st->sema)
+#else
+	if (st->sema.sem)
+#endif
 		gotsem = getsem2 (unitnum, true);
 	_tcscpy (currprefs.cdslots[unitnum].name, st->newimagefile);
 	_tcscpy (changed_prefs.cdslots[unitnum].name, st->newimagefile);

--- a/sources/src/blkdev.c
+++ b/sources/src/blkdev.c
@@ -53,7 +53,6 @@ struct blkdevstate
 
 static struct blkdevstate state[MAX_TOTAL_SCSI_DEVICES];
 
-static bool blkdevsema;
 static bool dev_init;
 
 /* convert minutes, seconds and frames -> logical sector number */
@@ -239,15 +238,10 @@ void blkdev_fix_prefs (struct uae_prefs *p)
 
 }
 
-/*
 static bool getsem2 (int unitnum, bool dowait)
 {
 	struct blkdevstate *st = &state[unitnum];
-#ifdef _WIN32
-	if (st->sema == INVALID_HANDLE_VALUE)
-#else
-	if (st->sema.sem == NULL)
-#endif
+	if (st->sema == NULL)
 		uae_sem_init (&st->sema, 0, 1);
 	bool gotit = false;
 	if (dowait) {
@@ -261,27 +255,6 @@ static bool getsem2 (int unitnum, bool dowait)
 	if (st->sema_cnt > 1)
 		write_log (_T("CD: unitsem%d acquire mismatch! cnt=%d\n"), unitnum, st->sema_cnt);
 	return gotit;
-}
-*/
-static bool getsem2 (int unitnum, bool dowait)
-{
-    struct blkdevstate *st = &state[unitnum];
-    if (!blkdevsema) {
-        blkdevsema = true;
-        uae_sem_init (&st->sema, 0, 1);
-    }
-    bool gotit = false;
-    if (dowait) {
-        uae_sem_wait (&st->sema);
-        gotit = true;
-    } else {
-        gotit = uae_sem_trywait (&st->sema) == 0;
-    }
-    if (gotit)
-        st->sema_cnt++;
-    if (st->sema_cnt > 1)
-        write_log (_T("CD: unitsem%d acquire mismatch! cnt=%d\n"), unitnum, st->sema_cnt);
-    return gotit;
 }
 static bool getsem (int unitnum)
 {
@@ -310,8 +283,7 @@ static void sys_command_close_internal (int unitnum)
 	freesem (unitnum);
 	if (st->isopen == 0) {
 		uae_sem_destroy (&st->sema);
-		blkdevsema = false;
-		//st->sema = NULL;
+		st->sema = NULL;
 	}
 }
 
@@ -319,10 +291,8 @@ static int sys_command_open_internal (int unitnum, const TCHAR *ident, unsigned 
 {
 	struct blkdevstate *st = &state[unitnum];
 	int ret = 0;
-	if (!blkdevsema) {
-		blkdevsema = true;
+	if (st->sema == NULL)
 		uae_sem_init (&st->sema, 0, 1);
-	}
 	getsem2 (unitnum, true);
 	if (st->isopen)
 		write_log (_T("BUG unit %d open: opencnt=%d!\n"), unitnum, st->isopen);
@@ -623,7 +593,7 @@ static void check_changes (int unitnum)
 
 	if (changed) {
 		bool wasimage = currprefs.cdslots[unitnum].name[0] != 0;
-		if (blkdevsema)
+		if (st->sema)
 			gotsem = getsem2 (unitnum, true);
 		st->cdimagefileinuse = changed_prefs.cdslots[unitnum].inuse;
 		_tcscpy (st->newimagefile, changed_prefs.cdslots[unitnum].name);
@@ -662,7 +632,7 @@ static void check_changes (int unitnum)
 	st->imagechangetime--;
 	if (st->imagechangetime > 0)
 		return;
-	if (blkdevsema)
+	if (st->sema)
 		gotsem = getsem2 (unitnum, true);
 	_tcscpy (currprefs.cdslots[unitnum].name, st->newimagefile);
 	_tcscpy (changed_prefs.cdslots[unitnum].name, st->newimagefile);
@@ -1439,24 +1409,24 @@ int scsi_cd_emulate (int unitnum, uae_u8 *cmdbuf, int scsi_cmd_len,
 		}
 		for (;;) {
 			psize = 0;
-		if (pcode == 0) {
-			p[0] = 0;
-			p[1] = 0;
-			p[2] = 0x20;
-			p[3] = 0;
+			if (pcode == 0) {
+				p[0] = 0;
+				p[1] = 0;
+				p[2] = 0x20;
+				p[3] = 0;
 				psize = 4;
-		} else if (pcode == 14) { // CD audio control
-			uae_u32 vol = sys_command_cd_volume (unitnum, 0xffff, 0xffff);
-			p[0] = 0x0e;
-			p[1] = 0x0e;
+			} else if (pcode == 14) { // CD audio control
+				uae_u32 vol = sys_command_cd_volume (unitnum, 0xffff, 0xffff);
+				p[0] = 0x0e;
+				p[1] = 0x0e;
 				p[2] = 4|1;
-			p[3] = 4;
-			p[6] = 0;
-			p[7] = 75;
-			p[8] = 1;
-			p[9] = pc == 0 ? (vol >> 7) & 0xff : 0xff;
-			p[10] = 2;
-			p[11] = pc == 0 ? (vol >> (16 + 7)) & 0xff : 0xff;
+				p[3] = 4;
+				p[6] = 0;
+				p[7] = 75;
+				p[8] = 1;
+				p[9] = pc == 0 ? (vol >> 7) & 0xff : 0xff;
+				p[10] = 2;
+				p[11] = pc == 0 ? (vol >> (16 + 7)) & 0xff : 0xff;
 				psize = p[1] + 2;
 			} else if (pcode == 0x2a) {  // cd/dvd capabilities
 				p[0] = 0x2a;
@@ -1501,7 +1471,7 @@ int scsi_cd_emulate (int unitnum, uae_u8 *cmdbuf, int scsi_cmd_len,
 			totalsize += bdsize;
 			r[3] = bdsize & 0xff;
 			r[0] = totalsize & 0xff;
-	}
+		}
 		scsi_len = lr = totalsize + 1;
 		if (scsi_len > maxlen)
 			scsi_len = maxlen;

--- a/sources/src/blkdev_cdimage.c
+++ b/sources/src/blkdev_cdimage.c
@@ -62,7 +62,7 @@
 #endif
 
 #define scsi_log write_log
-#define CDDA_BUFFERS 12
+#define CDDA_BUFFERS 14
 
 extern volatile bool cd_audio_mode_changed;
 
@@ -272,6 +272,7 @@ static void flac_get_size (struct cdtoc *t)
 	FLAC__StreamDecoder *decoder = FLAC__stream_decoder_new ();
 	if (decoder) {
 		FLAC__stream_decoder_set_md5_checking (decoder, false);
+		FLAC__stream_decoder_set_metadata_respond(decoder, FLAC__METADATA_TYPE_CUESHEET);
 		int init_status = FLAC__stream_decoder_init_stream (decoder,
 			&file_read_callback, &file_seek_callback, &file_tell_callback,
 			&file_len_callback, &file_eof_callback,
@@ -457,7 +458,6 @@ static void *cdda_unpack_func (void *v)
 	delete mp3dec;
 #endif
 	cdimage_unpack_thread = -1;
-	return 0;
 }
 
 static void audio_unpack (struct cdunit *cdu, struct cdtoc *t)
@@ -488,7 +488,7 @@ static void next_cd_audio_buffer_callback(int bufnum, void *params)
 	if (bufnum < 0) {
 		audio_cda_new_buffer(&cdu->cas, NULL, -1, 0, NULL, cdu);
 	}
-	uae_sem_post (&play_sem);
+	uae_sem_post(&play_sem);
 }
 
 static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
@@ -514,7 +514,11 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 	cdu->cda_bufon[0] = cdu->cda_bufon[1] = 0;
 	bufnum = 0;
 
-	cda_new (CDDA_BUFFERS, 2352, 44100, mode != 0);//cdu->cda = new cda_audio (CDDA_BUFFERS, 2352, 44100, mode != 0);
+#if 0
+	cdu->cda = new cda_audio (CDDA_BUFFERS, 2352, 44100, mode != 0);
+#else
+	cda_new (CDDA_BUFFERS, 2352, 44100, mode != 0);
+#endif
 
 	while (cdu->cdda_play > 0) {
 
@@ -613,7 +617,11 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 				sleep_millis(10);
 			}
 		} else {
-			cda_wait(bufnum);//cdu->cda->wait(bufnum);
+#if 0
+			cdu->cda->wait(bufnum);
+#else
+			cda_wait(bufnum);
+#endif
 		}
 
 		cdu->cda_bufon[bufnum] = 0;
@@ -635,10 +643,17 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 
 			cdu_setstate(cdu, AUDIO_STATUS_IN_PROGRESS, cdda_pos);
 
-			memset (cda_audio_buffers[bufnum], 0, CDDA_BUFFERS * 2352);//memset (cdu->cda->buffers[bufnum], 0, CDDA_BUFFERS * 2352);
-
+#if 0
+			memset (cdu->cda->buffers[bufnum], 0, CDDA_BUFFERS * 2352);
+#else
+			memset (cda_audio_buffers[bufnum], 0, CDDA_BUFFERS * 2352);
+#endif
 			for (cnt = 0; cnt < CDDA_BUFFERS && cdu->cdda_play > 0; cnt++) {
-				uae_u8 *dst = cda_audio_buffers[bufnum] + cnt * 2352;//uae_u8 *dst = cdu->cda->buffers[bufnum] + cnt * 2352;
+#if 0
+				uae_u8 *dst = cdu->cda->buffers[bufnum] + cnt * 2352;
+#else
+				uae_u8 *dst = cda_audio_buffers[bufnum] + cnt * 2352;
+#endif
 				uae_u8 subbuf[SUB_CHANNEL_SIZE];
 				sector = cdda_pos;
 
@@ -660,7 +675,7 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 								uae_u8 p;
 								p = dst[i + 0];
 								dst[i + 0] = dst[i + 1];
-								dst[i +1] = p;
+								dst[i + 1] = p;
 							}
 #endif
 						} else if (t->handle) {
@@ -722,9 +737,14 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 				cdu->cda_bufon[bufnum] = 1;
 			} else {
 				cdu->cda_bufon[bufnum] = 1;
-				cda_setvolume (cdu->cdda_volume[0], cdu->cdda_volume[1]);//cdu->cda->setvolume (cdu->cdda_volume[0], cdu->cdda_volume[1]);
-				if (!cda_play (bufnum)) {//if (!cdu->cda->play (bufnum)) {
-					if (cdu->cdda_play > 0)
+#if 0
+				cdu->cda->setvolume (cdu->cdda_volume[0], cdu->cdda_volume[1]);
+				if (!cdu->cda->play (bufnum)) {
+#else
+				cda_setvolume (cdu->cdda_volume[0], cdu->cdda_volume[1]);
+				if (!cda_play (bufnum)) {
+#endif
+				if (cdu->cdda_play > 0)
 						cdu_setstate (cdu, AUDIO_STATUS_PLAY_ERROR, -1);
 					goto end;
 				}
@@ -764,14 +784,23 @@ end:
 		if (restart)
 			audio_cda_new_buffer(&cdu->cas, NULL, -1, -1, NULL, NULL);
 	} else {
-		cda_wait (0);//cdu->cda->wait (0);
-		cda_wait (1);//cdu->cda->wait (1);
+#if 0
+		cdu->cda->wait (0);
+		cdu->cda->wait (1);
+#else
+		cda_wait (0);
+		cda_wait (1);
+#endif
 	}
 
 	while (cdimage_unpack_active == 1)
 		sleep_millis(10);
 
-	cda_delete();//delete cdu->cda;
+#if 0
+	delete cdu->cda;
+#else
+	cda_delete();
+#endif
 
 	write_log (_T("IMAGE CDDA: thread killed (%s)\n"), restart ? _T("restart") : _T("play end"));
 	cd_audio_mode_changed = false;
@@ -798,7 +827,6 @@ static void *cdda_play_func (void *v)
 		cdu->cdda_play = 1;
 	}
 	cdu->thread_active = false;
-	return NULL;
 }
 
 static void cdda_stop (struct cdunit *cdu)
@@ -1495,6 +1523,7 @@ static int parsechd (struct cdunit *cdu, struct zfile *zcue, const TCHAR *img)
 #endif
 		dtrack->track = i + 1;
 		dtrack[1].address = dtrack->address + strack->frames;
+#if 0
 		if (chd_hunk_info(cf, dtrack->offset * CD_FRAME_SIZE / hunksize, &compr, &cbytes) == CHDERR_NONE) {
 			TCHAR tmp[100];
 			uae_u32 c = (uae_u32)compr;
@@ -1510,6 +1539,7 @@ static int parsechd (struct cdunit *cdu, struct zfile *zcue, const TCHAR *img)
 			tmp[4] = 0;
 			dtrack->extrainfo = my_strdup (tmp);
 		}
+#endif
 	}
 	return cdu->tracks;
 }
@@ -2181,19 +2211,27 @@ static int parse_image (struct cdunit *cdu, const TCHAR *img)
 			write_log (_T("   INDEX1 : %02d:%02d:%02d\n"), (msf >> 16) & 0x7fff, (msf >> 8) & 0xff, (msf >> 0) & 0xff);
 		}
 		if (i < cdu->tracks)
-			//write_log (_T("%2d: "), i + 1);
+#if 0
+			write_log (_T("%2d: "), i + 1);
+#endif
 			snprintf(toc_tmp, sizeof(toc_tmp), "%2d: ", i + 1);
 		else
-			//write_log (_T("    "));
+#if 0
+			write_log (_T("    "));
+#endif
 			snprintf(toc_tmp, sizeof(toc_tmp), "    ");
 		strcat(toc_row, toc_tmp);
 		msf = lsn2msf (t->address);
-		//write_log (_T("%7d %02d:%02d:%02d"),
+#if 0
+		write_log (_T("%7d %02d:%02d:%02d"),
+#endif
 		snprintf(toc_tmp, sizeof(toc_tmp), "%7d %02d:%02d:%02d",
 			t->address, (msf >> 16) & 0x7fff, (msf >> 8) & 0xff, (msf >> 0) & 0xff);
 		strcat(toc_row, toc_tmp);
 		if (i < cdu->tracks) {
-			//write_log (_T(" %s %x %10lld %10lld %s%s"),
+#if 0
+			write_log (_T(" %s %x %10lld %10lld %s%s"),
+#endif
 			snprintf(toc_tmp, sizeof(toc_tmp), " %s %x %10lld %10lld %s%s",
 				(t->ctrl & 4) ? _T("DATA    ") : (t->subcode ? _T("CDA+SUB") : _T("CDA     ")),
 				t->ctrl, t->offset, t->filesize,
@@ -2210,7 +2248,9 @@ static int parse_image (struct cdunit *cdu, const TCHAR *img)
 			t->filesize = zfile_size (t->handle);
 		if (t->postgap) {
 			msf = lsn2msf (t->postgap - 150);
-			//write_log (_T("   POSTGAP: %02d:%02d:%02d\n"), (msf >> 16) & 0x7fff, (msf >> 8) & 0xff, (msf >> 0) & 0xff);
+#if 0
+			write_log (_T("   POSTGAP: %02d:%02d:%02d\n"), (msf >> 16) & 0x7fff, (msf >> 8) & 0xff, (msf >> 0) & 0xff);
+#endif
 			snprintf(toc_tmp, sizeof(toc_tmp), "   POSTGAP: %02d:%02d:%02d",
 				(msf >> 16) & 0x7fff, (msf >> 8) & 0xff, (msf >> 0) & 0xff);
 			strcat(toc_row, toc_tmp);

--- a/sources/src/blkdev_cdimage.c
+++ b/sources/src/blkdev_cdimage.c
@@ -15,9 +15,10 @@
 #ifdef __CELLOS_LV2__
 #include "ps3_headers.h"
 #else
+#if 0
 #include <sys/timeb.h>
 #endif
-#include <ctype.h>
+#endif
 
 #include "sysconfig.h"
 #include "sysdeps.h"
@@ -36,6 +37,7 @@
 #include "cdrom.h"
 #include "sleep.h"
 #include "misc.h"
+#include "hrtimer.h"
 
 //#define WITH_MP3
 #ifdef WITH_MP3
@@ -525,12 +527,20 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 		if (oldplay != cdu->cdda_play) {
 			struct cdtoc *t;
 			int sector, diff;
+#if 0
 			struct timeb tb1, tb2;
+#else
+			uae_s64 tb1, tb2;
+#endif
 
 			idleframes = 0;
 			silentframes = 0;
 			foundsub = false;
+#if 0
 			ftime (&tb1);
+#else
+			tb1 = read_processor_time();
+#endif
 			cdda_pos = cdu->cdda_start;
 			oldplay = cdu->cdda_play;
 			sector = cdu->cd_last_pos = cdda_pos;
@@ -585,8 +595,13 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 			cdda_pos -= idleframes;
 
 			if (*outpos < 0) {
+#if 0
 				ftime (&tb2);
 				diff = (tb2.time * (uae_s64)1000 + tb2.millitm) - (tb1.time * (uae_s64)1000 + tb1.millitm);
+#else
+				tb2 = read_processor_time();
+				diff = (tb2 - tb1) / 1000;
+#endif
 				diff -= cdu->cdda_delay;
 				if (idleframes >= 0 && diff < 0 && cdu->cdda_play > 0)
 					sleep_millis(-diff);

--- a/sources/src/cdtv.c
+++ b/sources/src/cdtv.c
@@ -1963,7 +1963,11 @@ void restore_cdtv_final(void)
 		write_comm_pipe_u32(&requests, last_play_pos, 0);
 		write_comm_pipe_u32(&requests, last_play_end, 0);
 		write_comm_pipe_u32(&requests, 0, 1);
-		uae_sem_wait(&cda_sem);
+		if (cd_paused) {
+			write_comm_pipe_u32(&requests, 0x0105, 1); // paused
+		} else {
+			uae_sem_wait(&cda_sem);
+		}
 	}
 }
 

--- a/sources/src/cia.c
+++ b/sources/src/cia.c
@@ -82,7 +82,7 @@ static unsigned long ciaata_passed, ciaatb_passed, ciabta_passed, ciabtb_passed;
 
 static unsigned long ciaatod, ciabtod, ciaatol, ciabtol, ciaaalarm, ciabalarm;
 static int ciaatlatch, ciabtlatch;
-static bool oldled, oldovl, oldcd32mute;
+static bool oldled, oldovl;
 static bool led;
 static int led_old_brightness;
 static unsigned long led_cycles_on, led_cycles_off, led_cycle;
@@ -809,10 +809,7 @@ static void bfe001_change (void)
 		}
 	}
 #ifdef CD32
-	if (currprefs.cs_cd32cd && (v & 1) != oldcd32mute) {
-		oldcd32mute = v & 1;
-		akiko_mute (oldcd32mute ? 0 : 1);
-	}
+	akiko_mute((v & 1) == 0);
 #endif
 }
 
@@ -1402,7 +1399,6 @@ void CIA_reset (void)
 
 	kblostsynccnt = 0;
 	serbits = 0;
-	oldcd32mute = 1;
 	oldled = true;
 	resetwarning_phase = resetwarning_timer = 0;
 	heartbeat_cnt = 0;

--- a/sources/src/statusline.c
+++ b/sources/src/statusline.c
@@ -29,7 +29,7 @@ void statusline_getpos (int *x, int *y, int width, int height)
 {
 #ifdef __LIBRETRO__
 	currprefs.osd_pos.x=0;
-	currprefs.osd_pos.y=(opt_statusbar_position == -1) ? 30000 : opt_statusbar_position; // Have to fake -1 to get -0 as top position
+	currprefs.osd_pos.y=(opt_statusbar_position == -1) ? 30000 : opt_statusbar_position; /* Have to fake -1 to get -0 as top position */
 #endif
 	if (currprefs.osd_pos.x >= 20000) {
 		if (currprefs.osd_pos.x >= 30000)
@@ -153,16 +153,16 @@ static void write_tdnumber (uae_u8 *buf, int bpp, int x, int y, int num, uae_u32
 #ifdef __LIBRETRO__
 #define BLACK           0x000000
 #define YELLOW_DISABLED 0x222200
-#define YELLOW_DARK     0x444400
-#define YELLOW_DIM      0x666600
-#define YELLOW_BRIGHT   0x999900
+#define YELLOW_DARK     0x555500
+#define YELLOW_DIM      0x888800
+#define YELLOW_BRIGHT   0xCCCC00
 #define GREEN_DISABLED  0x002200
-#define GREEN_DARK      0x004400
-#define GREEN_DIM       0x006600
-#define GREEN_BRIGHT    0x009900
-#define RED_DARK        0x440000
-#define RED_DIM         0x660000
-#define RED_BRIGHT      0x990000
+#define GREEN_DARK      0x005500
+#define GREEN_DIM       0x008800
+#define GREEN_BRIGHT    0x00CC00
+#define RED_DARK        0x550000
+#define RED_DIM         0x880000
+#define RED_BRIGHT      0xCC0000
 
 void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u32 *rc, uae_u32 *gc, uae_u32 *bc, uae_u32 *alpha)
 {
@@ -221,7 +221,7 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             pos = 6 + pled;
             if ((gui_data.hd >= 0 || gui_data.cd >= 0 || gui_data.md >= 0) && !gui_data.df[0][0] && !gui_data.df[1][0])
             {
-                on_rgb = BLACK;
+                on_rgb  = BLACK;
                 on_rgb2 = BLACK;
                 off_rgb = BLACK;
             }
@@ -229,13 +229,13 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             {
                 if (currprefs.chipset_mask & CSMASK_MASK)
                 {
-                    on_rgb = YELLOW_BRIGHT;
+                    on_rgb  = YELLOW_BRIGHT;
                     on_rgb2 = YELLOW_DIM;
                     off_rgb = YELLOW_DARK;
                 }
                 else
                 {
-                    on_rgb = GREEN_BRIGHT;
+                    on_rgb  = GREEN_BRIGHT;
                     on_rgb2 = GREEN_DIM;
                     off_rgb = GREEN_DARK;
                 }
@@ -245,7 +245,7 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
                 num3 = track % 10;
                 on = gui_data.drive_motor[pled];
                 if (gui_data.drive_writing[pled]) {
-                    on_rgb = RED_BRIGHT;
+                    on_rgb  = RED_BRIGHT;
                     on_rgb2 = RED_DIM;
                 }
                 half = gui_data.drive_side ? 1 : -1;
@@ -269,21 +269,25 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
 
             if (opt_statusbar & STATUSBAR_MINIMAL)
                 num1 = num2 = num3 = -1;
-        /*} else if (led == LED_POWER) {
+#if 0
+        } else if (led == LED_POWER) {
             pos = 3;
             on_rgb = ((gui_data.powerled_brightness * 10 / 16) + 0x33) << 16;
             on = 1;
-            off_rgb = 0x330000;*/
+            off_rgb = 0x330000;
+#endif
         } else if (led == LED_CD && gui_data.cd >= 0) {
             pos = 9;
             if (gui_data.cd >= 0) {
                 on = gui_data.cd & (LED_CD_AUDIO | LED_CD_ACTIVE);
                 on_rgb = (on & LED_CD_AUDIO) ? YELLOW_DIM : YELLOW_BRIGHT;
                 off_rgb = YELLOW_DARK;
+#if 0
                 if ((gui_data.cd & LED_CD_ACTIVE2) && !(gui_data.cd & LED_CD_AUDIO)) {
                     on_rgb &= 0xfefefe;
                     on_rgb >>= 1;
                 }
+#endif
                 if (!currprefs.cdslots[0].name[0])
                 {
                     pen_rgb = ledcolor (YELLOW_DIM, rc, gc, bc, alpha);
@@ -299,7 +303,7 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             pos = 9;
             if (gui_data.hd >= 0) {
                 on = gui_data.hd;
-                on_rgb = on == 2 ? RED_BRIGHT : YELLOW_BRIGHT;
+                on_rgb  = on == 2 ? RED_BRIGHT : YELLOW_BRIGHT;
                 off_rgb = YELLOW_DARK;
                 num1 = -1;
                 num2 = 11;
@@ -313,12 +317,12 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
                 num1 = -1;
                 num2 = -1;
                 num3 = 16;
-                on_rgb = 0xcccccc;
+                on_rgb  = 0xcccccc;
                 off_rgb = 0x000000;
                 am = 2;
             } else {
                 int fps = (gui_data.fps + 5) / 10;
-                on_rgb = 0x000000;
+                on_rgb  = 0x000000;
                 off_rgb = gui_data.fps_color ? 0xcccc00 : 0x000000;
                 am = 2;
                 if (fps > 999) {
@@ -339,18 +343,19 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             }
             if (currprefs.chipset_mask & CSMASK_MASK)
             {
-                on_rgb = ((gui_data.powerled_brightness * 10 / 16) + 0x33) << 9;
+                on_rgb  = GREEN_BRIGHT;
                 off_rgb = GREEN_DARK;
             }
             else
             {
-                on_rgb = ((gui_data.powerled_brightness * 10 / 16) + 0x33) << 16;
+                on_rgb  = RED_BRIGHT;
                 off_rgb = RED_DARK;
             }
-            on = 1;
+            on = (gui_data.powerled_brightness > 0) ? 1 : 0;
             if (opt_statusbar & STATUSBAR_MINIMAL)
                 num1 = num2 = num3 = -1;
-        /*} else if (led == LED_CPU) {
+#if 0
+        } else if (led == LED_CPU) {
             int idle = (gui_data.idle + 5) / 10;
             pos = 1;
             on_rgb = 0xcc0000;
@@ -378,8 +383,8 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
                 num3 = idle % 10;
                 num4 = num1 == 0 ? 13 : -1;
                 am = 3;
-            }*/
-        /*} else if (led == LED_SND) {
+            }
+        } else if (led == LED_SND) {
             int snd = abs(gui_data.sndbuf + 5) / 10;
             if (snd > 99)
                 snd = 99;
@@ -398,7 +403,8 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             else if (on == 1)
                 on_rgb = 0x0000cc; // "normal" overflow
             off_rgb = 0x000000;
-            am = 3;*/
+            am = 3;
+#endif
         } else if (led == LED_MD && gui_data.drive_disabled[3] && gui_data.md >= 1) {
             // DF3 reused as internal non-volatile ram led (cd32/cdtv)
             pos = 8;
@@ -418,7 +424,8 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
             }
             if (opt_statusbar & STATUSBAR_MINIMAL)
                 num1 = num2 = num3 = -1;
-        /*} else if (led == LED_NET) {
+#if 0
+        } else if (led == LED_NET) {
             pos = 6;
             if (gui_data.net >= 0) {
                 on = gui_data.net;
@@ -432,7 +439,8 @@ void draw_status_line_single (uae_u8 *buf, int bpp, int y, int totalwidth, uae_u
                 num2 = -1;
                 num3 = 17;
                 am = 1;
-            }*/
+            }
+#endif
         } else {
             continue;
         }


### PR DESCRIPTION
VKBD:
- Better readability with font outline instead of simple shadow
- Reworked core option with new "Automatic" default

CDA:
- Upstream sync and backports
- Changed CDA playback LED behavior from blink to steady

CHD:
- Fixed crash when restoring state with more than average amount of audio tracks
- Fixed CDA track starting frame

Bonus:
- Statusline color adjustments
- Removed deprecated `ftime`
- Comment and unused stuff cleanups
