### PR TITLE
Minor corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ endif
 ifeq ($(DEBUG), 1)
    CFLAGS += -O0 -g
 else
-   CFLAGS += -O3 -Wno-format
+   CFLAGS += -O3 -Wno-format -Wno-format-security
    LDFLAGS += -s
 endif
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ It delivers the best of both worlds, and looks great with high resolution games,
 
 You can force a specific model if a game needs one (AGA games for instance) either by the "Model" core option or by file path tags.
 
-The "Model" core option at "**Automatic**" will default to A500 when booting floppy disks, A1200 when booting hard drives, and CD32 when booting CD images.
+The "Model" core option at "**Automatic**" will default to A500 when booting floppy disks, A1200 when booting hard drives, and CD32 when booting compact discs.
 
 The whole path (filename and directory) will be searched for the following tags if the model is "**Automatic**":
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -290,7 +290,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "puae_model",
          "Model",
-         "'Automatic' defaults to 'A500' with floppy disks, 'A600' with hard drives and 'CD32' with CD images. 'Automatic' can be overridden with file path tags.\nCore restart required.",
+         "'Automatic' defaults to 'A500' with floppy disks, 'A1200' with hard drives and 'CD32' with compact discs. 'Automatic' can be overridden with file path tags.\nCore restart required.",
          {
             { "auto", "Automatic" },
             { "A500OG", "A500 (512KB Chip)" },

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -1810,7 +1810,8 @@ void update_input(unsigned disable_keys)
       /* Press Return, RetroPad Start */
       i = RETRO_DEVICE_ID_JOYPAD_START;
       if (!vkflag[i] && mapper_keys[i] >= 0 && ((joypad_bits[0] & (1 << i)) ||
-                                                (joypad_bits[1] & (1 << i))))
+                                                (joypad_bits[1] & (1 << i)))
+                                            && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RETURN))
       {
          vkflag[i] = 1;
          retro_key_down(AK_RET);


### PR DESCRIPTION
- Rewordings and corrections to core option label + README
- Add `-Wno-format-security` to Makefile
- Prevent duplicate VKBD press when keyboard Return is RetroPad Start
