### PR TITLE
add IPF support to PS3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ else ifneq ($(findstring win,$(shell uname -a)),)
 endif
 endif
 
+ifeq ($(capsimg), 1)
+   CFLAGS += -DHAVE_CAPS_CAPSIMAGE_H
+endif
+   
 # Unix
 ifneq (,$(findstring unix,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so

--- a/sources/src/caps/caps.c
+++ b/sources/src/caps/caps.c
@@ -22,6 +22,7 @@ static int caps_locked[4];
 static int caps_flags = DI_LOCK_DENVAR|DI_LOCK_DENNOISE|DI_LOCK_NOISE|DI_LOCK_UPDATEFD|DI_LOCK_TYPE;
 #define LIB_TYPE 1
 
+#ifndef HAVE_CAPS_CAPSIMAGE_H
 #if !defined HAVE_FRAMEWORK_CAPSIMAGE
 #include "uae_dlopen.h"
 
@@ -448,6 +449,7 @@ static int load_capslib (void)
 #endif
 #endif
 #endif
+#endif //HAVE_CAPS_CAPSIMAGE_H
 
 /*
  * CAPS support proper starts here
@@ -460,6 +462,7 @@ int caps_init (void)
     unsigned int i;
     struct CapsVersionInfo cvi;
 
+#ifndef HAVE_CAPS_CAPSIMAGE_H
     if (init)
 		return 1;
 
@@ -473,6 +476,7 @@ int caps_init (void)
 		noticed = 1;
 		return 0;
     }
+#endif //HAVE_CAPS_CAPSIMAGE_H
     init = 1;
     cvi.type = LIB_TYPE;
 	CAPSGetVersionInfo (&cvi, 0);


### PR DESCRIPTION
For platforms like PS3 where cores are statically linked to RetroArch, CapsImg library have to be linked when final RetroArch SELF is built.
make adding parameter ´capsimg=1´ for example ´make platform=ps3 capsimg=1´
At RetroArch compiling time, add ´-lcapsimg´ as additional library.

------------------------
```
[libretro INFO] Opening cfgfile '/dev_hdd0/game/RETROARCH/USRDIR/savefiles/puae_libretro.uae' 
[libretro INFO] Known ROM 'KS ROM v1.3 (A500,A1000,A2000)' loaded 
[libretro INFO] CAPS: library version 5.1 
[libretro INFO] CAPS: type:1 date:13.6.2003 2:13:47 rel:298 rev:1 
[libretro INFO] Building CPU table for configuration: 68000 24-bit
[libretro INFO] 1883 CPU functions 
[libretro INFO] Building CPU, 44316 opcodes (0 0 1) 
[libretro INFO] CPU=68000, FPU=0, MMU=0, JIT=CPU=0. 
[libretro INFO] Reset at 00000000. Chipset mask = 00000000 
[libretro INFO] CAPS: library version 5.1 
[libretro INFO] CAPS: type:1 date:13.6.2003 2:13:47 rel:298 rev:1 
[libretro INFO] PAL mode V=49.9201Hz H=15625.0881Hz (227x312+1) IDX=10 (PAL) D=0 RTG=0/0 
[libretro INFO] hardreset, memory cleared 
[libretro INFO] PAL mode V=49.9201Hz H=15625.0881Hz (227x312+1) IDX=10 (PAL) D=0 RTG=0/0
``` 
------------------------
