### PR TITLE
Remove temporary config write

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3227,6 +3227,9 @@ void retro_init(void)
       return;
    }
 
+   bool achievements = true;
+   environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &achievements);
+
    memset(retro_bmp, 0, sizeof(retro_bmp));
 
    libretro_runloop_active = 0;

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4366,9 +4366,6 @@ static bool retro_create_config()
                         /* Extract ZIP */
                         zip_uncompress(whdload_files_zip, whdload_path, NULL);
                         remove(whdload_files_zip);
-
-                        /* Copy Kickstarts */
-                        whdload_kscopy();
                      }
                      else
                         log_cb(RETRO_LOG_ERROR, "Unable to create WHDLoad image directory: '%s'\n", (const char*)&whdload_path);
@@ -4411,6 +4408,9 @@ static bool retro_create_config()
                   }
                   else
                      log_cb(RETRO_LOG_ERROR, "Unable to create WHDSaves image directory: '%s'\n", (const char*)&whdsaves_path);
+
+                  /* Copy Kickstarts */
+                  whdload_kscopy();
 
                   /* Copy required files host-wise with file mode */
                   if (path_is_valid(whdload_prefs_path))

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -1517,7 +1517,7 @@ UINT64 be_read(const UINT8 *base, int numbytes)
     the data stream in bigendian order
 -------------------------------------------------*/
 
-INLINE UINT32 get_bigendian_uint32(const UINT8 *base)
+UINT32 get_bigendian_uint32(const UINT8 *base)
 {
 	return (base[0] << 24) | (base[1] << 16) | (base[2] << 8) | base[3];
 }
@@ -1527,7 +1527,7 @@ INLINE UINT32 get_bigendian_uint32(const UINT8 *base)
     the data stream in bigendian order
 -------------------------------------------------*/
 
-INLINE UINT64 get_bigendian_uint64(const UINT8 *base)
+UINT64 get_bigendian_uint64(const UINT8 *base)
 {
 	return ((UINT64)base[0] << 56) | ((UINT64)base[1] << 48) | ((UINT64)base[2] << 40) | ((UINT64)base[3] << 32) |
 			((UINT64)base[4] << 24) | ((UINT64)base[5] << 16) | ((UINT64)base[6] << 8) | (UINT64)base[7];

--- a/libretro/libretro-graph.c
+++ b/libretro/libretro-graph.c
@@ -268,7 +268,13 @@ void draw_hline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
    }
 }
 
-
+void draw_vline(int x, int y, int dx, int dy, uint32_t color)
+{
+   if (pix_bytes == 4)
+      draw_vline_bmp32((uint32_t *)retro_bmp, x, y, dx, dy, color);
+   else
+      draw_vline_bmp(retro_bmp, x, y, dx, dy, color);
+}
 
 void draw_vline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color)
 {
@@ -280,7 +286,20 @@ void draw_vline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsign
    {
       idx = x+j*retrow;
       buffer[idx] = color;
-   }	
+   }
+}
+
+void draw_vline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color)
+{
+   int i, j, idx;
+
+   (void)i;
+
+   for (j=y; j<y+dy; j++)
+   {
+      idx = x+j*retrow;
+      buffer[idx] = color;
+   }
 }
 
 void draw_line_bmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color)

--- a/libretro/libretro-graph.h
+++ b/libretro/libretro-graph.h
@@ -29,8 +29,9 @@ void draw_hline(int x, int y, int dx, int dy, uint32_t color);
 void draw_hline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
 void draw_hline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
 
+void draw_vline(int x, int y, int dx, int dy, uint32_t color);
 void draw_vline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-void draw_vline_bmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color);
+void draw_vline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
 
 void draw_string(unsigned short *surf, unsigned short int x, unsigned short int y,
       const char *string, unsigned short int maxstrlen,

--- a/sources/src/cfgfile.c
+++ b/sources/src/cfgfile.c
@@ -38,6 +38,10 @@
 #include "sounddep/sound.h"
 #include "misc.h"
 
+#ifdef __LIBRETRO__
+extern char uae_full_config[4096];
+#endif
+
 static int config_newfilesystem;
 static struct strlist *temp_lines;
 static struct zfile *default_file, *configstore;
@@ -3906,7 +3910,12 @@ static int cfgfile_load_2 (struct uae_prefs *p, const TCHAR *filename, bool real
 		config_newfilesystem = 0;
 		//reset_inputdevice_config (p);
 	}
-
+#ifdef __LIBRETRO__
+    fh = NULL;
+    char *token;
+    for (token = strtok(uae_full_config, "\n"); token; token = strtok(NULL, "\n")) {
+		strcpy(linea, token);
+#else
 	write_log ("Opening cfgfile '%s' ", filename);
 	fh = zfile_fopen (filename, _T("r"), ZFD_NORMAL);
 #ifndef	SINGLEFILE
@@ -3918,6 +3927,7 @@ static int cfgfile_load_2 (struct uae_prefs *p, const TCHAR *filename, bool real
 	//write_log ("OK\n");
 
 	while (cfg_fgets (linea, sizeof (linea), fh) != 0) {
+#endif /* __LIBRETRO__ */
 		trimwsa (linea);
 		if (strlen (linea) > 0) {
 			if (linea[0] == '#' || linea[0] == ';') {

--- a/sources/src/main.c
+++ b/sources/src/main.c
@@ -855,12 +855,10 @@ static void parse_cmdline_and_init_file (int argc, TCHAR **argv)
 #ifdef __LIBRETRO__
 	_tcscpy (optionsfile, ".");
 	_tcscat (optionsfile, _T("/"));
-#endif
+	target_cfgfile_load (&currprefs, NULL, 0, default_config);
+#else
 	parse_cmdline_2 (argc, argv);
-
-#ifndef __LIBRETRO__
 	_tcscat (optionsfile, restart_config);
-#endif
 
 	if (argc > 1 && ! target_cfgfile_load (&currprefs, argv[1], 0, default_config)) {
 		write_log (_T("failed to load config '%s'\n"), optionsfile);
@@ -870,6 +868,7 @@ static void parse_cmdline_and_init_file (int argc, TCHAR **argv)
 		target_cfgfile_load (&currprefs, optionsfile, 0, default_config);
 #endif
 	}
+#endif
 	fixup_prefs (&currprefs);
 
 	parse_cmdline (argc, argv);

--- a/sources/src/misc.c
+++ b/sources/src/misc.c
@@ -286,10 +286,10 @@ static int qs_override;
 int target_cfgfile_load (struct uae_prefs *p, const TCHAR *filename, int type, int isdefault)
 {
 	int v, i, type2;
-	int ct, ct2 = 0;//, size;
+	int ct, ct2 = 0;
 	char tmp1[MAX_DPATH], tmp2[MAX_DPATH];
 	char fname[MAX_DPATH];
-
+#if 0
 	_tcscpy (fname, filename);
 	if (!zfile_exists (fname)) {
 		fetch_configurationpath (fname, sizeof (fname) / sizeof (TCHAR));
@@ -298,6 +298,7 @@ int target_cfgfile_load (struct uae_prefs *p, const TCHAR *filename, int type, i
 		else
 			_tcscpy (fname, filename);
 	}
+#endif
 
 	if (!isdefault)
 		qs_override = 1;
@@ -313,7 +314,6 @@ int target_cfgfile_load (struct uae_prefs *p, const TCHAR *filename, int type, i
 		default_prefs (p, type);
 	}
 		
-	//regqueryint (NULL, "ConfigFile_NoAuto", &ct2);
 	v = cfgfile_load (p, fname, &type2, ct2, isdefault ? 0 : 1);
 	if (!v)
 		return v;
@@ -321,12 +321,8 @@ int target_cfgfile_load (struct uae_prefs *p, const TCHAR *filename, int type, i
 		return v;
 	for (i = 1; i <= 2; i++) {
 		if (type != i) {
-			// size = sizeof (ct);
 			ct = 0;
-			//regqueryint (NULL, configreg2[i], &ct);
 			if (ct && ((i == 1 && p->config_hardware_path[0] == 0) || (i == 2 && p->config_host_path[0] == 0) || ct2)) {
-				// size = sizeof (tmp1) / sizeof (TCHAR);
-				//regquerystr (NULL, configreg[i], tmp1, &size);
 				fetch_path ("ConfigurationPath", tmp2, sizeof (tmp2) / sizeof (TCHAR));
 				_tcscat (tmp2, tmp1);
 				v = i;
@@ -386,13 +382,12 @@ int scan_roms (int show)
 // writelog
 TCHAR* buf_out (TCHAR *buffer, int *bufsize, const TCHAR *format, ...)
 {
-	/// REMOVEME: unused: int count;
 	va_list parms;
 	va_start (parms, format);
 
 	if (buffer == NULL)
 		return 0;
-	/** REMOVEME: unused: count = **/
+
 	vsnprintf (buffer, (*bufsize) - 1, format, parms);
 	va_end (parms);
 	*bufsize -= _tcslen (buffer);
@@ -402,7 +397,6 @@ TCHAR* buf_out (TCHAR *buffer, int *bufsize, const TCHAR *format, ...)
 // dinput
 void setid (struct uae_input_device *uid, int i, int slot, int sub, int port, int evt)
 {
-	// wrong place!
 	uid->eventid[slot][SPARE_SUB_EVENT] = uid->eventid[slot][sub];
 	uid->flags[slot][SPARE_SUB_EVENT] = uid->flags[slot][sub];
 	uid->port[slot][SPARE_SUB_EVENT] = MAX_JPORTS + 1;


### PR DESCRIPTION
- Remove temporary config write
  - Feeds the uae conf directly without exporting `puae_libretro.uae`, but the old file stays until manually deleted
- Set achievements support
- Always check for missing WHDLoad Kickstarts in files-mode
- libretro graph update
- Fixed debug build by removing some INLINEs