### PR TITLE
Add basic support for loading RP9 files

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4025,14 +4025,16 @@ static bool retro_create_config(void)
    if (!string_is_empty(full_path) && (path_is_valid(full_path) || path_is_directory(full_path)))
    {
       /* Extract ZIP for examination */
-      if (strendswith(full_path, "zip") || strendswith(full_path, "7z"))
+      if (strendswith(full_path, "zip")
+       || strendswith(full_path, "7z")
+       || strendswith(full_path, "rp9"))
       {
          char zip_basename[RETRO_PATH_MAX] = {0};
          snprintf(zip_basename, sizeof(zip_basename), "%s", path_basename(full_path));
          path_remove_extension(zip_basename);
 
          path_mkdir(retro_temp_directory);
-         if (strendswith(full_path, "zip"))
+         if (strendswith(full_path, "zip") || strendswith(full_path, "rp9"))
             zip_uncompress(full_path, retro_temp_directory, NULL);
          else if (strendswith(full_path, "7z"))
             sevenzip_uncompress(full_path, retro_temp_directory, NULL);

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -248,14 +248,16 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
       }
 
       /* ZIP */
-      else if (strendswith(full_path_replace, "zip") || strendswith(full_path_replace, "7z"))
+      else if (strendswith(full_path_replace, "zip")
+       || strendswith(full_path_replace, "7z")
+       || strendswith(full_path_replace, "rp9"))
       {
          char zip_basename[RETRO_PATH_MAX] = {0};
          snprintf(zip_basename, sizeof(zip_basename), "%s", path_basename(full_path_replace));
          path_remove_extension(zip_basename);
 
          path_mkdir(retro_temp_directory);
-         if (strendswith(full_path_replace, "zip"))
+         if (strendswith(full_path_replace, "zip") || strendswith(full_path_replace, "rp9"))
             zip_uncompress(full_path_replace, retro_temp_directory, NULL);
          else if (strendswith(full_path_replace, "7z"))
             sevenzip_uncompress(full_path_replace, retro_temp_directory, NULL);


### PR DESCRIPTION
This adds basic support for loading RP9 files, which are distributed by Cloanto in their Amiga Forever package and are just renamed zip files with an adf/hdf file located inside (plus metadata used by Amiga Forever).