### PR TITLE
Save path fix + hack

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3197,6 +3197,10 @@ void retro_init(void)
               sizeof(retro_save_directory));
    }
 
+   /* Remove ending slash created by 'savefiles_in_content_dir' */
+   if (retro_save_directory[strlen(retro_save_directory)-1] == DIR_SEP_CHR)
+      retro_save_directory[strlen(retro_save_directory)-1] = '\0';
+
    /* Temp directory for ZIPs */
    snprintf(retro_temp_directory, sizeof(retro_temp_directory), "%s%s%s", retro_save_directory, DIR_SEP_STR, "TEMP");
 
@@ -3695,10 +3699,15 @@ static void retro_config_harddrives(void)
 
    for (i = 0; i < dc->count; i++)
    {
-      tmp_str = string_replace_substring(dc->files[i], "\\", "\\\\");
-      tmp_str = utf8_to_local_string_alloc(tmp_str);
       char tmp_str_name[RETRO_PATH_MAX];
       char tmp_str_path[RETRO_PATH_MAX];
+
+#ifdef WIN32
+      tmp_str = utf8_to_local_string_alloc(string_replace_substring(dc->files[i], "\\", "\\\\"));
+#else
+      tmp_str = utf8_to_local_string_alloc(dc->files[i]);
+#endif
+
       snprintf(tmp_str_name, sizeof(tmp_str_name), "%s", path_basename(tmp_str));
       path_remove_extension(tmp_str_name);
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3201,6 +3201,11 @@ void retro_init(void)
    if (retro_save_directory[strlen(retro_save_directory)-1] == DIR_SEP_CHR)
       retro_save_directory[strlen(retro_save_directory)-1] = '\0';
 
+   /* Hack: Remove one-letter subdirectories from save path,
+    * to prevent multiple WHDLoad images */
+   if (retro_save_directory[strlen(retro_save_directory)-2] == DIR_SEP_CHR)
+      retro_save_directory[strlen(retro_save_directory)-2] = '\0';
+
    /* Temp directory for ZIPs */
    snprintf(retro_temp_directory, sizeof(retro_temp_directory), "%s%s%s", retro_save_directory, DIR_SEP_STR, "TEMP");
 

--- a/sources/src/cfgfile.c
+++ b/sources/src/cfgfile.c
@@ -5282,6 +5282,7 @@ void default_prefs (struct uae_prefs *p, int type)
 
 	zfile_fclose (default_file);
 	default_file = NULL;
+#ifndef __LIBRETRO__
 	f = zfile_fopen_empty (NULL, _T("configstore"), 0);
 	if (f) {
 		uaeconfig++;
@@ -5290,6 +5291,7 @@ void default_prefs (struct uae_prefs *p, int type)
 		cfg_write (&zero, f);
 		default_file = f;
 	}
+#endif
 }
 
 static void buildin_default_prefs_68020 (struct uae_prefs *p)


### PR DESCRIPTION
`savefiles_in_content_dir` in combination with one-letter directories causes memory corruption in Linux, thus:
- Remove ending slash from `saves` path
- Also disregard one-letter subdirectories, so that WHDLoad data is saved in one place instead

Closes #437 