### PR TITLE
Kickstart improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,49 +57,50 @@ Some games use mouse instead of joystick. D-Pad can be switched between joystick
 
 ## Configuration
 
-To generate the temporary uae configuration file the core will use the core options configured in RetroArch.
-
 The following model presets are provided:
 
-| Short   | Long           | Chipset | Memory                          |
-|---------|----------------|---------|---------------------------------|
-| A500OG  | Amiga 500      | OCS     | 0.5MB Chip RAM                  |
-| A500    | Amiga 500      | OCS     | 0.5MB Chip RAM + 0.5MB Slow RAM |
-| A500+   | Amiga 500+     | ECS     | 1MB Chip RAM                    |
-| A600    | Amiga 600      | ECS     | 2MB Chip RAM + 8MB Fast RAM     |
-| A1200OG | Amiga 1200     | AGA     | 2MB Chip RAM                    |
-| A1200   | Amiga 1200     | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
-| A4030   | Amiga 4000/030 | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
-| A4040   | Amiga 4000/040 | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
-| CDTV    | Amiga CDTV     | ECS     | 1MB Chip RAM                    |
-| CD32    | Amiga CD32     | AGA     | 2MB Chip RAM                    |
-| CD32FR  | Amiga CD32     | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
-
-The configuration file is generated at launch and at core restart.
+| Short   | Long           | Kickstart | Chipset | Memory                          |
+|---------|----------------|-----------|---------|---------------------------------|
+| A500OG  | Amiga 500      | v1.2      | OCS     | 0.5MB Chip RAM                  |
+| A500    | Amiga 500      | v1.3      | OCS     | 0.5MB Chip RAM + 0.5MB Slow RAM |
+| A500+   | Amiga 500+     | v2.04     | ECS     | 1MB Chip RAM                    |
+| A600    | Amiga 600      | v3.1      | ECS     | 2MB Chip RAM + 8MB Fast RAM     |
+| A1200OG | Amiga 1200     | v3.1      | AGA     | 2MB Chip RAM                    |
+| A1200   | Amiga 1200     | v3.1      | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
+| A2000OG | Amiga 2000     | v1.2      | OCS     | 0.5MB Chip RAM + 0.5MB Slow RAM |
+| A2000   | Amiga 2000     | v3.1      | ECS     | 1MB Chip RAM                    |
+| A4030   | Amiga 4000/030 | v3.1      | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
+| A4040   | Amiga 4000/040 | v3.1      | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
+| CDTV    | Amiga CDTV     | v1.3+ext  | ECS     | 1MB Chip RAM                    |
+| CD32    | Amiga CD32     | v3.1+ext  | AGA     | 2MB Chip RAM                    |
+| CD32FR  | Amiga CD32     | v3.1+ext  | AGA     | 2MB Chip RAM + 8MB Fast RAM     |
 
 ### Kickstart ROMs
 
-The following Kickstart ROMs are required in RetroArch `system` directory:
+The emulated model requires a matching Kickstart ROM in RetroArch `system` directory.
 
-*It is critical to use ROMs with the correct MD5, otherwise the core might not start!*
-
-*The core has a built-in AROS fallback Kickstart, which is used when the real Kickstart is not found. It can be compatible enough for some A500 games.*
+The core has a built-in AROS Kickstart, which is used as a fallback when the proper Kickstart is not found. It is compatible enough for some games.
 
 Amiga Forever BIOS files must be renamed accordingly.
 
+*It is critical to use ROMs with the correct MD5, otherwise the core might not start!*
+
 | System | Version                       | Filename               | Amiga Forever             | Size      | MD5                              |
 |--------|-------------------------------|------------------------|---------------------------|----------:|----------------------------------|
-| A500   | KS v1.2 rev 33.180 !          | **kick33180.A500**     | amiga-os-120.rom          |   262 144 | 85ad74194e87c08904327de1a9443b7a |
+| A500   | KS v1.2 rev 33.180            | **kick33180.A500**     | amiga-os-120.rom          |   262 144 | 85ad74194e87c08904327de1a9443b7a |
 | A500   | KS v1.3 rev 34.005            | **kick34005.A500**     | amiga-os-130.rom          |   262 144 | 82a21c1890cae844b3df741f2762d48d |
 | A500+  | KS v2.04 rev 37.175           | **kick37175.A500**     | amiga-os-204.rom          |   524 288 | dc10d7bdd1b6f450773dfb558477c230 |
+| A600   | KS v2.05 rev 37.350           | **kick37350.A600**     | amiga-os-205-a600.rom     |   524 288 | 465646c9b6729f77eea5314d1f057951 |
 | A600   | KS v3.1 rev 40.063            | **kick40063.A600**     | amiga-os-310-a600.rom     |   524 288 | e40a5dfb3d017ba8779faba30cbd1c8e |
+| A1200  | KS v3.0 rev 39.106            | **kick39106.A1200**    | amiga-os-300-a1200.rom    |   524 288 | b7cc148386aa631136f510cd29e42fc3 |
 | A1200  | KS v3.1 rev 40.068            | **kick40068.A1200**    | amiga-os-310-a1200.rom    |   524 288 | 646773759326fbac3b2311fd8c8793ee |
+| A2000  | KS v1.2 rev 33.180            | **kick33180.A500**     | amiga-os-120.rom          |   262 144 | 85ad74194e87c08904327de1a9443b7a |
+| A2000  | KS v3.1 rev 40.063            | **kick40063.A600**     | amiga-os-310-a600.rom     |   524 288 | dc10d7bdd1b6f450773dfb558477c230 |
+| A4000  | KS v3.0 rev 39.106            | **kick39106.A4000**    | amiga-os-300-a4000.rom    |   524 288 | 9b8bdd5a3fd32c2a5a6f5b1aefc799a5 |
 | A4000  | KS v3.1 rev 40.068            | **kick40068.A4000**    | amiga-os-310-a4000.rom    |   524 288 | 9bdedde6a4f33555b4a270c8ca53297d |
-| CDTV   | CDTV extended ROM v1.00       | **kick34005.CDTV**     | amiga-os-130-cdtv-ext.rom |   262 144 | 89da1838a24460e4b93f4f0c5d92d48d |
+| CDTV   | CDTV extended ROM v1.0        | **kick34005.CDTV**     | amiga-os-130-cdtv-ext.rom |   262 144 | 89da1838a24460e4b93f4f0c5d92d48d |
 
-(!) Kickstart v1.2 only needed for WHDLoad Arcadia games.
-
-For CD32 you need either separate ROMs (Kickstart + extended ROM) or the combined ROM:
+CD32 requires either separate ROMs (Kickstart + extended ROM) or the combined ROM:
 
 | System | Version                       | Filename               | Amiga Forever             | Size      | MD5                              |
 |--------|-------------------------------|------------------------|---------------------------|----------:|----------------------------------|
@@ -194,8 +195,6 @@ Supported formats are:
 - **HDF**, **HDZ**, **LHA** for hard drive images
 - **M3U** for multiple image playlist
 - **ZIP** for various content (FD, HD, CD, WHDLoad)
-
-When launching these files the core will generate a temporary configuration file in RetroArch `saves` directory and use it to start the emulation.
 
 ### Floppy drive sounds
 
@@ -402,7 +401,9 @@ Note the size of the HDF specified by SIZE_OF_HDF must be greater than size of t
 
 You can pass `.uae` configuration files and they will be appended to the core option configuration.
 
-If the file `puae_libretro_global.uae` exists in RetroArch `saves` it will be appended to the configuration.
+If `puae_libretro_global.uae` exists in RetroArch `saves` it will be appended to the configuration.
+
+If `puae_libretro_[model].uae` exists in RetroArch `saves` it will replace the model preset section.
 
 The final generated configuration output is available in debug level log.
 

--- a/README.md
+++ b/README.md
@@ -77,37 +77,37 @@ The following model presets are provided:
 
 ### Kickstart ROMs
 
-The emulated model requires a matching Kickstart ROM in RetroArch `system` directory.
+The models require matching Kickstart ROMs in RetroArch `system` directory.
 
-The core has a built-in AROS Kickstart, which is used as a fallback when the proper Kickstart is not found. It is compatible enough for some games.
+Amiga Forever and TOSEC filenames are also accepted.
 
-Amiga Forever BIOS files must be renamed accordingly.
+The core has a somewhat compatible built-in AROS Kickstart, which is used as a fallback when the proper Kickstart is not found.
 
-*It is critical to use ROMs with the correct MD5, otherwise the core might not start!*
+*It is critical to use ROMs with the correct MD5!*
 
-| System | Version                       | Filename               | Amiga Forever             | Size      | MD5                              |
-|--------|-------------------------------|------------------------|---------------------------|----------:|----------------------------------|
-| A500   | KS v1.2 rev 33.180            | **kick33180.A500**     | amiga-os-120.rom          |   262 144 | 85ad74194e87c08904327de1a9443b7a |
-| A500   | KS v1.3 rev 34.005            | **kick34005.A500**     | amiga-os-130.rom          |   262 144 | 82a21c1890cae844b3df741f2762d48d |
-| A500+  | KS v2.04 rev 37.175           | **kick37175.A500**     | amiga-os-204.rom          |   524 288 | dc10d7bdd1b6f450773dfb558477c230 |
-| A600   | KS v2.05 rev 37.350           | **kick37350.A600**     | amiga-os-205-a600.rom     |   524 288 | 465646c9b6729f77eea5314d1f057951 |
-| A600   | KS v3.1 rev 40.063            | **kick40063.A600**     | amiga-os-310-a600.rom     |   524 288 | e40a5dfb3d017ba8779faba30cbd1c8e |
-| A1200  | KS v3.0 rev 39.106            | **kick39106.A1200**    | amiga-os-300-a1200.rom    |   524 288 | b7cc148386aa631136f510cd29e42fc3 |
-| A1200  | KS v3.1 rev 40.068            | **kick40068.A1200**    | amiga-os-310-a1200.rom    |   524 288 | 646773759326fbac3b2311fd8c8793ee |
-| A2000  | KS v1.2 rev 33.180            | **kick33180.A500**     | amiga-os-120.rom          |   262 144 | 85ad74194e87c08904327de1a9443b7a |
-| A2000  | KS v3.1 rev 40.063            | **kick40063.A600**     | amiga-os-310-a600.rom     |   524 288 | dc10d7bdd1b6f450773dfb558477c230 |
-| A4000  | KS v3.0 rev 39.106            | **kick39106.A4000**    | amiga-os-300-a4000.rom    |   524 288 | 9b8bdd5a3fd32c2a5a6f5b1aefc799a5 |
-| A4000  | KS v3.1 rev 40.068            | **kick40068.A4000**    | amiga-os-310-a4000.rom    |   524 288 | 9bdedde6a4f33555b4a270c8ca53297d |
-| CDTV   | CDTV extended ROM v1.0        | **kick34005.CDTV**     | amiga-os-130-cdtv-ext.rom |   262 144 | 89da1838a24460e4b93f4f0c5d92d48d |
+| System | Version                       | Filename               | Amiga Forever                 | Size      | MD5                              |
+|--------|-------------------------------|------------------------|-------------------------------|----------:|----------------------------------|
+| A500   | KS v1.2 rev 33.180            | **kick33180.A500**     | **amiga-os-120.rom**          |   262 144 | 85ad74194e87c08904327de1a9443b7a |
+| A500   | KS v1.3 rev 34.005            | **kick34005.A500**     | **amiga-os-130.rom**          |   262 144 | 82a21c1890cae844b3df741f2762d48d |
+| A500+  | KS v2.04 rev 37.175           | **kick37175.A500**     | **amiga-os-204.rom**          |   524 288 | dc10d7bdd1b6f450773dfb558477c230 |
+| A600   | KS v2.05 rev 37.350           | **kick37350.A600**     | **amiga-os-205-a600.rom**     |   524 288 | 465646c9b6729f77eea5314d1f057951 |
+| A600   | KS v3.1 rev 40.063            | **kick40063.A600**     | **amiga-os-310-a600.rom**     |   524 288 | e40a5dfb3d017ba8779faba30cbd1c8e |
+| A1200  | KS v3.0 rev 39.106            | **kick39106.A1200**    | **amiga-os-300-a1200.rom**    |   524 288 | b7cc148386aa631136f510cd29e42fc3 |
+| A1200  | KS v3.1 rev 40.068            | **kick40068.A1200**    | **amiga-os-310-a1200.rom**    |   524 288 | 646773759326fbac3b2311fd8c8793ee |
+| A2000  | KS v1.2 rev 33.180            | **kick33180.A500**     | **amiga-os-120.rom**          |   262 144 | 85ad74194e87c08904327de1a9443b7a |
+| A2000  | KS v3.1 rev 40.063            | **kick40063.A600**     | **amiga-os-310-a600.rom**     |   524 288 | dc10d7bdd1b6f450773dfb558477c230 |
+| A4000  | KS v3.0 rev 39.106            | **kick39106.A4000**    | **amiga-os-300-a4000.rom**    |   524 288 | 9b8bdd5a3fd32c2a5a6f5b1aefc799a5 |
+| A4000  | KS v3.1 rev 40.068            | **kick40068.A4000**    | **amiga-os-310-a4000.rom**    |   524 288 | 9bdedde6a4f33555b4a270c8ca53297d |
+| CDTV   | CDTV extended ROM v1.0        | **kick34005.CDTV**     | **amiga-os-130-cdtv-ext.rom** |   262 144 | 89da1838a24460e4b93f4f0c5d92d48d |
 
 CD32 requires either separate ROMs (Kickstart + extended ROM) or the combined ROM:
 
-| System | Version                       | Filename               | Amiga Forever             | Size      | MD5                              |
-|--------|-------------------------------|------------------------|---------------------------|----------:|----------------------------------|
-| CD32   | KS + extended v3.1 rev 40.060 | **kick40060.CD32**     |                           | 1 048 576 | f2f241bf094168cfb9e7805dc2856433 |
-|        |                               | OR                     |                           |           |                                  |
-| CD32   | KS v3.1 rev 40.060            | **kick40060.CD32**     | amiga-os-310-cd32.rom     |   524 288 | 5f8924d013dd57a89cf349f4cdedc6b1 |
-| CD32   | Extended ROM rev 40.060       | **kick40060.CD32.ext** | amiga-os-310-cd32-ext.rom |   524 288 | bb72565701b1b6faece07d68ea5da639 |
+| System | Version                       | Filename               | Amiga Forever                 | Size      | MD5                              |
+|--------|-------------------------------|------------------------|-------------------------------|----------:|----------------------------------|
+| CD32   | KS + extended v3.1 rev 40.060 | **kick40060.CD32**     |                               | 1 048 576 | f2f241bf094168cfb9e7805dc2856433 |
+|        |                               | OR                     |                               |           |                                  |
+| CD32   | KS v3.1 rev 40.060            | **kick40060.CD32**     | **amiga-os-310-cd32.rom**     |   524 288 | 5f8924d013dd57a89cf349f4cdedc6b1 |
+| CD32   | Extended ROM rev 40.060       | **kick40060.CD32.ext** | **amiga-os-310-cd32-ext.rom** |   524 288 | bb72565701b1b6faece07d68ea5da639 |
 
 ### Resolution and rendering
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -48,6 +48,7 @@ char opt_model[10] = {0};
 char opt_model_fd[10] = {0};
 char opt_model_hd[10] = {0};
 char opt_model_cd[10] = {0};
+char opt_kickstart[20] = {0};
 bool opt_region_auto = true;
 bool opt_video_resolution_auto = false;
 bool opt_video_vresolution_auto = false;
@@ -296,17 +297,39 @@ void retro_set_environment(retro_environment_t cb)
          "'Automatic' defaults to 'A500' with floppy disks, 'A1200' with hard drives and 'CD32' with compact discs. 'Automatic' can be overridden with file path tags.\nCore restart required.",
          {
             { "auto", "Automatic" },
-            { "A500OG", "A500 (512KB Chip)" },
-            { "A500", "A500 (512KB Chip + 512KB Slow)" },
-            { "A500PLUS", "A500+ (1MB Chip)" },
-            { "A600", "A600 (2MB Chip + 8MB Fast)" },
-            { "A1200OG", "A1200 (2MB Chip)" },
-            { "A1200", "A1200 (2MB Chip + 8MB Fast)" },
-            { "A4030", "A4000/030 (2MB Chip + 8MB Fast)" },
-            { "A4040", "A4000/040 (2MB Chip + 8MB Fast)" },
-            { "CDTV", "CDTV (1MB Chip)" },
-            { "CD32", "CD32 (2MB Chip)" },
-            { "CD32FR", "CD32 (2MB Chip + 8MB Fast)" },
+            { "A500OG", "A500 (v1.2, 0.5M Chip)" },
+            { "A500", "A500 (v1.3, 0.5M Chip + 0.5M Slow)" },
+            { "A500PLUS", "A500+ (v2.04, 1M Chip)" },
+            { "A600", "A600 (v3.1, 2M Chip + 8M Fast)" },
+            { "A1200OG", "A1200 (v3.1, 2M Chip)" },
+            { "A1200", "A1200 (v3.1, 2M Chip + 8M Fast)" },
+            { "A2000OG", "A2000 (v1.2, 0.5M Chip + 0.5M Slow)" },
+            { "A2000", "A2000 (v3.1, 1M Chip)" },
+            { "A4030", "A4000/030 (v3.1, 2M Chip + 8M Fast)" },
+            { "A4040", "A4000/040 (v3.1, 2M Chip + 8M Fast)" },
+            { "CDTV", "CDTV (1M Chip)" },
+            { "CD32", "CD32 (2M Chip)" },
+            { "CD32FR", "CD32 (2M Chip + 8M Fast)" },
+            { NULL, NULL },
+         },
+         "auto"
+      },
+      {
+         "puae_kickstart",
+         "Model > Kickstart ROM",
+         "'Automatic' defaults to the most compatible version for the model. AROS is a built-in replacement with fair compatibility.\nCore restart required.",
+         {
+            { "auto", "Automatic" },
+            { "aros", "AROS" },
+            { "kick33180.A500", "v1.2 rev 33.180 (A500-A2000)" },
+            { "kick34005.A500", "v1.3 rev 34.005 (A500-A1000-A2000-CDTV)" },
+            { "kick37175.A500", "v2.04 rev 37.175 (A500+)" },
+            { "kick37350.A600", "v2.05 rev 37.350 (A600)" },
+            { "kick40063.A600", "v3.1 rev 40.063 (A500-A600-A2000)" },
+            { "kick39106.A1200", "v3.0 rev 39.106 (A1200)" },
+            { "kick40068.A1200", "v3.1 rev 40.068 (A1200)" },
+            { "kick39106.A4000", "v3.0 rev 39.106 (A4000)" },
+            { "kick40068.A4000", "v3.1 rev 40.068 (A4000)" },
             { NULL, NULL },
          },
          "auto"
@@ -327,14 +350,16 @@ void retro_set_environment(retro_environment_t cb)
          "Model > Automatic Floppy",
          "Default model when floppies are launched with 'Automatic' model.\nCore restart required.",
          {
-            { "A500OG", "A500 (512KB Chip)" },
-            { "A500", "A500 (512KB Chip + 512KB Slow)" },
-            { "A500PLUS", "A500+ (1MB Chip)" },
-            { "A600", "A600 (2MB Chip + 8MB Fast)" },
-            { "A1200OG", "A1200 (2MB Chip)" },
-            { "A1200", "A1200 (2MB Chip + 8MB Fast)" },
-            { "A4030", "A4000/030 (2MB Chip + 8MB Fast)" },
-            { "A4040", "A4000/040 (2MB Chip + 8MB Fast)" },
+            { "A500OG", "A500 (v1.2, 0.5M Chip)" },
+            { "A500", "A500 (v1.3, 0.5M Chip + 0.5M Slow)" },
+            { "A500PLUS", "A500+ (v2.04, 1M Chip)" },
+            { "A600", "A600 (v3.1, 2M Chip + 8M Fast)" },
+            { "A1200OG", "A1200 (v3.1, 2M Chip)" },
+            { "A1200", "A1200 (v3.1, 2M Chip + 8M Fast)" },
+            { "A2000OG", "A2000 (v1.2, 0.5M Chip + 0.5M Slow)" },
+            { "A2000", "A2000 (v3.1, 1M Chip)" },
+            { "A4030", "A4000/030 (v3.1, 2M Chip + 8M Fast)" },
+            { "A4040", "A4000/040 (v3.1, 2M Chip + 8M Fast)" },
             { NULL, NULL },
          },
          "A500"
@@ -344,11 +369,12 @@ void retro_set_environment(retro_environment_t cb)
          "Model > Automatic HD",
          "Default model when HD interface is used with 'Automatic' model. Affects WHDLoad installs and other hard drive images.\nCore restart required.",
          {
-            { "A600", "A600 (2MB Chip + 8MB Fast)" },
-            { "A1200OG", "A1200 (2MB Chip)" },
-            { "A1200", "A1200 (2MB Chip + 8MB Fast)" },
-            { "A4030", "A4000/030 (2MB Chip + 8MB Fast)" },
-            { "A4040", "A4000/040 (2MB Chip + 8MB Fast)" },
+            { "A600", "A600 (v3.1, 2M Chip + 8M Fast)" },
+            { "A1200OG", "A1200 (v3.1, 2M Chip)" },
+            { "A1200", "A1200 (v3.1, 2M Chip + 8M Fast)" },
+            { "A2000", "A2000 (v3.1, 1M Chip)" },
+            { "A4030", "A4000/030 (v3.1, 2M Chip + 8M Fast)" },
+            { "A4040", "A4000/040 (v3.1, 2M Chip + 8M Fast)" },
             { NULL, NULL },
          },
          "A1200"
@@ -358,9 +384,9 @@ void retro_set_environment(retro_environment_t cb)
          "Model > Automatic CD",
          "Default model when compact discs are launched with 'Automatic' model.\nCore restart required.",
          {
-            { "CDTV", "CDTV (1MB Chip)" },
-            { "CD32", "CD32 (2MB Chip)" },
-            { "CD32FR", "CD32 (2MB Chip + 8MB Fast)" },
+            { "CDTV", "CDTV (1M Chip)" },
+            { "CD32", "CD32 (2M Chip)" },
+            { "CD32FR", "CD32 (2M Chip + 8M Fast)" },
             { NULL, NULL },
          },
          "CD32"
@@ -1600,28 +1626,35 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      _tcscpy(opt_model, var.value);
+      strlcpy(opt_model, var.value, sizeof(opt_model));
    }
 
    var.key = "puae_model_fd";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      _tcscpy(opt_model_fd, var.value);
+      strlcpy(opt_model_fd, var.value, sizeof(opt_model_fd));
    }
 
    var.key = "puae_model_hd";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      _tcscpy(opt_model_hd, var.value);
+      strlcpy(opt_model_hd, var.value, sizeof(opt_model_hd));
    }
 
    var.key = "puae_model_cd";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      _tcscpy(opt_model_cd, var.value);
+      strlcpy(opt_model_cd, var.value, sizeof(opt_model_cd));
+   }
+
+   var.key = "puae_kickstart";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      strlcpy(opt_kickstart, var.value, sizeof(opt_kickstart));
    }
 
    var.key = "puae_video_standard";
@@ -2114,7 +2147,7 @@ static void update_variables(void)
             else
             {
                changed_prefs.floppyslots[i].dfxclick = -1;
-               _tcscpy(changed_prefs.floppyslots[i].dfxclickexternal, var.value);
+               strcpy(changed_prefs.floppyslots[i].dfxclickexternal, var.value);
             }
          }
       }
@@ -3630,10 +3663,19 @@ static void retro_config_boot_hd(void)
 static void retro_config_kickstart(void)
 {
    char kickstart[RETRO_PATH_MAX];
+
+   /* Forced Kickstart */
+   if (strcmp(opt_kickstart, "auto"))
+      strlcpy(uae_kickstart, opt_kickstart, sizeof(uae_kickstart));
+
    path_join(kickstart, retro_system_directory, uae_kickstart);
 
    /* Main Kickstart */
-   if (!path_is_valid(kickstart))
+   if (!strcmp(opt_kickstart, "aros"))
+   {
+      log_cb(RETRO_LOG_INFO, "Kickstart: '%s'\n", "AROS");
+   }
+   else if (!path_is_valid(kickstart))
    {
       /* Kickstart ROM not found */
       log_cb(RETRO_LOG_ERROR, "Kickstart ROM '%s' not found!\n", kickstart);
@@ -3642,7 +3684,10 @@ static void retro_config_kickstart(void)
       retro_message = true;
    }
    else
+   {
+      log_cb(RETRO_LOG_INFO, "Kickstart: '%s'\n", uae_kickstart);
       retro_config_append("kickstart_rom_file=%s\n", kickstart);
+   }
 
    /* Extended KS + NVRAM */
    if (!string_is_empty(uae_kickstart_ext))
@@ -3655,7 +3700,7 @@ static void retro_config_kickstart(void)
       stat(kickstart, &kickstart_st);
 
       /* Verify extended ROM if external */
-      if (kickstart_st.st_size <= 524288)
+      if (kickstart_st.st_size <= ROM_SIZE_512)
       {
          if (!path_is_valid(kickstart_ext))
          {
@@ -3666,7 +3711,10 @@ static void retro_config_kickstart(void)
             retro_message = true;
          }
          else
+         {
+            log_cb(RETRO_LOG_INFO, "+Extended: '%s'\n", uae_kickstart_ext);
             retro_config_append("kickstart_ext_rom_file=%s\n", kickstart_ext);
+         }
       }
 
       /* NVRAM */
@@ -3677,7 +3725,7 @@ static void retro_config_kickstart(void)
       {
          snprintf(flash_filename, sizeof(flash_filename), "%s.nvr", LIBRETRO_PUAE_PREFIX);
          /* CDTV suffix */
-         if (kickstart_st.st_size == 262144)
+         if (kickstart_st.st_size == ROM_SIZE_256)
             snprintf(flash_filename, sizeof(flash_filename), "%s_cdtv.nvr", LIBRETRO_PUAE_PREFIX);
       }
       /* Per game */
@@ -3689,7 +3737,7 @@ static void retro_config_kickstart(void)
          snprintf(flash_filename, sizeof(flash_filename), "%s.nvr", flash_filebase);
       }
       path_join(flash_filepath, retro_save_directory, flash_filename);
-      log_cb(RETRO_LOG_INFO, "Using NVRAM: '%s'\n", flash_filepath);
+      log_cb(RETRO_LOG_INFO, "NVRAM: '%s'\n", flash_filepath);
       retro_config_append("flash_file=%s\n", flash_filepath);
    }
 }
@@ -3787,10 +3835,10 @@ static void whdload_kscopy(void)
 
    unsigned int ks_size[4] =
    {
-      262144,
-      262144,
-      524288,
-      524288
+      ROM_SIZE_256,
+      ROM_SIZE_256,
+      ROM_SIZE_512,
+      ROM_SIZE_512
    };
 
    struct stat ks_stat;
@@ -3876,6 +3924,8 @@ static char* emu_config_string(char *mode, int config)
          case EMU_CONFIG_A600:      return "A600";
          case EMU_CONFIG_A1200:     return "A1200";
          case EMU_CONFIG_A1200OG:   return "A1200OG";
+         case EMU_CONFIG_A2000:     return "A2000";
+         case EMU_CONFIG_A2000OG:   return "A2000OG";
          case EMU_CONFIG_A4030:     return "A4030";
          case EMU_CONFIG_A4040:     return "A4040";
          case EMU_CONFIG_CDTV:      return "CDTV";
@@ -3887,15 +3937,17 @@ static char* emu_config_string(char *mode, int config)
    {
       switch (config)
       {
-         case EMU_CONFIG_A500:      return A500_ROM;
-         case EMU_CONFIG_A500OG:    return A500_ROM;
-         case EMU_CONFIG_A500PLUS:  return A500KS2_ROM;
-         case EMU_CONFIG_A600:      return A600_ROM;
-         case EMU_CONFIG_A1200:     return A1200_ROM;
-         case EMU_CONFIG_A1200OG:   return A1200_ROM;
-         case EMU_CONFIG_A4030:     return A4000_ROM;
-         case EMU_CONFIG_A4040:     return A4000_ROM;
-         case EMU_CONFIG_CDTV:      return A500_ROM;
+         case EMU_CONFIG_A500:      return A500_KS13_ROM;
+         case EMU_CONFIG_A500OG:    return A500_KS12_ROM;
+         case EMU_CONFIG_A500PLUS:  return A500_KS204_ROM;
+         case EMU_CONFIG_A600:      return A600_KS31_ROM;
+         case EMU_CONFIG_A1200:     return A1200_KS31_ROM;
+         case EMU_CONFIG_A1200OG:   return A1200_KS31_ROM;
+         case EMU_CONFIG_A2000:     return A600_KS31_ROM;
+         case EMU_CONFIG_A2000OG:   return A500_KS12_ROM;
+         case EMU_CONFIG_A4030:     return A4000_KS31_ROM;
+         case EMU_CONFIG_A4040:     return A4000_KS31_ROM;
+         case EMU_CONFIG_CDTV:      return A500_KS13_ROM;
          case EMU_CONFIG_CD32:      return CD32_ROM;
          case EMU_CONFIG_CD32FR:    return CD32_ROM;
       }
@@ -3904,17 +3956,10 @@ static char* emu_config_string(char *mode, int config)
    {
       switch (config)
       {
-         case EMU_CONFIG_A500:      return "";
-         case EMU_CONFIG_A500OG:    return "";
-         case EMU_CONFIG_A500PLUS:  return "";
-         case EMU_CONFIG_A600:      return "";
-         case EMU_CONFIG_A1200:     return "";
-         case EMU_CONFIG_A1200OG:   return "";
-         case EMU_CONFIG_A4030:     return "";
-         case EMU_CONFIG_A4040:     return "";
          case EMU_CONFIG_CDTV:      return CDTV_ROM;
          case EMU_CONFIG_CD32:      return CD32_ROM_EXT;
          case EMU_CONFIG_CD32FR:    return CD32_ROM_EXT;
+         default:                   return "";
       }
    }
    return "";
@@ -3922,17 +3967,19 @@ static char* emu_config_string(char *mode, int config)
 
 static int emu_config_int(char *model)
 {
-   if      (!strcmp(model, "A500"))     return EMU_CONFIG_A500;
-   else if (!strcmp(model, "A500OG"))   return EMU_CONFIG_A500OG;
-   else if (!strcmp(model, "A500PLUS")) return EMU_CONFIG_A500PLUS;
-   else if (!strcmp(model, "A600"))     return EMU_CONFIG_A600;
-   else if (!strcmp(model, "A1200"))    return EMU_CONFIG_A1200;
-   else if (!strcmp(model, "A1200OG"))  return EMU_CONFIG_A1200OG;
-   else if (!strcmp(model, "A4030"))    return EMU_CONFIG_A4030;
-   else if (!strcmp(model, "A4040"))    return EMU_CONFIG_A4040;
-   else if (!strcmp(model, "CDTV"))     return EMU_CONFIG_CDTV;
-   else if (!strcmp(model, "CD32"))     return EMU_CONFIG_CD32;
-   else if (!strcmp(model, "CD32FR"))   return EMU_CONFIG_CD32FR;
+   if      (!strcmp(model, "A500"))      return EMU_CONFIG_A500;
+   else if (!strcmp(model, "A500OG"))    return EMU_CONFIG_A500OG;
+   else if (!strcmp(model, "A500PLUS"))  return EMU_CONFIG_A500PLUS;
+   else if (!strcmp(model, "A600"))      return EMU_CONFIG_A600;
+   else if (!strcmp(model, "A1200"))     return EMU_CONFIG_A1200;
+   else if (!strcmp(model, "A1200OG"))   return EMU_CONFIG_A1200OG;
+   else if (!strcmp(model, "A2000"))     return EMU_CONFIG_A2000;
+   else if (!strcmp(model, "A2000OG"))   return EMU_CONFIG_A2000OG;
+   else if (!strcmp(model, "A4030"))     return EMU_CONFIG_A4030;
+   else if (!strcmp(model, "A4040"))     return EMU_CONFIG_A4040;
+   else if (!strcmp(model, "CDTV"))      return EMU_CONFIG_CDTV;
+   else if (!strcmp(model, "CD32"))      return EMU_CONFIG_CD32;
+   else if (!strcmp(model, "CD32FR"))    return EMU_CONFIG_CD32FR;
    else return -1;
 }
 
@@ -4012,6 +4059,22 @@ static char* emu_config(int config)
          "chipset_compatible=A1200\n"
          "chipmem_size=4\n"
          "bogomem_size=0\n"
+         "fastmem_size=0\n";
+
+      case EMU_CONFIG_A2000: return
+         "cpu_model=68000\n"
+         "chipset=ecs\n"
+         "chipset_compatible=A2000\n"
+         "chipmem_size=2\n"
+         "bogomem_size=0\n"
+         "fastmem_size=0\n";
+
+      case EMU_CONFIG_A2000OG: return
+         "cpu_model=68000\n"
+         "chipset=ocs\n"
+         "chipset_compatible=A2000\n"
+         "chipmem_size=1\n"
+         "bogomem_size=2\n"
          "fastmem_size=0\n";
 
       case EMU_CONFIG_A4030: return
@@ -4223,49 +4286,41 @@ static bool retro_create_config(void)
             if (strstr(full_path, "(A4030)") || strstr(full_path, "(030)"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A4030)' or '(030)' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A4000/030: '%s'\n", A4000_ROM);
                retro_config_preset("A4030");
             }
             else if (strstr(full_path, "(A4040)") || strstr(full_path, "(040)"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A4040)' or '(040)' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A4000/040: '%s'\n", A4000_ROM);
                retro_config_preset("A4040");
             }
             else if (strstr(full_path, "(A1200OG)") || strstr(full_path, "(A1200NF)"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A1200OG)' or '(A1200NF)' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A1200 NoFast: '%s'\n", A1200_ROM);
                retro_config_preset("A1200OG");
             }
             else if (strstr(full_path, "(A1200)") || strstr(full_path, "AGA") || strstr(full_path, "CD32") || strstr(full_path, "AmigaCD"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A1200)', 'AGA', 'CD32', or 'AmigaCD' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A1200: '%s'\n", A1200_ROM);
                retro_config_preset("A1200");
             }
             else if (strstr(full_path, "(A600)") || strstr(full_path, "ECS"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A600)' or 'ECS' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A600: '%s'\n", A600_ROM);
                retro_config_preset("A600");
             }
             else if (strstr(full_path, "(A500+)") || strstr(full_path, "(A500PLUS)"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A500+)' or '(A500PLUS)' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A500+: '%s'\n", A500KS2_ROM);
                retro_config_preset("A500PLUS");
             }
             else if (strstr(full_path, "(A500OG)") || strstr(full_path, "(512K)"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A500OG)' or '(512K)' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A500 512K: '%s'\n", A500_ROM);
                retro_config_preset("A500OG");
             }
             else if (strstr(full_path, "(A500)") || strstr(full_path, "OCS"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(A500)' or 'OCS' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting A500: '%s'\n", A500_ROM);
                retro_config_preset("A500");
             }
             else
@@ -4280,12 +4335,8 @@ static bool retro_create_config(void)
 
                /* No model specified */
                log_cb(RETRO_LOG_INFO, "No model specified in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting default model: '%s'\n", uae_kickstart);
             }
          }
-         else
-            /* Core option model */
-            log_cb(RETRO_LOG_INFO, "Booting model: '%s'\n", uae_kickstart);
 
          /* Write model preset */
          retro_config_append(uae_model);
@@ -4734,19 +4785,16 @@ static bool retro_create_config(void)
             if (strstr(full_path, "(CD32FR)") || strstr(full_path, "FastRAM"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(CD32FR)' or 'FastRAM' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting CD32 FastRAM: '%s'\n", CD32_ROM);
                retro_config_preset("CD32FR");
             }
             else if (strstr(full_path, "(CD32)") || strstr(full_path, "(CD32NF)"))
             {
                log_cb(RETRO_LOG_INFO, "Found '(CD32)' or '(CD32NF)' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting CD32: '%s'\n", CD32_ROM);
                retro_config_preset("CD32");
             }
             else if (strstr(full_path, "CDTV"))
             {
                log_cb(RETRO_LOG_INFO, "Found 'CDTV' in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting CDTV: '%s'\n", CDTV_ROM);
                retro_config_preset("CDTV");
             }
             else
@@ -4759,12 +4807,8 @@ static bool retro_create_config(void)
 
                /* No model specified */
                log_cb(RETRO_LOG_INFO, "No model specified in: '%s'\n", full_path);
-               log_cb(RETRO_LOG_INFO, "Booting default model: '%s'\n", uae_kickstart);
             }
          }
-         else
-            /* Core option model */
-            log_cb(RETRO_LOG_INFO, "Booting model: '%s'\n", uae_kickstart);
 
          /* Write model preset */
          retro_config_append(uae_model);
@@ -4907,9 +4951,6 @@ static bool retro_create_config(void)
    /* Empty content */
    else
    {
-      /* No model specified */
-      log_cb(RETRO_LOG_INFO, "Booting model: '%s'\n", uae_kickstart);
-
       /* Write model preset */
       retro_config_append(uae_model);
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4895,6 +4895,24 @@ static bool retro_create_config(void)
 
             while (fgets(filebuf, sizeof(filebuf), configfile_custom))
             {
+               /* Skip Kickstart row if Kickstart is not automatic */
+               if (strcmp(opt_kickstart, "auto"))
+                  if ((strstr(filebuf, "kickstart_rom_file=") && filebuf[0] == 'k'))
+                     continue;
+
+               /* Skip Kickstart & model rows if model is not automatic */
+               if (strcmp(opt_model, "auto"))
+               {
+                  if ((strstr(filebuf, "kickstart_rom_file=") && filebuf[0] == 'k')
+                   || (strstr(filebuf, "cpu_model=") && filebuf[0] == 'c')
+                   || (strstr(filebuf, "chipset=") && filebuf[0] == 'c')
+                   || (strstr(filebuf, "chipset_compatible=") && filebuf[0] == 'c')
+                   || (strstr(filebuf, "chipmem_size=") && filebuf[0] == 'c')
+                   || (strstr(filebuf, "bogomem_size=") && filebuf[0] == 'b')
+                   || (strstr(filebuf, "fastmem_size=") && filebuf[0] == 'f'))
+                     continue;
+               }
+
                retro_config_append(filebuf);
 
                /* Parse diskimage & floppy rows */

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -107,7 +107,8 @@ enum EMU_FUNCTIONS
 };
 
 /* Configs */
-enum EMU_CONFIG {
+enum EMU_CONFIG
+{
    EMU_CONFIG_A500 = 0,
    EMU_CONFIG_A500OG,
    EMU_CONFIG_A500PLUS,
@@ -125,18 +126,98 @@ enum EMU_CONFIG {
 };
 
 /* Kickstarts */
-#define A500_KS12_ROM           "kick33180.A500"
-#define A500_KS13_ROM           "kick34005.A500"
-#define A500_KS204_ROM          "kick37175.A500"
-#define A600_KS205_ROM          "kick37350.A600"
-#define A600_KS31_ROM           "kick40063.A600"
-#define A1200_KS30_ROM          "kick39106.A1200"
-#define A1200_KS31_ROM          "kick40068.A1200"
-#define A4000_KS30_ROM          "kick39106.A4000"
-#define A4000_KS31_ROM          "kick40068.A4000"
-#define CDTV_ROM                "kick34005.CDTV"
-#define CD32_ROM                "kick40060.CD32"
-#define CD32_ROM_EXT            "kick40060.CD32.ext"
+enum retro_kickstart_ids
+{
+   A500_KS12_ROM = 0,
+   A500_KS13_ROM,
+   A500_KS204_ROM,
+   A600_KS205_ROM,
+   A600_KS31_ROM,
+   A1200_KS30_ROM,
+   A1200_KS31_ROM,
+   A4000_KS30_ROM,
+   A4000_KS31_ROM,
+   CDTV_ROM,
+   CD32_ROM,
+   CD32_ROM_EXT
+};
+
+typedef struct
+{
+   unsigned id;
+   char normal[20];
+   char aforever[30];
+   char tosec_mod[100];
+   char tosec[100];
+} retro_kickstarts;
+
+static retro_kickstarts uae_kickstarts[15] =
+{
+   {A500_KS12_ROM,
+         "kick33180.A500",
+         "amiga-os-120.rom",
+         "Kickstart v1.2 rev 33.180 (1986)(Commodore)(A500-A2000)[!].rom",
+         "Kickstart v1.2 rev 33.180 (1986)(Commodore)(A500-A1000-A2000).rom"},
+   {A500_KS13_ROM,
+         "kick34005.A500",
+         "amiga-os-130.rom",
+         "Kickstart v1.3 rev 34.5 (1987)(Commodore)(A500-A1000-A2000-CDTV)[!].rom",
+         "Kickstart v1.3 rev 34.5 (1987)(Commodore)(A500-A1000-A2000-CDTV).rom"},
+   {A500_KS204_ROM,
+         "kick37175.A500",
+         "amiga-os-204.rom",
+         "Kickstart v2.04 rev 37.175 (1991)(Commodore)(A500+)[!].rom",
+         "Kickstart v2.04 rev 37.175 (1991)(Commodore)(A500+).rom"},
+
+   {A600_KS205_ROM,
+         "kick37350.A600",
+         "amiga-os-205-a600.rom",
+         "Kickstart v2.05 rev 37.350 (1992)(Commodore)(A600HD)[!].rom",
+         ""},
+   {A600_KS31_ROM,
+         "kick40063.A600",
+         "amiga-os-310-a600.rom",
+         "Kickstart v3.1 rev 40.63 (1993)(Commodore)(A500-A600-A2000)[!].rom",
+         "Kickstart v3.1 rev 40.63 (1993)(Commodore)(A500-A600-A2000).rom"},
+
+   {A1200_KS30_ROM,
+         "kick39106.A1200",
+         "amiga-os-300-a1200.rom",
+         "Kickstart v3.0 rev 39.106 (1992)(Commodore)(A1200)[!].rom",
+         ""},
+   {A1200_KS31_ROM,
+         "kick40068.A1200",
+         "amiga-os-310-a1200.rom",
+         "Kickstart v3.1 rev 40.68 (1993)(Commodore)(A1200)[!].rom",
+         "Kickstart v3.1 rev 40.68 (1993)(Commodore)(A1200).rom"},
+
+   {A4000_KS30_ROM,
+         "kick39106.A4000",
+         "amiga-os-300-a4000.rom",
+         "Kickstart v3.0 rev 39.106 (1992)(Commodore)(A4000)[!].rom",
+         ""},
+   {A4000_KS31_ROM,
+         "kick40068.A4000",
+         "amiga-os-310-a4000.rom",
+         "",
+         "Kickstart v3.1 rev 40.68 (1993)(Commodore)(A4000).rom"},
+
+   {CDTV_ROM,
+         "kick34005.CDTV",
+         "amiga-os-130-cdtv-ext.rom",
+         "CDTV Extended-ROM v1.0 (1991)(Commodore)(CDTV)[!].rom",
+         "CDTV Extended-ROM v1.0 (1992)(Commodore)(CDTV).rom"},
+   {CD32_ROM,
+         "kick40060.CD32",
+         "amiga-os-310-cd32.rom",
+         "",
+         "Kickstart v3.1 rev 40.60 (1993)(Commodore)(CD32).rom"},
+   {CD32_ROM_EXT,
+         "kick40060.CD32.ext",
+         "amiga-os-310-cd32-ext.rom",
+         "",
+         "CD32 Extended-ROM rev 40.60 (1993)(Commodore)(CD32).rom"},
+};
 
 /* Support files */
 #define LIBRETRO_PUAE_PREFIX    "puae_libretro"

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -114,6 +114,8 @@ enum EMU_CONFIG {
    EMU_CONFIG_A600,
    EMU_CONFIG_A1200,
    EMU_CONFIG_A1200OG,
+   EMU_CONFIG_A2000,
+   EMU_CONFIG_A2000OG,
    EMU_CONFIG_A4030,
    EMU_CONFIG_A4040,
    EMU_CONFIG_CDTV,
@@ -123,11 +125,15 @@ enum EMU_CONFIG {
 };
 
 /* Kickstarts */
-#define A500_ROM                "kick34005.A500"
-#define A500KS2_ROM             "kick37175.A500"
-#define A600_ROM                "kick40063.A600"
-#define A1200_ROM               "kick40068.A1200"
-#define A4000_ROM               "kick40068.A4000"
+#define A500_KS12_ROM           "kick33180.A500"
+#define A500_KS13_ROM           "kick34005.A500"
+#define A500_KS204_ROM          "kick37175.A500"
+#define A600_KS205_ROM          "kick37350.A600"
+#define A600_KS31_ROM           "kick40063.A600"
+#define A1200_KS30_ROM          "kick39106.A1200"
+#define A1200_KS31_ROM          "kick40068.A1200"
+#define A4000_KS30_ROM          "kick39106.A4000"
+#define A4000_KS31_ROM          "kick40068.A4000"
 #define CDTV_ROM                "kick34005.CDTV"
 #define CD32_ROM                "kick40060.CD32"
 #define CD32_ROM_EXT            "kick40060.CD32.ext"

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -330,7 +330,7 @@ void print_statusbar(void)
    mem_size += (float)(currprefs.bogomem_size / 0x40000) / 4;
    mem_size += (float)(currprefs.fastmem_size / 0x100000);
    if (TEXT_X_MEMORY > 0)
-      snprintf(MEMORY, sizeof(MEMORY), (mem_size < 1) ? "%0.1fM" : "%1.0fM", mem_size);
+      snprintf(MEMORY, sizeof(MEMORY), (mem_size < 1) ? "%0.1fM" : "%2.0fM", mem_size);
    switch (currprefs.cs_compatible)
    {
       case CP_A500:

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -330,7 +330,7 @@ void print_statusbar(void)
    mem_size += (float)(currprefs.bogomem_size / 0x40000) / 4;
    mem_size += (float)(currprefs.fastmem_size / 0x100000);
    if (TEXT_X_MEMORY > 0)
-      snprintf(MEMORY, sizeof(MEMORY), "%2.0fM", floor(mem_size));
+      snprintf(MEMORY, sizeof(MEMORY), (mem_size < 1) ? "%0.1fM" : "%1.0fM", mem_size);
    switch (currprefs.cs_compatible)
    {
       case CP_A500:
@@ -344,6 +344,9 @@ void print_statusbar(void)
          break;
       case CP_A1200:
          snprintf(MODEL, sizeof(MODEL), "%s", "A1200");
+         break;
+      case CP_A2000:
+         snprintf(MODEL, sizeof(MODEL), "%s", "A2000");
          break;
       case CP_A4000:
          snprintf(MODEL, sizeof(MODEL), "%s", "A4000");


### PR DESCRIPTION
- Core option for forcing Kickstart, so that AROS can be used even with proper Kickstarts in place
- A500 512KB preset uses v1.2 KS
- Added 2 A2000 presets: "v1.2, 512KB+512KB" & "v3.1, 1MB"
- Model & Kickstart options get the final say even with custom uae confs
- Kickstarts no longer have to be renamed to the WHDLoad required format
  - Amiga Forever + TOSEC are recognized, and WHDLoad will still get the proper format in both modes