### PR TITLE
Fix heap buffer overflows in retro_create_config()

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5190,9 +5190,11 @@ static bool retro_create_config(void)
 #ifdef WIN32
                      tmp_str = string_replace_substring(whdload_path, "\\", "\\\\");
 #else
-                     tmp_str = strdup(whdload_path);
+                     size_t str_len = strlen(whdload_path);
+                     tmp_str = calloc((str_len + 2), sizeof(char));
+                     strlcpy(tmp_str, whdload_path, str_len + 1);
                      /* Force ending slash with empty path_join to make sure the path is not treated as a file */
-                     if (tmp_str[strlen(tmp_str)-1] != '/')
+                     if (tmp_str[str_len - 1] != '/')
                         path_join(tmp_str, whdload_path, "");
 #endif
                      retro_config_append("filesystem2=rw,WHDLoad:WHDLoad:\"%s\",0\n", tmp_str);
@@ -5218,9 +5220,11 @@ static bool retro_create_config(void)
 #ifdef WIN32
                      tmp_str = string_replace_substring(whdsaves_path, "\\", "\\\\");
 #else
-                     tmp_str = strdup(whdsaves_path);
+                     size_t str_len = strlen(whdsaves_path);
+                     tmp_str = calloc((str_len + 2), sizeof(char));
+                     strlcpy(tmp_str, whdsaves_path, str_len + 1);
                      /* Force ending slash with empty path_join to make sure the path is not treated as a file */
-                     if (tmp_str[strlen(tmp_str)-1] != '/')
+                     if (tmp_str[str_len - 1] != '/')
                         path_join(tmp_str, whdsaves_path, "");
 #endif
                      retro_config_append("filesystem2=rw,WHDSaves:WHDSaves:\"%s\",0\n", tmp_str);
@@ -5324,9 +5328,11 @@ static bool retro_create_config(void)
 #ifdef WIN32
                   tmp_str = string_replace_substring(retro_system_directory, "\\", "\\\\");
 #else
-                  tmp_str = strdup(retro_system_directory);
+                  size_t str_len = strlen(retro_system_directory);
+                  tmp_str = calloc((str_len + 2), sizeof(char));
+                  strlcpy(tmp_str, retro_system_directory, str_len + 1);
                   /* Force ending slash with empty path_join to make sure the path is not treated as a file */
-                  if (tmp_str[strlen(tmp_str)-1] != '/')
+                  if (tmp_str[str_len - 1] != '/')
                      path_join(tmp_str, retro_system_directory, "");
 #endif
                   retro_config_append("filesystem2=ro,RASystem:RASystem:\"%s\",-128\n", tmp_str);


### PR DESCRIPTION
This PR just fixes 3 string-manipulation-related heap buffer overflows in `retro_create_config()`, affecting non-Windows platforms.