### PR TITLE
Third "Allow Hz" mode + misc

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -6591,9 +6591,12 @@ static bool retro_update_av_info(void)
       /* If still no change */
       if (video_config_old == video_config && retro_refresh == hz)
       {
+         /* Allow other calculations but don't alter timing */
+         change_timing   = false;
+         change_geometry = true;
+
          if (av_log)
             printf("  * Already at wanted AV\n");
-         change_timing = false; /* Allow other calculations but don't alter timing */
       }
    }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -838,12 +838,13 @@ static void retro_set_core_options()
          "puae_video_allow_hz_change",
          "Video > Allow Hz Change",
          "Allow Hz Change",
-         "Let Amiga decide the exact refresh rate when interlace mode or PAL/NTSC changes.",
+         "Let Amiga decide the exact refresh rate when interlace mode or PAL/NTSC changes. 'Locked' changes only when video standard changes.\nCore restart required.",
          NULL,
          "video",
          {
             { "disabled", NULL },
             { "enabled", NULL },
+            { "locked", "Locked PAL/NTSC" },
             { NULL, NULL },
          },
          "enabled"
@@ -2538,8 +2539,22 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled")) video_config_allow_hz_change = 0;
-      else                                video_config_allow_hz_change = 1;
+      if      (!strcmp(var.value, "disabled")) video_config_allow_hz_change = 0;
+      else if (!strcmp(var.value, "enabled"))  video_config_allow_hz_change = 1;
+      else if (!strcmp(var.value, "locked"))   video_config_allow_hz_change = 2;
+
+      switch (video_config_allow_hz_change)
+      {
+         case 0:
+         case 1:
+            strcat(uae_config, "displaydata_pal=-1,pal\n");
+            strcat(uae_config, "displaydata_ntsc=-1,ntsc\n");
+            break;
+         case 2:
+            strcat(uae_config, "displaydata_pal=50.000000,locked,pal\n");
+            strcat(uae_config, "displaydata_ntsc=59.940000,locked,ntsc\n");
+            break;
+      }
    }
 
    var.key = "puae_video_resolution";

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -669,7 +669,7 @@ static void retro_set_core_options()
          "puae_autoloadfastforward",
          "Media > Automatic Load Fast-Forward",
          "Automatic Load Fast-Forward",
-         "Toggle frontend fast-forward during media access if there is no sound output. Mutes 'Floppy Sound Emulation'.",
+         "Toggle frontend fast-forward during media access if there is no audio output. Mutes 'Floppy Sound Emulation'.",
          NULL,
          "media",
          {
@@ -1147,7 +1147,7 @@ static void retro_set_core_options()
          "puae_vkbd_theme",
          "Video > Virtual KBD Theme",
          "Virtual KBD Theme",
-         "By default, the keyboard comes up with RetroPad Select.",
+         "The keyboard comes up with RetroPad Select by default.",
          NULL,
          "video",
          {
@@ -1260,7 +1260,7 @@ static void retro_set_core_options()
          "puae_sound_interpol",
          "Audio > Interpolation",
          "Interpolation",
-         "",
+         "Paula sound chip interpolation type.",
          NULL,
          "audio",
          {
@@ -1277,7 +1277,7 @@ static void retro_set_core_options()
          "puae_sound_filter",
          "Audio > Filter",
          "Filter",
-         "",
+         "'Emulated' allows states between ON/OFF.",
          NULL,
          "audio",
          {
@@ -1292,7 +1292,7 @@ static void retro_set_core_options()
          "puae_sound_filter_type",
          "Audio > Filter Type",
          "Filter Type",
-         "",
+         "'Automatic' picks the filter type for the hardware.",
          NULL,
          "audio",
          {
@@ -1307,7 +1307,7 @@ static void retro_set_core_options()
          "puae_sound_volume_cd",
          "Audio > CD Audio Volume",
          "CD Audio Volume",
-         "",
+         "CD volume in percent.",
          NULL,
          "audio",
          {
@@ -1340,7 +1340,7 @@ static void retro_set_core_options()
          "puae_floppy_sound",
          "Audio > Floppy Sound Emulation",
          "Floppy Sound Emulation",
-         "",
+         "Floppy volume in percent.",
          NULL,
          "audio",
          {
@@ -1402,7 +1402,7 @@ static void retro_set_core_options()
          "puae_analogmouse",
          "Input > Analog Stick Mouse",
          "Analog Stick Mouse",
-         "",
+         "Default mouse control stick when remappings are empty.",
          NULL,
          "input",
          {
@@ -1418,7 +1418,7 @@ static void retro_set_core_options()
          "puae_analogmouse_deadzone",
          "Input > Analog Stick Mouse Deadzone",
          "Analog Stick Mouse Deadzone",
-         "",
+         "Required distance from stick center to register input.",
          NULL,
          "input",
          {
@@ -1441,7 +1441,7 @@ static void retro_set_core_options()
          "puae_analogmouse_speed",
          "Input > Analog Stick Mouse Speed",
          "Analog Stick Mouse Speed",
-         "",
+         "Mouse movement speed multiplier for analog stick.",
          NULL,
          "input",
          {
@@ -1483,7 +1483,7 @@ static void retro_set_core_options()
          "puae_dpadmouse_speed",
          "Input > D-Pad Mouse Speed",
          "D-Pad Mouse Speed",
-         "",
+         "Mouse movement speed multiplier for directional pad.",
          NULL,
          "input",
          {
@@ -1513,7 +1513,7 @@ static void retro_set_core_options()
          "puae_mouse_speed",
          "Input > Mouse Speed",
          "Mouse Speed",
-         "Affects mouse speed globally.",
+         "Global mouse speed.",
          NULL,
          "input",
          {
@@ -1774,7 +1774,7 @@ static void retro_set_core_options()
          "puae_mapper_select",
          "RetroPad > Select",
          "Select",
-         "",
+         "VKBD comes up with RetroPad Select by default.",
          NULL,
          "retropad",
          {{ NULL, NULL }},

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -350,6 +350,16 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
          image_label[0] = '\0';
          fill_short_pathname_representation(image_label, full_path_replace, sizeof(image_label));
 
+         /* Dupecheck */
+         for (unsigned i = 0; i < dc->count - 1; i++)
+         {
+            if (!strcmp(dc->files[i], full_path_replace))
+            {
+               dc_remove_file(dc, index);
+               return true;
+            }
+         }
+
          dc->files[index]  = strdup(full_path_replace);
          dc->labels[index] = strdup(image_label);
          dc->types[index]  = dc_get_image_type(full_path_replace);

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -370,7 +370,7 @@ void print_statusbar(void)
    /* Double line positions */
    if (video_config & PUAE_VIDEO_DOUBLELINE)
    {
-      TEXT_X_RESOLUTION = TEXT_X + (FONT_SLOT*15) + (FONT_WIDTH*5) - ZOOMED_WIDTH_OFFSET;
+      TEXT_X_RESOLUTION = TEXT_X + (FONT_SLOT*9)  + (FONT_WIDTH*25) - (ZOOMED_WIDTH_OFFSET/2);
       TEXT_X_MODEL      = TEXT_X + (FONT_SLOT*17) + (FONT_WIDTH*15) - ZOOMED_WIDTH_OFFSET;
       TEXT_X_MEMORY     = TEXT_X + (FONT_SLOT*16) + (FONT_WIDTH*25) - ZOOMED_WIDTH_OFFSET;
    }

--- a/libretro/libretro-graph.c
+++ b/libretro/libretro-graph.c
@@ -78,10 +78,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
           * correct colour */
          break;
       case GRAPH_ALPHA_25:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND_ALPHA25(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -89,10 +89,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
          }
          break;
       case GRAPH_ALPHA_50:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND_ALPHA50(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -100,10 +100,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
          }
          break;
       case GRAPH_ALPHA_75:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND_ALPHA75(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -112,10 +112,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
          break;
       case GRAPH_ALPHA_100:
       default:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                *buf_ptr = color;
                buf_ptr++;
@@ -138,10 +138,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
           * correct colour */
          break;
       case GRAPH_ALPHA_25:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND32_ALPHA25(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -149,10 +149,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
          }
          break;
       case GRAPH_ALPHA_50:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND32_ALPHA50(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -160,10 +160,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
          }
          break;
       case GRAPH_ALPHA_75:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND32_ALPHA75(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -172,10 +172,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
          break;
       case GRAPH_ALPHA_100:
       default:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                *buf_ptr = color;
                buf_ptr++;
@@ -198,19 +198,19 @@ void draw_box_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t col
 {
    int i, j, idx;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
       buffer[idx] = color;
-      idx = i+(y+dy)*retrow;
+      idx = i + ((y + dy) * retrow);
       buffer[idx] = color;
    }
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
       buffer[idx] = color;
-      idx = (x+dx)+j*retrow;
+      idx = (x + dx) + (j * retrow);
       buffer[idx] = color;
    }
 }
@@ -219,19 +219,19 @@ void draw_box_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t col
 {
    int i, j, idx;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
       buffer[idx] = color;
-      idx = i+(y+dy)*retrow;
+      idx = i + ((y + dy) * retrow);
       buffer[idx] = color;
    }
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
       buffer[idx] = color;
-      idx = (x+dx)+j*retrow;
+      idx = (x + dx) + (j * retrow);
       buffer[idx] = color;
    }
 }
@@ -252,9 +252,11 @@ void draw_hline_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t c
 
    (void)j;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }
@@ -265,9 +267,11 @@ void draw_hline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
 
    (void)j;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }
@@ -286,9 +290,11 @@ void draw_vline_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t c
 
    (void)i;
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }
@@ -299,9 +305,11 @@ void draw_vline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
 
    (void)i;
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -485,6 +485,7 @@ static void process_controller(int retro_port, int i)
 
          if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_UP))
          && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_UP]
+         && !mapper_flag[retro_port][RETRO_DEVICE_ID_JOYPAD_UP]
          && !jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT])
          {
             retro_joystick(retro_port_uae, 1, 0);
@@ -493,6 +494,7 @@ static void process_controller(int retro_port, int i)
          else
          if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_DOWN))
          && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_DOWN]
+         && !mapper_flag[retro_port][RETRO_DEVICE_ID_JOYPAD_DOWN]
          && !jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_SELECT])
          {
             retro_joystick(retro_port_uae, 1, 0);
@@ -523,14 +525,16 @@ static void process_controller(int retro_port, int i)
          }
 
          if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_LEFT))
-         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_LEFT])
+         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_LEFT]
+         && !mapper_flag[retro_port][RETRO_DEVICE_ID_JOYPAD_LEFT])
          {
             retro_joystick(retro_port_uae, 0, 0);
             jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_LEFT] = 0;
          }
          else
          if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT))
-         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_RIGHT])
+         && jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_RIGHT]
+         && !mapper_flag[retro_port][RETRO_DEVICE_ID_JOYPAD_RIGHT])
          {
             retro_joystick(retro_port_uae, 0, 0);
             jflag[retro_port_uae][RETRO_DEVICE_ID_JOYPAD_RIGHT] = 0;
@@ -1039,6 +1043,26 @@ void update_input(unsigned disable_keys)
                   else
                      jflag[j][RETRO_DEVICE_ID_JOYPAD_A] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_A] = 1;
                }
+               else if (mapper_keys[i] == JOYSTICK_UP)
+               {
+                  retro_joystick(j, 1, -1);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_UP] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_UP] = 1;
+               }
+               else if (mapper_keys[i] == JOYSTICK_DOWN)
+               {
+                  retro_joystick(j, 1, 1);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_DOWN] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_DOWN] = 1;
+               }
+               else if (mapper_keys[i] == JOYSTICK_LEFT)
+               {
+                  retro_joystick(j, 0, -1);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_LEFT] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_LEFT] = 1;
+               }
+               else if (mapper_keys[i] == JOYSTICK_RIGHT)
+               {
+                  retro_joystick(j, 0, 1);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_RIGHT] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_RIGHT] = 1;
+               }
                else if (mapper_keys[i] == TOGGLE_VKBD)
                   mapper_keys_pressed_time = now; /* Decide on release */
                else if (mapper_keys[i] == TOGGLE_STATUSBAR)
@@ -1104,6 +1128,26 @@ void update_input(unsigned disable_keys)
                      jflag[j][RETRO_DEVICE_ID_JOYPAD_B] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_B] = 0;
                   else
                      jflag[j][RETRO_DEVICE_ID_JOYPAD_A] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_A] = 0;
+               }
+               else if (mapper_keys[i] == JOYSTICK_UP)
+               {
+                  retro_joystick(j, 1, 0);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_UP] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_UP] = 0;
+               }
+               else if (mapper_keys[i] == JOYSTICK_DOWN)
+               {
+                  retro_joystick(j, 1, 0);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_DOWN] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_DOWN] = 0;
+               }
+               else if (mapper_keys[i] == JOYSTICK_LEFT)
+               {
+                  retro_joystick(j, 0, 0);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_LEFT] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_LEFT] = 0;
+               }
+               else if (mapper_keys[i] == JOYSTICK_RIGHT)
+               {
+                  retro_joystick(j, 0, 0);
+                  jflag[j][RETRO_DEVICE_ID_JOYPAD_RIGHT] = mapper_flag[j][RETRO_DEVICE_ID_JOYPAD_RIGHT] = 0;
                }
                else if (mapper_keys[i] == TOGGLE_VKBD)
                {

--- a/libretro/libretro-mapper.h
+++ b/libretro/libretro-mapper.h
@@ -30,16 +30,20 @@
 
 #define RETRO_MAPPER_LAST               32
 
-#define TOGGLE_VKBD                     -11
-#define TOGGLE_STATUSBAR                -12
-#define SWITCH_JOYMOUSE                 -13
+#define TOGGLE_VKBD                     -31
+#define TOGGLE_STATUSBAR                -32
+#define SWITCH_JOYMOUSE                 -33
 #define MOUSE_LEFT_BUTTON               -2
 #define MOUSE_RIGHT_BUTTON              -3
 #define MOUSE_MIDDLE_BUTTON             -4
 #define MOUSE_SLOWER                    -5
 #define MOUSE_FASTER                    -6
-#define JOYSTICK_FIRE                   -7
-#define JOYSTICK_2ND_FIRE               -8
+#define JOYSTICK_UP                     -11
+#define JOYSTICK_DOWN                   -12
+#define JOYSTICK_LEFT                   -13
+#define JOYSTICK_RIGHT                  -14
+#define JOYSTICK_FIRE                   -15
+#define JOYSTICK_2ND_FIRE               -16
 
 extern int16_t joypad_bits[RETRO_DEVICES];
 extern int mapper_keys[RETRO_MAPPER_LAST];
@@ -85,8 +89,12 @@ static retro_keymap retro_keys[RETROK_LAST] =
    {MOUSE_LEFT_BUTTON,  "MOUSE_LEFT_BUTTON",   "Mouse Left Button"},
    {MOUSE_RIGHT_BUTTON, "MOUSE_RIGHT_BUTTON",  "Mouse Right Button"},
    {MOUSE_MIDDLE_BUTTON,"MOUSE_MIDDLE_BUTTON", "Mouse Middle Button"},
-   {JOYSTICK_FIRE,      "JOYSTICK_FIRE",       "Joystick Fire Button"},
-   {JOYSTICK_2ND_FIRE,  "JOYSTICK_2ND_FIRE",   "Joystick 2nd Fire Button"},
+   {JOYSTICK_UP,        "JOYSTICK_UP",         "Joystick Up"},
+   {JOYSTICK_DOWN,      "JOYSTICK_DOWN",       "Joystick Down"},
+   {JOYSTICK_LEFT,      "JOYSTICK_LEFT",       "Joystick Left"},
+   {JOYSTICK_RIGHT,     "JOYSTICK_RIGHT",      "Joystick Right"},
+   {JOYSTICK_FIRE,      "JOYSTICK_FIRE",       "Joystick Fire"},
+   {JOYSTICK_2ND_FIRE,  "JOYSTICK_2ND_FIRE",   "Joystick Fire 2"},
    {RETROK_BACKSPACE,   "RETROK_BACKSPACE",    "Keyboard Backspace"},
    {RETROK_TAB,         "RETROK_TAB",          "Keyboard Tab"},
 /* {RETROK_CLEAR,       "RETROK_CLEAR",        "Keyboard Clear"}, */
@@ -100,10 +108,10 @@ static retro_keymap retro_keys[RETROK_LAST] =
 /* {RETROK_DOLLAR,      "RETROK_DOLLAR",       "Keyboard $"}, */
 /* {RETROK_AMPERSAND,   "RETROK_AMPERSAND",    "Keyboard &"}, */
    {RETROK_QUOTE,       "RETROK_QUOTE",        "Keyboard \'"},
-   {RETROK_LEFTPAREN,   "RETROK_LEFTPAREN",    "Keyboard ("},
-   {RETROK_RIGHTPAREN,  "RETROK_RIGHTPAREN",   "Keyboard )"},
-   {RETROK_ASTERISK,    "RETROK_ASTERISK",     "Keyboard *"},
-   {RETROK_PLUS,        "RETROK_PLUS",         "Keyboard +"},
+/* {RETROK_LEFTPAREN,   "RETROK_LEFTPAREN",    "Keyboard ("}, */
+/* {RETROK_RIGHTPAREN,  "RETROK_RIGHTPAREN",   "Keyboard )"}, */
+/* {RETROK_ASTERISK,    "RETROK_ASTERISK",     "Keyboard *"}, */
+/* {RETROK_PLUS,        "RETROK_PLUS",         "Keyboard +"}, */
    {RETROK_COMMA,       "RETROK_COMMA",        "Keyboard ,"},
    {RETROK_MINUS,       "RETROK_MINUS",        "Keyboard -"},
    {RETROK_PERIOD,      "RETROK_PERIOD",       "Keyboard ."},
@@ -118,7 +126,7 @@ static retro_keymap retro_keys[RETROK_LAST] =
    {RETROK_7,           "RETROK_7",            "Keyboard 7"},
    {RETROK_8,           "RETROK_8",            "Keyboard 8"},
    {RETROK_9,           "RETROK_9",            "Keyboard 9"},
-   {RETROK_COLON,       "RETROK_COLON",        "Keyboard :"},
+/* {RETROK_COLON,       "RETROK_COLON",        "Keyboard :"}, */
    {RETROK_SEMICOLON,   "RETROK_SEMICOLON",    "Keyboard ;"},
    {RETROK_LESS,        "RETROK_LESS",         "Keyboard <"},
    {RETROK_EQUALS,      "RETROK_EQUALS",       "Keyboard ="},
@@ -128,8 +136,8 @@ static retro_keymap retro_keys[RETROK_LAST] =
    {RETROK_LEFTBRACKET, "RETROK_LEFTBRACKET",  "Keyboard ["},
    {RETROK_BACKSLASH,   "RETROK_BACKSLASH",    "Keyboard \\"},
    {RETROK_RIGHTBRACKET,"RETROK_RIGHTBRACKET", "Keyboard ]"},
-   {RETROK_CARET,       "RETROK_CARET",        "Keyboard ^"},
-   {RETROK_UNDERSCORE,  "RETROK_UNDERSCORE",   "Keyboard _"},
+/* {RETROK_CARET,       "RETROK_CARET",        "Keyboard ^"}, */
+/* {RETROK_UNDERSCORE,  "RETROK_UNDERSCORE",   "Keyboard _"}, */
    {RETROK_BACKQUOTE,   "RETROK_BACKQUOTE",    "Keyboard `"},
    {RETROK_a,           "RETROK_a",            "Keyboard A"},
    {RETROK_b,           "RETROK_b",            "Keyboard B"},


### PR DESCRIPTION
Video related:
- "Locked PAL/NTSC" option which forces rate to 50/59.94 regardless of interlace state so that audio buffer stays in line, making interlace toggling seamless. It maybe should be the new default, but no reason to rush yet.
- Geometry adjustments

Other:
- Added joystick directions to core option RetroPad mapper
- Removed possibility to add the same disk to DC list
- Adjusted core option sublabels
