### PR TITLE
Don't upload audio to frontend multiple times per frame

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -213,6 +213,13 @@ static char uae_config[2048] = {0};
 static char uae_custom_config[2048] = {0};
 char uae_full_config[4096] = {0};
 
+/* Audio output buffer */
+static struct {
+   int16_t *data;
+   int32_t size;
+   int32_t capacity;
+} output_audio_buffer = {NULL, 0, 0};
+
 /* FPS counter + mapper tick */
 long retro_ticks(void)
 {
@@ -432,6 +439,39 @@ static void retro_autoloadfastforwarding(void)
                ff_counter_on, ff_counter_off, ff_counter_audio, audio_playing);
 #endif
    }
+}
+
+static void ensure_output_audio_buffer_capacity(int32_t capacity)
+{
+   if (capacity <= output_audio_buffer.capacity) {
+      return;
+   }
+
+   output_audio_buffer.data = realloc(output_audio_buffer.data, capacity * sizeof(*output_audio_buffer.data));
+   output_audio_buffer.capacity = capacity;
+   log_cb(RETRO_LOG_DEBUG, "Output audio buffer capacity set to %d\n", capacity);
+}
+
+static void init_output_audio_buffer(int32_t capacity)
+{
+   output_audio_buffer.data = NULL;
+   output_audio_buffer.size = 0;
+   output_audio_buffer.capacity = 0;
+   ensure_output_audio_buffer_capacity(capacity);
+}
+
+static void free_output_audio_buffer()
+{
+   free(output_audio_buffer.data);
+   output_audio_buffer.data = NULL;
+   output_audio_buffer.size = 0;
+   output_audio_buffer.capacity = 0;
+}
+
+static void upload_output_audio_buffer()
+{
+   audio_batch_cb(output_audio_buffer.data, output_audio_buffer.size / 2);
+   output_audio_buffer.size = 0;
 }
 
 static void retro_set_core_options()
@@ -4284,6 +4324,8 @@ void retro_init(void)
    log_cb(RETRO_LOG_DEBUG, "Resolution selected: %dx%d\n", defaultw, defaulth);
    retrow = defaultw;
    retroh = defaulth;
+
+   init_output_audio_buffer(2048);
 }
 
 void retro_deinit(void)
@@ -4298,6 +4340,8 @@ void retro_deinit(void)
 
    /* Free buffers used by libretro-graph */
    libretro_graph_free();
+
+   free_output_audio_buffer();
 
    /* 'Reset' troublesome static variables */
    pix_bytes_initialized = false;
@@ -4466,14 +4510,18 @@ void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb)
 
 #define RETRO_AUDIO_BATCH
 
-void retro_audio_render(const int16_t *data, size_t frames)
+void retro_audio_queue(const int16_t *data, int32_t samples)
 {
-   if ((frames < 1) || !libretro_runloop_active)
+   if ((samples < 1) || !libretro_runloop_active)
       return;
+
 #ifdef RETRO_AUDIO_BATCH
-   audio_batch_cb(data, frames >> 1);
+   if (output_audio_buffer.capacity - output_audio_buffer.size < samples)
+      ensure_output_audio_buffer_capacity((output_audio_buffer.capacity + samples) * 1.5);
+   memcpy(output_audio_buffer.data + output_audio_buffer.size, data, samples * sizeof(*output_audio_buffer.data));
+   output_audio_buffer.size += samples;
 #else
-   for (int x = 0; x < frames; x += 2) audio_cb(data[x], data[x+1]);
+   for (int x = 0; x < samples; x += 2) audio_cb(data[x], data[x + 1]);
 #endif
 }
 
@@ -7013,6 +7061,7 @@ void retro_run(void)
       /* Re-run emulation first pass */
       restart_pending = m68k_go(1, 0);
       video_cb(retro_bmp, zoomed_width, zoomed_height, retrow << (pix_bytes / 2));
+      upload_output_audio_buffer();
       return;
    }
 
@@ -7058,6 +7107,7 @@ void retro_run(void)
    }
 
    video_cb(retro_bmp, zoomed_width, zoomed_height, retrow << (pix_bytes / 2));
+   upload_output_audio_buffer();
 }
 
 bool retro_load_game(const struct retro_game_info *info)

--- a/retrodep/sounddep/sound.h
+++ b/retrodep/sounddep/sound.h
@@ -9,7 +9,7 @@
 #ifndef OSDEP_SOUND_H
 #define OSDEP_SOUND_H
 #define SOUNDSTUFF 1
-extern void retro_audio_render(const int16_t *data, size_t frames);
+extern void retro_audio_queue(const int16_t *data, int32_t samples);
 
 #define sndbuffer paula_sndbuffer
 #define sndbufpt paula_sndbufpt
@@ -30,7 +30,7 @@ static __inline__ void check_sound_buffers (void)
 #ifdef DRIVESOUND
         driveclick_mix ((uae_s16*)sndbuffer, sndbufsize >> 1, currprefs.dfxclickchannelmask);
 #endif	
-        retro_audio_render((short*)sndbuffer, sndbufsize >> 1);
+        retro_audio_queue((short*)sndbuffer, sndbufsize >> 1);
         sndbufpt = sndbuffer;
     }
 }


### PR DESCRIPTION
It increases the chance of audio dropouts. Also, it's better to submit
audio to the fronend after video, as the audio upload can block for a
long time and unnecessarily delay video frame presentation.

Fix this by accumulating all audio samples into a single output buffer
which is submitted at the end of each frame.

Reviewers
======
@sonninnos @jdgleaver 