### PR TITLE
Flush all remaining audio samples at the end of each frame

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -7061,6 +7061,7 @@ void retro_run(void)
       /* Re-run emulation first pass */
       restart_pending = m68k_go(1, 0);
       video_cb(retro_bmp, zoomed_width, zoomed_height, retrow << (pix_bytes / 2));
+      flush_sound_buffers(2);
       upload_output_audio_buffer();
       return;
    }
@@ -7107,6 +7108,7 @@ void retro_run(void)
    }
 
    video_cb(retro_bmp, zoomed_width, zoomed_height, retrow << (pix_bytes / 2));
+   flush_sound_buffers(2);
    upload_output_audio_buffer();
 }
 

--- a/retrodep/sounddep/sound.h
+++ b/retrodep/sounddep/sound.h
@@ -22,17 +22,22 @@ extern void driveclick_mix (uae_s16*, int, int);
 
 extern int soundcheck;
 
-static __inline__ void check_sound_buffers (void)
+static __inline__ void flush_sound_buffers(int32_t min_samples_required)
 {
     unsigned int size = (char *)sndbufpt - (char *)sndbuffer;
 
-    if (size >= sndbufsize) {
+    if (size >= min_samples_required) {
 #ifdef DRIVESOUND
-        driveclick_mix ((uae_s16*)sndbuffer, sndbufsize >> 1, currprefs.dfxclickchannelmask);
-#endif	
-        retro_audio_queue((short*)sndbuffer, sndbufsize >> 1);
+        driveclick_mix((uae_s16 *)sndbuffer, size >> 1, currprefs.dfxclickchannelmask);
+#endif
+        retro_audio_queue((short *)sndbuffer, size >> 1);
         sndbufpt = sndbuffer;
     }
+}
+
+static __inline__ void check_sound_buffers (void)
+{
+    flush_sound_buffers(sndbufsize);
 }
 
 STATIC_INLINE void set_sound_buffers (void)


### PR DESCRIPTION
Currently, the core submits a short and then a long audio buffer each
other frame. This alternating pattern of too few and too many audio
samples messes up frame pacing and produces audio dropouts when using a
low audio latency setting in the frontend.

Fix this by flushing all remaining audio samples at the end of each
frame rather than postponing them until the next frame.

Reviewers
======
@sonninnos 