### PR TITLE
Auto region force + video buffer reset corrections

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -7031,11 +7031,7 @@ void retro_run(void)
          request_reset_drawing = true;
       request_init_custom_timer--;
       if (request_init_custom_timer == 0)
-      {
-         /* Clear video buffer */
-         memset(retro_bmp, 0, sizeof(retro_bmp));
          init_custom();
-      }
    }
 
    /* Refresh CPU prefs */

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2561,8 +2561,13 @@ static void update_variables(void)
          if (strstr(var.value, "PAL")) changed_prefs.ntscmode = 0;
          else                          changed_prefs.ntscmode = 1;
       }
-      else if (forced_video > -1)
-         changed_prefs.ntscmode = !forced_video;
+      else if (opt_region_auto)
+      {
+         if (forced_video > -1)
+            changed_prefs.ntscmode = !forced_video;
+         else
+            changed_prefs.ntscmode = !(strstr(var.value, "PAL"));
+      }
    }
 
    var.key = "puae_video_aspect";
@@ -6638,7 +6643,6 @@ static bool retro_update_av_info(void)
          video_config &= ~PUAE_VIDEO_PAL;
          video_config_geometry = video_config;
          fake_ntsc = true;
-         forced_video = RETRO_REGION_NTSC;
       }
 
       /* If still no change */

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -796,6 +796,9 @@ int check_prefs_changed_gfx (void)
    gfxvidinfo.height_allocated         = currprefs.gfx_size_win.height;
    gfxvidinfo.rowbytes                 = gfxvidinfo.width_allocated * gfxvidinfo.pixbytes;
 
+   /* Reset video buffer */
+   memset(retro_bmp, 0, sizeof(retro_bmp));
+
 #if 0
    printf("check_prefs_changed_gfx: %d:%d, res:%d vres:%d\n", changed_prefs.gfx_size_win.width, changed_prefs.gfx_size_win.height, changed_prefs.gfx_resolution, changed_prefs.gfx_vresolution);
 #endif


### PR DESCRIPTION
- Fixed fake NTSC modes going haywire after changing any core option
- Relocated video buffer reset to remove statusbar ghosting on standard & interlace toggle
