### PR TITLE
Build fix: glibc 2.35+

### DIFF
--- a/sources/src/fpp_native.c
+++ b/sources/src/fpp_native.c
@@ -903,7 +903,7 @@ static void fp_log10(fpdata *a, fpdata *b)
 static void fp_log2(fpdata *a, fpdata *b)
 {
 	fp_normal_prec();
-	a->fp = log2l(b->fp);
+	a->fp = logbl(b->fp);
 	fp_reset_normal_prec();
 	fp_round(a);
 }

--- a/sources/src/include/sysdeps.h
+++ b/sources/src/include/sysdeps.h
@@ -746,11 +746,4 @@ typedef uint8_t uint8;
 #define _daylight 0
 #endif
 
-#ifndef log2
-#define log2 logb
-#endif
-#ifndef log2l
-#define log2l logbl
-#endif
-
 #endif /* UAE_SYSDEPS_H */


### PR DESCRIPTION
In file included from sources/src/audio.c:46:
/usr/include/bits/mathcalls.h:133:1: error: expected ';' before 'extern'
 __MATHCALL_VEC (log2,, (_Mdouble_ __x));

The following defines: log2 and log2l were interacting with the
commit: 7e1722fec84c65bf95f249f9ad8d15ab12d8c853 from glibc