### PR TITLE
Rename Zoom to Crop

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2868,9 +2868,9 @@ void retro_set_environment(retro_environment_t cb)
    environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &support_no_game);
 
    struct retro_led_interface led_interface;
-   environ_cb(RETRO_ENVIRONMENT_GET_LED_INTERFACE, &led_interface);
-   if (led_interface.set_led_state && !led_state_cb)
-      led_state_cb = led_interface.set_led_state;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_LED_INTERFACE, &led_interface))
+      if (led_interface.set_led_state && !led_state_cb)
+         led_state_cb = led_interface.set_led_state;
 
 #ifdef USE_LIBRETRO_VFS
    struct retro_vfs_interface_info vfs_iface_info;

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -606,7 +606,7 @@ static void retro_set_core_options()
          "puae_model_options_display",
          "System > Show Automatic Model Options",
          "Show Automatic Model Options",
-         "Show/hide default model options (Floppy/HD/CD) for 'Automatic' model.\nPage refresh by menu toggle required!",
+         "Show/hide default model options (Floppy/HD/CD) for 'Automatic' model.",
          NULL,
          "system",
          {
@@ -1052,7 +1052,7 @@ static void retro_set_core_options()
          "puae_video_options_display",
          "Show Video Options",
          NULL,
-         "Page refresh by menu toggle required!",
+         "",
          NULL,
          NULL,
          {
@@ -1525,7 +1525,7 @@ static void retro_set_core_options()
          "puae_audio_options_display",
          "Show Audio Options",
          NULL,
-         "Page refresh by menu toggle required!",
+         "",
          NULL,
          NULL,
          {
@@ -1900,7 +1900,7 @@ static void retro_set_core_options()
          "puae_mapping_options_display",
          "Show Mapping Options",
          NULL,
-         "Page refresh by menu toggle required!",
+         "",
          NULL,
          NULL,
          {

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -102,7 +102,7 @@ enum EMU_FUNCTIONS
    EMU_FREEZE,
    EMU_SAVE_DISK,
    EMU_ASPECT_RATIO,
-   EMU_ZOOM_MODE,
+   EMU_CROP,
    EMU_TURBO_FIRE,
    EMU_FUNCTION_COUNT
 };
@@ -259,9 +259,27 @@ extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
 extern unsigned int pix_bytes;
 extern int retrow;
 extern int retroh;
-extern int zoomed_width;
-extern int zoomed_height;
+extern int retrow_crop;
+extern int retroh_crop;
 extern unsigned int video_config;
 extern unsigned int video_config_geometry;
+
+#define CROP_NONE            0
+#define CROP_MINIMUM         1
+#define CROP_SMALLER         2
+#define CROP_SMALL           3
+#define CROP_MEDIUM          4
+#define CROP_LARGE           5
+#define CROP_LARGER          6
+#define CROP_MAXIMUM         7
+#define CROP_AUTO            8
+
+#define CROP_MODE_BOTH       0
+#define CROP_MODE_VERTICAL   1
+#define CROP_MODE_HORIZONTAL 2
+#define CROP_MODE_16_9       3
+#define CROP_MODE_16_10      4
+#define CROP_MODE_4_3        5
+#define CROP_MODE_5_4        6
 
 #endif /* LIBRETRO_CORE_H */

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -344,17 +344,17 @@ void print_statusbar(void)
    BOX_Y = TEXT_Y - BOX_PADDING;
 
    /* Statusbar size */
-   BOX_WIDTH = zoomed_width;
-   int ZOOMED_WIDTH_OFFSET = retrow - zoomed_width;
+   BOX_WIDTH = retrow_crop;
+   int CROP_WIDTH_OFFSET = retrow - retrow_crop;
 
    /* Video resolution */
-   int TEXT_X_RESOLUTION = TEXT_X + (FONT_SLOT*4) + (FONT_WIDTH*16) - (ZOOMED_WIDTH_OFFSET/2);
+   int TEXT_X_RESOLUTION = TEXT_X + (FONT_SLOT*4) + (FONT_WIDTH*16) - (CROP_WIDTH_OFFSET/2);
    unsigned char RESOLUTION[10] = {0};
-   snprintf(RESOLUTION, sizeof(RESOLUTION), "%4dx%3d", zoomed_width, zoomed_height);
+   snprintf(RESOLUTION, sizeof(RESOLUTION), "%4dx%3d", retrow_crop, retroh_crop);
 
    /* Model & memory */
-   int TEXT_X_MODEL  = TEXT_X + (FONT_SLOT*6) + (FONT_WIDTH*35) - ZOOMED_WIDTH_OFFSET;
-   int TEXT_X_MEMORY = TEXT_X + (FONT_SLOT*6) + (FONT_WIDTH*3) - ZOOMED_WIDTH_OFFSET;
+   int TEXT_X_MODEL  = TEXT_X + (FONT_SLOT*6) + (FONT_WIDTH*35) - CROP_WIDTH_OFFSET;
+   int TEXT_X_MEMORY = TEXT_X + (FONT_SLOT*6) + (FONT_WIDTH*3) - CROP_WIDTH_OFFSET;
    /* Sacrifice memory slot if there is not enough width */
    if (!(video_config & PUAE_VIDEO_DOUBLELINE))
    {
@@ -403,9 +403,9 @@ void print_statusbar(void)
    /* Double line positions */
    if (video_config & PUAE_VIDEO_DOUBLELINE)
    {
-      TEXT_X_RESOLUTION = TEXT_X + (FONT_SLOT*9)  + (FONT_WIDTH*25) - (ZOOMED_WIDTH_OFFSET/2);
-      TEXT_X_MODEL      = TEXT_X + (FONT_SLOT*17) + (FONT_WIDTH*20) - ZOOMED_WIDTH_OFFSET;
-      TEXT_X_MEMORY     = TEXT_X + (FONT_SLOT*16) + (FONT_WIDTH*15) - ZOOMED_WIDTH_OFFSET;
+      TEXT_X_RESOLUTION = TEXT_X + (FONT_SLOT*9)  + (FONT_WIDTH*25) - (CROP_WIDTH_OFFSET/2);
+      TEXT_X_MODEL      = TEXT_X + (FONT_SLOT*17) + (FONT_WIDTH*20) - CROP_WIDTH_OFFSET;
+      TEXT_X_MEMORY     = TEXT_X + (FONT_SLOT*16) + (FONT_WIDTH*15) - CROP_WIDTH_OFFSET;
    }
 
    /* Joy port indicators */
@@ -687,7 +687,7 @@ void unlockscr(struct vidbuffer *vb, int y_start, int y_end)
    retro_min_diwstart               = min_diwstart;
    retro_max_diwstop                = max_diwstop;
 
-   /* Align the resulting Automatic Zoom screen height to even number */
+   /* Align the resulting Automatic Crop screen height to even number */
    if (!retro_av_info_is_lace && (retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line + 1) % 2)
       retro_thisframe_last_drawn_line++;
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -60,8 +60,8 @@ extern float retro_refresh;
 /* Core options */
 extern unsigned int video_config_aspect;
 extern bool opt_aspect_ratio_locked;
-extern unsigned int zoom_mode_id;
-extern unsigned int opt_zoom_mode_id;
+extern unsigned int crop_id;
+extern unsigned int opt_crop_id;
 extern int opt_statusbar;
 extern int opt_statusbar_position;
 extern unsigned int opt_analogmouse;
@@ -179,18 +179,18 @@ void emu_function(int function)
                "Pixel Aspect",
                (video_config_aspect == PUAE_VIDEO_PAL) ? "PAL" : "NTSC");
          break;
-      case EMU_ZOOM_MODE:
-         if (zoom_mode_id == 0 && opt_zoom_mode_id == 0)
+      case EMU_CROP:
+         if (crop_id == 0 && opt_crop_id == 0)
             break;
-         if (zoom_mode_id > 0)
-            zoom_mode_id = 0;
-         else if (zoom_mode_id == 0)
-            zoom_mode_id = opt_zoom_mode_id;
+         if (crop_id > 0)
+            crop_id = 0;
+         else if (crop_id == 0)
+            crop_id = opt_crop_id;
          request_update_av_info = true;
          /* Statusbar notification */
          statusbar_message_show(5, "%s %s",
-               "Zoom Mode",
-               (zoom_mode_id) ? "ON" : "OFF");
+               "Crop",
+               (crop_id) ? "ON" : "OFF");
          break;
       case EMU_TURBO_FIRE:
          retro_turbo_fire = !retro_turbo_fire;
@@ -887,8 +887,8 @@ void update_input(unsigned disable_keys)
             case RETRO_MAPPER_ASPECT_RATIO:
                emu_function(EMU_ASPECT_RATIO);
                break;
-            case RETRO_MAPPER_ZOOM_MODE:
-               emu_function(EMU_ZOOM_MODE);
+            case RETRO_MAPPER_CROP:
+               emu_function(EMU_CROP);
                break;
             case RETRO_MAPPER_TURBO_FIRE:
                emu_function(EMU_TURBO_FIRE);
@@ -1082,8 +1082,8 @@ void update_input(unsigned disable_keys)
                   emu_function(EMU_RESET);
                else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_ASPECT_RATIO])
                   emu_function(EMU_ASPECT_RATIO);
-               else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_ZOOM_MODE])
-                  emu_function(EMU_ZOOM_MODE);
+               else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_CROP])
+                  emu_function(EMU_CROP);
                else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_TURBO_FIRE])
                   emu_function(EMU_TURBO_FIRE);
                else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_SAVE_DISK])
@@ -1168,7 +1168,7 @@ void update_input(unsigned disable_keys)
                   ;/* no-op */
                else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_ASPECT_RATIO])
                   ;/* no-op */
-               else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_ZOOM_MODE])
+               else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_CROP])
                   ;/* no-op */
                else if (mapper_keys[i] == mapper_keys[RETRO_MAPPER_TURBO_FIRE])
                   ;/* no-op */

--- a/libretro/libretro-mapper.h
+++ b/libretro/libretro-mapper.h
@@ -30,7 +30,7 @@
 #define RETRO_MAPPER_JOYMOUSE           26
 #define RETRO_MAPPER_RESET              27
 #define RETRO_MAPPER_ASPECT_RATIO       28
-#define RETRO_MAPPER_ZOOM_MODE          29
+#define RETRO_MAPPER_CROP               29
 #define RETRO_MAPPER_TURBO_FIRE         30
 #define RETRO_MAPPER_SAVE_DISK          31
 

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -71,7 +71,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { {10,29},{10,29},VKBD_MOUSE_RIGHT },
    { "J/M" ,"J/M" ,VKBD_JOYMOUSE },
    { "TRBF","TRBF",VKBD_TURBOFIRE },
-   { "ASPR","ZOOM",VKBD_ASPECT_ZOOM },
+   { "ASPR","CROP",VKBD_ASPECT_CROP },
    { "STBR","SVDS",VKBD_STATUSBAR_SAVEDISK },
    { {17}  ,{17}  ,VKBD_RESET },
 
@@ -177,7 +177,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { {10,29},{10,29},VKBD_MOUSE_RIGHT },
    { "J/M" ,"J/M" ,VKBD_JOYMOUSE },
    { "TRBF","TRBF",VKBD_TURBOFIRE },
-   { "ASPR","ZOOM",VKBD_ASPECT_ZOOM },
+   { "ASPR","CROP",VKBD_ASPECT_CROP },
    { "STBR","SVDS",VKBD_STATUSBAR_SAVEDISK },
    { {17}  ,{17}  ,VKBD_RESET },
 
@@ -288,7 +288,7 @@ static const int vkbd_alt_keys_len = sizeof(vkbd_alt_keys) / sizeof(vkbd_alt_key
 /* Extra color keys */
 static const int vkbd_extra_keys[] =
 {
-   VKBD_NUMPAD, VKBD_JOYMOUSE, VKBD_TURBOFIRE, VKBD_ASPECT_ZOOM, VKBD_STATUSBAR_SAVEDISK
+   VKBD_NUMPAD, VKBD_JOYMOUSE, VKBD_TURBOFIRE, VKBD_ASPECT_CROP, VKBD_STATUSBAR_SAVEDISK
 };
 static const int vkbd_extra_keys_len = sizeof(vkbd_extra_keys) / sizeof(vkbd_extra_keys[0]);
 
@@ -427,8 +427,8 @@ void print_vkbd(void)
    int XSIDE     = (320 * FONT_WIDTH) / VKBDX;
    int YSIDE     = 21 * FONT_HEIGHT;
 
-   XPADDING      = zoomed_width - (XSIDE * VKBDX);
-   YPADDING      = zoomed_height - (YSIDE * VKBDY);
+   XPADDING      = retrow_crop - (XSIDE * VKBDX);
+   YPADDING      = retroh_crop - (YSIDE * VKBDY);
 
    int XBASEKEY  = (XPADDING > 0) ? (XPADDING / 2) : 0;
    int YBASEKEY  = (YPADDING > 0) ? (YPADDING / 2) : 0;
@@ -447,7 +447,7 @@ void print_vkbd(void)
 
    /* Coordinates */
    vkbd_x_min = XOFFSET + XBASEKEY + XKEYSPACING;
-   vkbd_x_max = XOFFSET - XBASEKEY - XKEYSPACING + zoomed_width;
+   vkbd_x_max = XOFFSET - XBASEKEY - XKEYSPACING + retrow_crop;
    vkbd_y_min = YOFFSET + YBASEKEY + YKEYSPACING;
    vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * VKBDY);
 
@@ -683,20 +683,20 @@ void print_vkbd(void)
    {
       unsigned corner_y_min = 0;
       unsigned corner_y_max = 0;
-      unsigned lores_offset = (zoomed_width < 361 && zoomed_width % 2 == 0);
+      unsigned lores_offset = (retrow_crop < 361 && retrow_crop % 2 == 0);
 
       /* Top */
       corner_y_min = 0;
       corner_y_max = vkbd_y_min - YKEYSPACING;
       draw_fbox(0, corner_y_min,
-                zoomed_width, corner_y_max,
+                retrow_crop, corner_y_max,
                 0, BRD_ALPHA);
 
       /* Bottom */
       corner_y_min = vkbd_y_max + YKEYSPACING;
-      corner_y_max = zoomed_height - vkbd_y_max - YKEYSPACING;
+      corner_y_max = retroh_crop - vkbd_y_max - YKEYSPACING;
       draw_fbox(0, corner_y_min,
-                zoomed_width, corner_y_max,
+                retrow_crop, corner_y_max,
                 0, BRD_ALPHA);
 
       /* Left + Right */
@@ -706,7 +706,7 @@ void print_vkbd(void)
                 vkbd_x_min - XKEYSPACING, corner_y_max,
                 0, BRD_ALPHA);
       draw_fbox(vkbd_x_max + (XKEYSPACING * 2) + ((lores_offset) ? -XKEYSPACING : 0), corner_y_min,
-                zoomed_width - vkbd_x_max - (XKEYSPACING * (lores_offset ? 1 : 2)), corner_y_max,
+                retrow_crop - vkbd_x_max - (XKEYSPACING * (lores_offset ? 1 : 2)), corner_y_max,
                 0, BRD_ALPHA);
    }
 
@@ -810,10 +810,10 @@ static void convert_vkbd_to_mapper(int *vkbd_mapping_key, char **var_value)
             *vkbd_mapping_key = TOGGLE_STATUSBAR;
          }
          break;
-      case VKBD_ASPECT_ZOOM:
+      case VKBD_ASPECT_CROP:
          if (retro_capslock)
          {
-            *var_value = get_variable("puae_mapper_zoom_mode_toggle");
+            *var_value = get_variable("puae_mapper_crop_toggle");
             *vkbd_mapping_key = 0;
          }
          else
@@ -1073,8 +1073,8 @@ void input_vkbd(void)
 
    if (p_x != 0 && p_y != 0 && (p_x != last_pointer_x || p_y != last_pointer_y))
    {
-      int px = (int)((p_x + 0x7fff) * zoomed_width / 0xffff);
-      int py = (int)((p_y + 0x7fff) * zoomed_height / 0xffff);
+      int px = (int)((p_x + 0x7fff) * retrow_crop / 0xffff);
+      int py = (int)((p_y + 0x7fff) * retroh_crop / 0xffff);
 
       last_pointer_x = p_x;
       last_pointer_y = p_y;
@@ -1219,9 +1219,9 @@ void input_vkbd(void)
             case VKBD_TURBOFIRE:
                emu_function(EMU_TURBO_FIRE);
                break;
-            case VKBD_ASPECT_ZOOM:
+            case VKBD_ASPECT_CROP:
                if (retro_capslock)
-                  emu_function(EMU_ZOOM_MODE);
+                  emu_function(EMU_CROP);
                else
                   emu_function(EMU_ASPECT_RATIO);
                break;

--- a/libretro/libretro-vkbd.h
+++ b/libretro/libretro-vkbd.h
@@ -32,7 +32,7 @@ extern void statusbar_message_show(signed char icon, const char *format, ...);
 #define VKBD_STATUSBAR_SAVEDISK -4
 #define VKBD_JOYMOUSE           -5
 #define VKBD_TURBOFIRE          -6
-#define VKBD_ASPECT_ZOOM        -7
+#define VKBD_ASPECT_CROP        -7
 #define VKBD_CAPSLOCK           -10
 
 #define VKBD_MOUSE_UP           -11

--- a/sources/src/akiko.c
+++ b/sources/src/akiko.c
@@ -1571,7 +1571,8 @@ static void akiko_thread (void *null)
 						write_log (_T("CD32: CD missing but statefile was stored with CD inserted: faking media present\n"));
 					lastmediastate = 3;
 				} else {
-					write_log (_T("CD32: media changed = %d\n"), media);
+					if (log_cd32 > 0)
+						write_log (_T("CD32: media changed = %d\n"), media);
 					lastmediastate = cdrom_disk = media;
 					mediachanged = 1;
 					cdaudiostop_do ();

--- a/sources/src/statusline.c
+++ b/sources/src/statusline.c
@@ -261,7 +261,7 @@ void draw_status_line_single (int monid, uae_u8 *buf, int bpp, int y, int totalw
     if (!retro_statusbar)
         return;
 
-    totalwidth = zoomed_width;
+    totalwidth = retrow_crop;
     num_multip = 1;
     if (currprefs.gfx_resolution == RES_HIRES && currprefs.gfx_vresolution == VRES_NONDOUBLE)
         num_multip = 2;


### PR DESCRIPTION
Zoom renamed everywhere to what the option actually does. Also included a method to automatically update the current options for the newly named keys.

