### PR TITLE
Floppy Write Redirect option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,9 @@ else
    LDFLAGS += -s
 endif
 
+# Zlib
+CFLAGS += -DHAVE_ZLIB
+
 # 7zip
 ifneq ($(NO_7ZIP), 1)
     CFLAGS += -DHAVE_7ZIP -D_7ZIP_ST

--- a/Makefile.common
+++ b/Makefile.common
@@ -199,6 +199,7 @@ SOURCES_C += \
 	$(DEPS_DIR)/libz/gzclose.c \
 	$(DEPS_DIR)/libz/gzlib.c \
 	$(DEPS_DIR)/libz/gzread.c \
+	$(DEPS_DIR)/libz/gzwrite.c \
 	$(DEPS_DIR)/libz/inffast.c \
 	$(DEPS_DIR)/libz/inflate.c \
 	$(DEPS_DIR)/libz/inftrees.c \

--- a/deps/libz/gzguts.h
+++ b/deps/libz/gzguts.h
@@ -6,8 +6,6 @@
 #ifndef _GZGUTS_H
 #define _GZGUTS_H
 
-#define NO_GZCOMPRESS
-
 #ifdef _LARGEFILE64_SOURCE
 #  ifndef _LARGEFILE_SOURCE
 #    define _LARGEFILE_SOURCE 1

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5627,12 +5627,13 @@ static void retro_config_harddrives(void)
       {
          path_parent_dir(tmp_str, strlen(tmp_str));
          snprintf(tmp_str_path, sizeof(tmp_str_path), "%s%s", tmp_str, tmp_str_name);
+
          if (!path_is_directory(tmp_str_path))
-         {
-            path_parent_dir(tmp_str_path, strlen(tmp_str));
-            if (tmp_str_path[strlen(tmp_str_path)-1] == DIR_SEP_CHR)
-               tmp_str_path[strlen(tmp_str_path)-1] = '\0';
-         }
+            path_parent_dir(tmp_str_path, strlen(tmp_str_path));
+
+         if (tmp_str_path[strlen(tmp_str_path)-1] == DIR_SEP_CHR)
+            tmp_str_path[strlen(tmp_str_path)-1] = '\0';
+
          tmp_str = strdup(tmp_str_path);
       }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -7372,10 +7372,6 @@ static void update_audiovideo(void)
          if (retro_thisframe_first_drawn_line_start == -1 && retro_thisframe_last_drawn_line_start == -1)
             request_update_av_info = true;
 
-         /* Update immediately with big enough difference in last line (last line for CD32 no disc) */
-         if (retro_thisframe_last_drawn_line_delta > 47 && retro_thisframe_last_drawn_line_delta < 189)
-            request_update_av_info = true;
-
          if ((retro_thisframe_first_drawn_line_start == retro_thisframe_first_drawn_line
            && retro_thisframe_last_drawn_line_start  == retro_thisframe_last_drawn_line)
           || (retro_thisframe_first_drawn_line_old == retro_thisframe_first_drawn_line
@@ -7402,6 +7398,10 @@ static void update_audiovideo(void)
             retro_thisframe_counter = 0;
             request_update_av_info  = false;
          }
+
+         /* Hasten the result with big enough difference in last line (last line for CD32 no disc) */
+         if (retro_thisframe_last_drawn_line_delta > 47 && retro_thisframe_last_drawn_line_delta < 189)
+            retro_thisframe_counter++;
 
          retro_thisframe_first_drawn_line_old = retro_thisframe_first_drawn_line;
          retro_thisframe_last_drawn_line_old  = retro_thisframe_last_drawn_line;
@@ -7616,7 +7616,7 @@ static bool retro_update_av_info(void)
    {
       if (update_vresolution(true))
       {
-         request_init_custom_timer = 2;
+         request_init_custom_timer = 3;
          set_config_changed();
          return false;
       }

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -548,6 +548,16 @@ static void floppy_open_redirect(int8_t drive)
          if (!string_is_empty(changed_prefs.floppyslots[i].df))
          {
             const char *saveimagepath = DISK_get_saveimagepath(changed_prefs.floppyslots[i].df, -2);
+            char parent_path[RETRO_PATH_MAX];
+
+            strlcpy(parent_path, changed_prefs.floppyslots[i].df, sizeof(parent_path));
+            path_parent_dir(parent_path, strlen(parent_path));
+
+            if (parent_path[strlen(parent_path)-1] == DIR_SEP_CHR)
+               parent_path[strlen(parent_path)-1] = '\0';
+
+            if (string_is_equal(parent_path, retro_save_directory))
+               continue;
 
             if (!string_is_empty(saveimagepath) && !path_is_valid(saveimagepath))
             {
@@ -585,6 +595,16 @@ static void floppy_close_redirect(int8_t drive)
          if (!string_is_empty(changed_prefs.floppyslots[i].df))
          {
             const char *saveimagepath = DISK_get_saveimagepath(changed_prefs.floppyslots[i].df, -2);
+            char parent_path[RETRO_PATH_MAX];
+
+            strlcpy(parent_path, changed_prefs.floppyslots[i].df, sizeof(parent_path));
+            path_parent_dir(parent_path, strlen(parent_path));
+
+            if (parent_path[strlen(parent_path)-1] == DIR_SEP_CHR)
+               parent_path[strlen(parent_path)-1] = '\0';
+
+            if (string_is_equal(parent_path, retro_save_directory))
+               continue;
 
             disk_setwriteprotect(&currprefs, i, changed_prefs.floppyslots[i].df, 1);
             disk_eject(i);
@@ -8250,6 +8270,10 @@ bool retro_load_game(const struct retro_game_info *info)
 
 void retro_unload_game(void)
 {
+   /* Gzip savedisks */
+   if (dc && dc->count > 1 && !string_is_empty(changed_prefs.floppyslots[0].df))
+      dc_save_disk_compress(dc);
+
    /* Close redirected save disks */
    floppy_close_redirect(-1);
 

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -48,6 +48,7 @@ extern bool retro_av_info_is_lace;
 /* Usual suspects */
 extern char retro_system_directory[RETRO_PATH_MAX];
 extern char retro_save_directory[RETRO_PATH_MAX];
+extern char retro_temp_directory[RETRO_PATH_MAX];
 extern struct zfile *retro_deserialize_file;
 extern dc_storage *dc;
 extern retro_log_printf_t log_cb;

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -519,7 +519,7 @@ bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
       retro_message = true;
    }
    else
-      log_cb(RETRO_LOG_INFO, "Save Disk 0 appended\n");
+      log_cb(RETRO_LOG_INFO, "Save Disk 0 appended.\n");
 
    return true;
 }

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -87,6 +87,7 @@ void dc_reset(dc_storage* dc)
 
    dc->count       = 0;
    dc->index       = 0;
+   dc->index_prev  = 0;
    dc->eject_state = true;
    dc->replace     = false;
 }
@@ -100,6 +101,7 @@ dc_storage* dc_create(void)
    {
       dc->count = 0;
       dc->index = -1;
+      dc->index_prev = -1;
       dc->eject_state = true;
       dc->replace = false;
       dc->command = NULL;

--- a/libretro/libretro-dc.h
+++ b/libretro/libretro-dc.h
@@ -65,5 +65,6 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename);
 bool dc_remove_file(dc_storage* dc, int index);
 enum dc_image_type dc_get_image_type(const char* filename);
 bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select);
+void dc_save_disk_compress(dc_storage* dc);
 
 #endif /* LIBRETRO_DC_H */

--- a/libretro/libretro-dc.h
+++ b/libretro/libretro-dc.h
@@ -49,9 +49,9 @@ struct dc_storage
    enum dc_image_type types[DC_MAX_SIZE];
    unsigned count;
    int index;
+   int index_prev;
    bool eject_state;
    bool replace;
-   unsigned index_prev;
 };
 
 typedef struct dc_storage dc_storage;

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -1719,9 +1719,49 @@ bool strendswith(const char* str, const char* end)
 }
 
 /* zlib */
+#define BUFLEN 16384
+
+void gz_compress(const char *in, const char *out)
+{
+   char buf[BUFLEN];
+   size_t len;
+   int err;
+   FILE *in_fp;
+   gzFile out_fp;
+
+   out_fp = gzopen(out, "wb");
+   if (out_fp == NULL)
+      return;
+
+   in_fp = fopen(in, "rb");
+   if (in_fp == NULL)
+      return;
+
+   for (;;)
+   {
+      len = fread(buf, 1, sizeof(buf), in_fp);
+      int buflen;
+
+      if (len <= 0)
+      {
+         if (len < 0)
+            log_cb(RETRO_LOG_ERROR, "GZip: Read error\n");
+         break;
+      }
+
+      buflen = gzwrite(out_fp, buf, len);
+      if (buflen != len)
+         log_cb(RETRO_LOG_ERROR, "GZip: %s\n", gzerror(out_fp, &err));
+   }
+   fclose(in_fp);
+
+   if (gzclose(out_fp) == Z_OK)
+      log_cb(RETRO_LOG_INFO, "GZip: %s\n", out);
+}
+
 void gz_uncompress(const char *in, const char *out)
 {
-   char gzbuf[16384];
+   char gzbuf[BUFLEN];
    int len;
    int err;
 

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -236,6 +236,7 @@ const cdrom_toc *cdrom_get_toc(cdrom_file *file);
 /* zlib */
 #include "deps/libz/zlib.h"
 #include "deps/libz/unzip.h"
+void gz_compress(const char *in, const char *out);
 void gz_uncompress(const char *in, const char *out);
 void zip_uncompress(const char *in, const char *out, char *lastfile);
 

--- a/retrodep/fsdb_host.c
+++ b/retrodep/fsdb_host.c
@@ -11,7 +11,8 @@ extern int log_filesys;
 bool my_stat (const TCHAR *name, struct mystat *ms) {
 	struct stat sonuc;
 	if (stat(name, &sonuc) == -1) {
-		write_log("my_stat: stat on file '%s' failed\n", name);
+		if (log_filesys)
+			write_log("my_stat: stat on file '%s' failed\n", name);
 		return false;
 	}
 	if (log_filesys)
@@ -34,16 +35,12 @@ bool my_stat (const TCHAR *name, struct mystat *ms) {
 
 bool my_chmod (const TCHAR *name, uae_u32 mode)
 {
-#if 0
-	DWORD attr = FILE_ATTRIBUTE_NORMAL;
-	if (!(mode & FILEFLAG_WRITE))
-		attr |= FILE_ATTRIBUTE_READONLY;
-	if (mode & FILEFLAG_ARCHIVE)
-		attr |= FILE_ATTRIBUTE_ARCHIVE;
-	if (chmod (name, attr))
-		return true;
-#endif
-	return false;
+    mode_t attr =   (S_IRUSR | S_IRGRP | S_IROTH);
+    attr |=         (S_IXUSR | S_IXGRP | S_IXOTH);
+    if (mode & FILEFLAG_WRITE)
+        attr |=     (S_IWUSR | S_IWGRP | S_IWOTH);
+
+        return chmod (name, attr);
 }
 
 static int setfiletime (const TCHAR *name, int days, int minute, int tick, int tolocal)


### PR DESCRIPTION
- Harnessed UAE internal save disk substitution feature as core option "Floppy Write Redirect", which is either on or off, and affecting all disks, not only IPF. Effectively allows writing to IPFs.
  1. UAE deletes created save disks that are not written to
  2. Resulting disks are gzipped and extracted silently
  Closes #550

- WHDLoad info launch path fix
  Closes #575

- Also gzipped the old manually created save disks
- Initialized the old save disk feature values to prevent a crash in certain situation (disk index moved manually to save disk index first, and then pressed save disk toggle hotkey)
- One more vertical position correction
- Fix for Speris Legacy startup interlace toggle issue when using Cycle-exact
