### PR TITLE
Fix core options not set in retro_set_environment()

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3214,6 +3214,8 @@ void retro_set_environment(retro_environment_t cb)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
       filestream_vfs_init(&vfs_iface_info);
 #endif
+
+   retro_set_core_options();
 }
 
 void set_variable(const char* key, const char* value)


### PR DESCRIPTION
## Description

This PR fixes core variables for frontends that require the variables to be set inside retro_set_environment().

The documentation of `RETRO_ENVIRONMENT_SET_VARIABLES` states:

> This should be called the first time as early as possible (ideally in retro_set_environment).
>
> Afterward it may be called again for the core to communicate updated options to the frontend, but the number of core options must not change from the number in the initial call.

By calling `retro_set_core_options()` both inside retro_set_environment and when loading a game, we satisfy the libretro documentation.

## Motivation and context

This PR is fully analogous to https://github.com/libretro/vice-libretro/pull/488 (indeed, the diff is nearly identical).

## How has this been tested?

Used to generate the Kodi game add-on for PUAE: https://github.com/kodi-game/game.libretro.uae
