### PR TITLE
WHDLoad optional NoWriteCache

### DIFF
--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -265,13 +265,13 @@ struct puae_cart_info
 #define RETRO_BMP_SIZE          (EMULATOR_DEF_WIDTH * EMULATOR_DEF_HEIGHT * 4) /* 4x is big enough for 24-bit SuperHires double line */
 
 extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
-extern unsigned int pix_bytes;
-extern int retrow;
-extern int retroh;
-extern int retrow_crop;
-extern int retroh_crop;
-extern unsigned int video_config;
-extern unsigned int video_config_geometry;
+extern uint8_t pix_bytes;
+extern unsigned short int retrow;
+extern unsigned short int retroh;
+extern unsigned short int retrow_crop;
+extern unsigned short int retroh_crop;
+extern unsigned short int video_config;
+extern unsigned short int video_config_geometry;
 
 #define CROP_NONE            0
 #define CROP_MINIMUM         1

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -43,10 +43,10 @@ extern unsigned int retro_devices[RETRO_DEVICES];
 bool inputdevice_finalized = false;
 extern int retro_ui_get_pointer_state(uint8_t port, int *px, int *py, uint8_t *pb);
 
-extern unsigned int defaultw;
-extern unsigned int defaulth;
-extern unsigned int width_multiplier;
-extern unsigned int libretro_frame_end;
+extern unsigned short int defaultw;
+extern unsigned short int defaulth;
+extern uint8_t width_multiplier;
+extern uint8_t libretro_frame_end;
 
 unsigned short int* pixbuf = NULL;
 extern unsigned short int retro_bmp[RETRO_BMP_SIZE];

--- a/sources/src/include/uae.h
+++ b/sources/src/include/uae.h
@@ -13,8 +13,8 @@
 
 #ifdef __LIBRETRO__
 extern void libretro_do_restart (int argc, TCHAR **argv);
-extern unsigned int libretro_runloop_active;
-extern unsigned int libretro_frame_end;
+extern uint8_t libretro_runloop_active;
+extern uint8_t libretro_frame_end;
 #endif
 
 extern void do_start_program (void);

--- a/sources/src/main.c
+++ b/sources/src/main.c
@@ -52,8 +52,8 @@
 #endif
 
 #ifdef __LIBRETRO__
-static int real_main2_ret = 0;
-unsigned int libretro_frame_end = 0;
+static int8_t real_main2_ret = 0;
+uint8_t libretro_frame_end = 0;
 static void hr (void)
 {
 	write_log (_T("--------------------------------------------------------------------------------\n"));


### PR DESCRIPTION
Eliminate the need for `NoWriteCache` by making sure WHDLoad is closed before closing core. This helps with a bunch of loading issues, and allows updating WHDLoad in the future, since the save issue does not exist with write cache.

Old behavior is kept as an option just in case, so nothing needs to be done to get the change. Please inform about any possible unsaved data!