### PR TITLE
'mapped_free' update

### DIFF
--- a/sources/src/memory.c
+++ b/sources/src/memory.c
@@ -2076,10 +2076,24 @@ bool mapped_malloc (addrbank *ab)
 
 void mapped_free (addrbank *ab)
 {
+#ifdef __LIBRETRO__
+	ab->flags &= ~ABFLAG_MAPPED;
+	if (ab->baseaddr == NULL) {
+		return;
+	}
+
+	if (!(ab->flags & ABFLAG_NOALLOC)) {
+		xfree(ab->baseaddr);
+	}
+
+	ab->allocated_size = 0;
+	ab->baseaddr = NULL;
+#else
 	xfree(ab->baseaddr);
 	ab->flags &= ~ABFLAG_MAPPED;
 	ab->allocated_size = 0;
 	ab->baseaddr = NULL;
+#endif
 }
 
 #else


### PR DESCRIPTION
Legacy non-`NATMEM_OFFSET` `mapped_free` isn't taking new features into account, and thus is trying to free non-allocated memory.

Closes #621
