### PR TITLE
Replace internal centering with video_cb offset

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1920,7 +1920,7 @@ static void retro_set_core_options()
             { "enabled", NULL },
             { NULL, NULL },
          },
-         "disabled"
+         "enabled"
       },
       {
          "puae_floppy_sound_type",

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -38,6 +38,7 @@
 
 uint8_t libretro_runloop_active = 0;
 unsigned short int retro_bmp[RETRO_BMP_SIZE] = {0};
+unsigned int retro_bmp_offset = 0;
 unsigned short int defaultw = EMULATOR_DEF_WIDTH / 2;
 unsigned short int defaulth = EMULATOR_DEF_HEIGHT / 2;
 unsigned short int retrow = EMULATOR_DEF_WIDTH / 2;
@@ -45,6 +46,8 @@ unsigned short int retroh = EMULATOR_DEF_HEIGHT / 2;
 unsigned short int retrow_max = EMULATOR_DEF_WIDTH;
 unsigned short int retrow_crop = 0;
 unsigned short int retroh_crop = 0;
+unsigned short int retrox_crop = 0;
+unsigned short int retroy_crop = 0;
 float aspect_ratio = 0;
 
 extern int bplcon0;
@@ -163,12 +166,11 @@ static int retro_thisframe_last_drawn_line_old = -1;
 static int retro_thisframe_last_drawn_line_start = -1;
 extern int thisframe_y_adjust;
 static int thisframe_y_adjust_old = -1;
-static int thisframe_y_adjust_update_frame_timer = 3;
 
 static int opt_horizontal_offset = 0;
 static bool opt_horizontal_offset_auto = true;
-static int retro_max_diwlastword_hires = 936;
-static int retro_max_diwlastword = 936;
+static int retro_max_diwlastword_hires = 938;
+static int retro_max_diwlastword = 938;
 extern int retro_min_diwstart;
 static int retro_min_diwstart_old = -1;
 extern int retro_max_diwstop;
@@ -176,7 +178,6 @@ static int retro_max_diwstop_old = -1;
 static int retro_diwstartstop_counter = 0;
 extern int visible_left_border;
 static int visible_left_border_old = 0;
-static int visible_left_border_update_frame_timer = 3;
 
 #define PAL_KS2_CROP_SAFE_FIRST_LINE  99
 #define PAL_KS2_CROP_SAFE_LAST_LINE   244
@@ -4355,20 +4356,13 @@ static void update_variables(void)
    {
       opt_vertical_offset = 0;
       if (!strcmp(var.value, "auto"))
-      {
          opt_vertical_offset_auto = true;
-         thisframe_y_adjust = minfirstline;
-      }
       else
       {
          opt_vertical_offset_auto = false;
          int new_vertical_offset = atoi(var.value);
-         if (new_vertical_offset >= -20 && new_vertical_offset <= 70)
-         {
-            /* This offset is used whenever minfirstline is reset on gfx mode changes in the init_hz() function */
+         if (new_vertical_offset >= -minfirstline && new_vertical_offset <= 70)
             opt_vertical_offset = new_vertical_offset;
-            thisframe_y_adjust = minfirstline + opt_vertical_offset;
-         }
       }
    }
 
@@ -4378,18 +4372,13 @@ static void update_variables(void)
    {
       opt_horizontal_offset = 0;
       if (!strcmp(var.value, "auto"))
-      {
          opt_horizontal_offset_auto = true;
-      }
       else
       {
          opt_horizontal_offset_auto = false;
          int new_horizontal_offset = atoi(var.value);
          if (new_horizontal_offset >= -40 && new_horizontal_offset <= 40)
-         {
-            opt_horizontal_offset = new_horizontal_offset;
-            visible_left_border = retro_max_diwlastword - retrow - (opt_horizontal_offset * width_multiplier);
-         }
+            opt_horizontal_offset = -new_horizontal_offset;
       }
    }
 
@@ -7350,9 +7339,9 @@ void retro_reset(void)
    /* Ensure WHDLoad saves are written with write cache enabled */
    whdload_quitkey();
 
-   if (forced_video < 0)
-      video_config_old = 0;
+   video_config_old = (forced_video < 0) ? 0 : video_config_old;
    fake_ntsc = false;
+   locked_video_horizontal = false;
    update_variables();
    retro_create_config();
    uae_restart(0, NULL); /* opengui, cfgfile */
@@ -7370,12 +7359,18 @@ static void update_video_center_vertical(void)
 {
    int retroh_crop_normal     = (video_config & PUAE_VIDEO_DOUBLELINE) ? retroh_crop / 2 : retroh_crop;
    int thisframe_y_adjust_new = minfirstline;
+   int thisframe_y_adjust_cur = thisframe_y_adjust;
+
+   /* Always reset default top border */
+   thisframe_y_adjust = minfirstline;
 
    /* Need proper values for calculations */
-   if (retro_thisframe_first_drawn_line != retro_thisframe_last_drawn_line
-    && retro_thisframe_first_drawn_line > 0 && retro_thisframe_last_drawn_line > 0
-    && (retro_thisframe_first_drawn_line < 150 || retro_thisframe_last_drawn_line > 150)
-   )
+   if (!opt_vertical_offset_auto)
+      thisframe_y_adjust_new = thisframe_y_adjust + opt_vertical_offset;
+   else if ( retro_thisframe_first_drawn_line       != retro_thisframe_last_drawn_line
+         && (retro_thisframe_first_drawn_line > 0   && retro_thisframe_last_drawn_line > 0)
+         && (retro_thisframe_first_drawn_line < 150 || retro_thisframe_last_drawn_line > 150)
+      )
       thisframe_y_adjust_new = (retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line - retroh_crop_normal) / 2 + retro_thisframe_first_drawn_line;
    else if (retro_thisframe_first_drawn_line == -1 && retro_thisframe_last_drawn_line == -1 && thisframe_y_adjust_old != 0)
       thisframe_y_adjust_new = thisframe_y_adjust_old;
@@ -7388,16 +7383,35 @@ static void update_video_center_vertical(void)
    if (retro_thisframe_last_drawn_line < 200 && thisframe_y_adjust_new < minfirstline)
       thisframe_y_adjust_new = thisframe_y_adjust_old;
 
-   /* Change value only if altered */
-   if (thisframe_y_adjust != thisframe_y_adjust_new)
-      thisframe_y_adjust = thisframe_y_adjust_new;
+   /* Remember the previous value */
+   thisframe_y_adjust_old = thisframe_y_adjust_new;
+
+   /* Corrections if top border has stuff in it, only if manually forced */
+   if (thisframe_y_adjust_new < thisframe_y_adjust)
+   {
+      int diff = thisframe_y_adjust - thisframe_y_adjust_new;
+      thisframe_y_adjust     -= diff;
+      thisframe_y_adjust_new -= diff;
+   }
+
+   /* Disallow centering if trying to crop NTSC aspect in full PAL mode */
+   if (retroh == retroh_crop)
+      thisframe_y_adjust = thisframe_y_adjust_new = minfirstline;
+
+   /* Offset adjustments */
+   thisframe_y_adjust_new -= thisframe_y_adjust;
+   thisframe_y_adjust_new = (thisframe_y_adjust_new < 0) ? 0 : thisframe_y_adjust_new;
+
+   /* Change value always due to the possible change of interlace */
+   retroy_crop = thisframe_y_adjust_new * ((video_config & PUAE_VIDEO_DOUBLELINE) ? 2 : 1);
 
 #if 0
-   printf("FIRSTDRAWN:%6d LASTDRAWN:%6d   yadjust:%3d old:%3d crop_h:%d\n", retro_thisframe_first_drawn_line, retro_thisframe_last_drawn_line, thisframe_y_adjust, thisframe_y_adjust_old, retroh_crop);
+   printf("FIRSTDRAWN:%6d LASTDRAWN:%6d   yadjust:%3d old:%3d cur:%3d croph:%d cropy:%d\n", retro_thisframe_first_drawn_line, retro_thisframe_last_drawn_line, thisframe_y_adjust, thisframe_y_adjust_old, thisframe_y_adjust_cur, retroh_crop, retroy_crop);
 #endif
 
-   /* Remember the previous value */
-   thisframe_y_adjust_old = thisframe_y_adjust;
+   /* Must reset drawing if internal border changes */
+   if (thisframe_y_adjust != thisframe_y_adjust_cur)
+      request_reset_drawing = true;
 
    /* Counter reset */
    retro_thisframe_counter = 0;
@@ -7406,39 +7420,63 @@ static void update_video_center_vertical(void)
 /* Horizontal centering */
 static void update_video_center_horizontal(void)
 {
-   int visible_left_border_new = retro_max_diwlastword - retrow + ((retrow - retrow_crop) / 2) + 2;
+   int default_left_border     = (retro_max_diwlastword - retrow);
+   int visible_left_border_new = retro_max_diwlastword - retrow + ((retrow - retrow_crop) / 2);
+   int visible_left_border_cur = visible_left_border;
 
    /* Horizontal centering thresholds */
    int min_diwstart_limit = 162 * width_multiplier;
    int max_diwstop_limit  = 300 * width_multiplier;
 
+   /* Always reset default left border */
+   visible_left_border = default_left_border;
+
    /* Need proper values for calculations */
    if (locked_video_horizontal)
       ; /* no-op */
+   else if (!opt_horizontal_offset_auto)
+      visible_left_border_new = visible_left_border + opt_horizontal_offset;
    else if (retro_min_diwstart != retro_max_diwstop
-    && retro_min_diwstart > 0
-    && retro_max_diwstop  > 0
-    && retro_min_diwstart < min_diwstart_limit
-    && retro_max_diwstop  > max_diwstop_limit
-    && (retro_max_diwstop - retro_min_diwstart) <= (retrow_crop + (4 * width_multiplier)))
+         && retro_min_diwstart > 0
+         && retro_max_diwstop  > 0
+         && retro_min_diwstart < min_diwstart_limit
+         && retro_max_diwstop  > max_diwstop_limit
+         && (retro_max_diwstop - retro_min_diwstart) <= (retrow_crop + (4 * width_multiplier)))
       visible_left_border_new = (retro_max_diwstop - retro_min_diwstart - retrow_crop) / 2 + retro_min_diwstart;
    else if (retro_min_diwstart == MAX_STOP && retro_max_diwstop == 0 && visible_left_border != 0)
       visible_left_border_new = visible_left_border;
 
    /* Sensible limits */
    visible_left_border_new = (visible_left_border_new < 0) ? 0 : visible_left_border_new;
-   visible_left_border_new = ((visible_left_border_new / width_multiplier) > 150) ? (150 * width_multiplier) : visible_left_border_new;
-
-   /* Change value only if altered */
-   if (visible_left_border != visible_left_border_new)
-      visible_left_border = visible_left_border_new;
-
-#if 0
-   printf("DIWSTART  :%6d DIWSTOP  :%6d   lborder:%3d old:%3d width:%3d\n", retro_min_diwstart, retro_max_diwstop, visible_left_border, visible_left_border_old, (retro_max_diwstop - retro_min_diwstart));
-#endif
+   visible_left_border_new = (visible_left_border_new / width_multiplier > 150) ? (150 * width_multiplier) : visible_left_border_new;
 
    /* Remember the previous value */
    visible_left_border_old = visible_left_border;
+
+   /* Corrections if left border has stuff in it, only for actual fullscreen needs */
+   if (     visible_left_border_new < visible_left_border
+         && retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line > 200)
+   {
+      int diff = visible_left_border - visible_left_border_new;
+      visible_left_border     -= diff;
+      visible_left_border_new -= diff;
+   }
+
+   /* Offset adjustments */
+   visible_left_border_new -= visible_left_border;
+   visible_left_border_new = (visible_left_border_new < 0) ? 0 : visible_left_border_new;
+
+   /* Change value only if altered */
+   if (retrox_crop != visible_left_border_new)
+      retrox_crop = visible_left_border_new;
+
+#if 0
+   printf("DIWSTART  :%6d DIWSTOP  :%6d   lborder:%3d old:%3d cur:%3d cropw:%3d cropx:%d\n", retro_min_diwstart, retro_max_diwstop, visible_left_border, visible_left_border_old, visible_left_border_cur, (retro_max_diwstop - retro_min_diwstart), retrox_crop);
+#endif
+
+   /* Must reset drawing if internal border changes */
+   if (visible_left_border != visible_left_border_cur)
+      request_reset_drawing = true;
 
    /* Counter reset */
    retro_diwstartstop_counter = 0;
@@ -7500,16 +7538,18 @@ static void update_audiovideo(void)
    }
 
    /* Automatic video resolution */
-   if (opt_video_resolution_auto)
+   if (opt_video_resolution_auto && retro_min_diwstart != MAX_STOP)
    {
       int current_resolution   = GET_RES_DENISE (bplcon0);
       bool request_init_custom = false;
 #if 0
-      printf("BPLCON0: %x, %d, %d %d\n", bplcon0, current_resolution, diwfirstword_total, diwlastword_total);
+      printf("BPLCON0: %x, %d, %d-%d, %d-%d\n", bplcon0, current_resolution, diwfirstword_total, diwlastword_total, retro_min_diwstart, retro_max_diwstop);
 #endif
 
       /* Super Skidmarks force to SuperHires */
-      if (current_resolution == 1 && bplcon0 == 0xC201 && (diwlastword_total == 898 || diwlastword_total == 1796))
+      if (current_resolution == 1 && bplcon0 == 0xC201
+            && (retro_min_diwstart == 322 || retro_min_diwstart == 644)
+            && (diwlastword_total == 898 || diwlastword_total == 1796))
          current_resolution = 2;
       /* Lores force to Hires */
       else if (current_resolution == 0)
@@ -7547,10 +7587,10 @@ static void update_audiovideo(void)
        * retro_max_diwlastword change which is crucial for visible_left_border */
       if (request_init_custom)
       {
-         request_init_custom_timer = 3;
+         request_init_custom_timer = 2;
          retro_min_diwstart_old    = -1;
          retro_max_diwstop_old     = -1;
-         visible_left_border       = retro_max_diwlastword - retrow;
+         set_config_changed();
       }
    }
 
@@ -7719,19 +7759,6 @@ static void update_audiovideo(void)
       retro_thisframe_first_drawn_line = (changed_prefs.ntscmode) ? NTSC_KS2_CROP_SAFE_FIRST_LINE : PAL_KS2_CROP_SAFE_FIRST_LINE;
       retro_thisframe_last_drawn_line  = (changed_prefs.ntscmode) ? NTSC_KS2_CROP_SAFE_LAST_LINE : PAL_KS2_CROP_SAFE_LAST_LINE;
    }
-   else
-   {
-      /* Vertical offset must not be set too early */
-      if (thisframe_y_adjust_update_frame_timer > 0)
-      {
-         thisframe_y_adjust_update_frame_timer--;
-         if ((thisframe_y_adjust_update_frame_timer == 0) && (opt_vertical_offset != 0))
-         {
-            thisframe_y_adjust = minfirstline + opt_vertical_offset;
-            request_reset_drawing = true;
-         }
-      }
-   }
 
    /* Automatic horizontal offset */
    if (opt_horizontal_offset_auto)
@@ -7748,35 +7775,58 @@ static void update_audiovideo(void)
       if ( (retro_min_diwstart != retro_min_diwstart_old
          || retro_max_diwstop  != retro_max_diwstop_old)
          && retro_min_diwstart != MAX_STOP
-         && retro_max_diwstop  != 0)
+         && retro_max_diwstop  != 0
+         && !locked_video_horizontal)
       {
 #if 0
-         printf("diwcnt %d, start:%3d old:%3d stop:%3d old:%3d width:%3d\n",
+         printf("diwcnt %d, start:%3d old:%3d stop:%3d old:%3d width:%3d, tfdl:%3d tldl:%3d\n",
                retro_diwstartstop_counter, retro_min_diwstart, retro_min_diwstart_old,
-               retro_max_diwstop, retro_max_diwstop_old, retro_max_diwstop - retro_min_diwstart);
+               retro_max_diwstop, retro_max_diwstop_old, retro_max_diwstop - retro_min_diwstart,
+               retro_thisframe_first_drawn_line, retro_thisframe_last_drawn_line);
 #endif
+         retro_diwstartstop_counter = 0;
+
+#if 1
          /* Game specific hacks: */
-         /* North & South */
-         if (retro_min_diwstart == (129 * width_multiplier) && retro_min_diwstart_old == retro_min_diwstart
-          && retro_max_diwstop  == (458 * width_multiplier) && retro_max_diwstop_old  == (449 * width_multiplier))
+         /* North & South PAL */
+         if (retro_thisframe_first_drawn_line == 44 && retro_thisframe_last_drawn_line == 243
+               && retro_min_diwstart == (129 * width_multiplier) && retro_min_diwstart_old == retro_min_diwstart
+               && retro_max_diwstop  == (458 * width_multiplier) && retro_max_diwstop_old  == (449 * width_multiplier))
          {
+            locked_video_horizontal = true;
             retro_max_diwstop = retro_max_diwstop_old;
-            retro_diwstartstop_counter = 0;
+            log_cb(RETRO_LOG_INFO, "Horizontal centering hack for '%s' active.\n", "North & South PAL");
          }
-         /* Chase HQ WHDLoad*/
-         else if (retro_min_diwstart == (129 * width_multiplier) && retro_min_diwstart_old == (127 * width_multiplier)
+         /* North & South NTSC */
+         else if (retro_thisframe_first_drawn_line == 44 && retro_thisframe_last_drawn_line == 243
+               && retro_min_diwstart == (129 * width_multiplier) && retro_min_diwstart_old == (127 * width_multiplier)
                && retro_max_diwstop  == (449 * width_multiplier) && retro_max_diwstop_old  == (447 * width_multiplier))
          {
-            retro_diwstartstop_counter = 0;
             locked_video_horizontal = true;
+            retro_max_diwstop = retro_max_diwstop_old;
+            log_cb(RETRO_LOG_INFO, "Horizontal centering hack for '%s' active.\n", "North & South NTSC");
+         }
+         /* Chase HQ WHDLoad */
+         else if (retro_thisframe_first_drawn_line == 50 && retro_thisframe_last_drawn_line == 249
+               && retro_min_diwstart == (137 * width_multiplier) && retro_min_diwstart_old == (129 * width_multiplier)
+               && retro_max_diwstop  == (457 * width_multiplier) && retro_max_diwstop_old  == (449 * width_multiplier))
+         {
+            locked_video_horizontal = true;
+            log_cb(RETRO_LOG_INFO, "Horizontal centering hack for '%s' active.\n", "Chase HQ");
          }
          /* Toki */
-         else if (retro_min_diwstart == (145 * width_multiplier) && retro_min_diwstart_old == (113 * width_multiplier)
+         else if (retro_thisframe_first_drawn_line == 60 && retro_thisframe_last_drawn_line == 259
+               && retro_min_diwstart == (145 * width_multiplier) && retro_min_diwstart_old == (113 * width_multiplier)
                && retro_max_diwstop  == (401 * width_multiplier) && retro_max_diwstop_old  == (465 * width_multiplier))
          {
-            retro_diwstartstop_counter = 0;
             locked_video_horizontal = true;
+            log_cb(RETRO_LOG_INFO, "Horizontal centering hack for '%s' active.\n", "Toki");
          }
+#endif
+
+         /* Immediate mode */
+         if (!crop_delay)
+            request_update_av_info = true;
          else
             retro_diwstartstop_counter = 1;
 
@@ -7793,23 +7843,7 @@ static void update_audiovideo(void)
          retro_diwstartstop_counter++;
 
          if (retro_diwstartstop_counter > 3)
-         {
-            request_reset_drawing = true;
-            update_video_center_horizontal();
-         }
-      }
-   }
-   else
-   {
-      /* Horizontal offset must not be set too early */
-      if (visible_left_border_update_frame_timer > 0)
-      {
-         visible_left_border_update_frame_timer--;
-         if (visible_left_border_update_frame_timer == 0)
-         {
-            visible_left_border = retro_max_diwlastword - retrow - (opt_horizontal_offset * width_multiplier);
-            request_reset_drawing = true;
-         }
+            request_update_av_info = true;
       }
    }
 }
@@ -7887,7 +7921,7 @@ static bool retro_update_av_info(void)
    {
       if (update_vresolution(true))
       {
-         request_init_custom_timer = 3;
+         request_init_custom_timer = 2;
          set_config_changed();
          return false;
       }
@@ -8014,10 +8048,6 @@ static bool retro_update_av_info(void)
    {
       defaultw = retrow;
       defaulth = retroh;
-
-      /* Statusbar location needs to get refreshed in B.C. Kid  */
-      if (fake_ntsc)
-         request_init_custom_timer = 1;
    }
 
    /* Disable Hz change if not allowed */
@@ -8026,6 +8056,7 @@ static bool retro_update_av_info(void)
 
    /* Ensure statusbar stays visible at the bottom */
    opt_statusbar_position = opt_statusbar_position_old;
+
    if (!change_timing)
       if (retroh < defaulth)
          if (opt_statusbar_position >= 0 && (defaulth - retroh) >= opt_statusbar_position)
@@ -8033,6 +8064,12 @@ static bool retro_update_av_info(void)
 
    /* Aspect offset for crop mode */
    opt_statusbar_position_offset = opt_statusbar_position_old - opt_statusbar_position;
+
+   /* Correction for "impossible" aspect mode */
+   if (     crop_id == CROP_AUTO
+         && video_config & PUAE_VIDEO_PAL
+         && video_config_aspect == PUAE_VIDEO_NTSC)
+      opt_statusbar_position_offset += (PUAE_VIDEO_HEIGHT_PAL - PUAE_VIDEO_HEIGHT_NTSC) / ((video_config_geometry & PUAE_VIDEO_DOUBLELINE) ? 1 : 2);
 
    /* Compensate for interlace, aargh */
    if (opt_statusbar_position >= 0 && !real_ntsc && !fake_ntsc)
@@ -8071,6 +8108,10 @@ static bool retro_update_av_info(void)
 #if 0
    printf("statusbar:%3d old:%3d offset:%3d, defaulth:%d retroh:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, defaulth, retroh);
 #endif
+
+   /* Horizontal width hack forcing */
+   if (locked_video_horizontal)
+      retro_max_diwstop = retro_max_diwstop_old;
 
    /* Apply crop mode */
    switch (crop_id)
@@ -8129,6 +8170,10 @@ static bool retro_update_av_info(void)
           && retro_thisframe_last_drawn_line > 0)
             retroh_crop = retro_thisframe_last_drawn_line - retro_thisframe_first_drawn_line + 1;
          retroh_crop = (retroh_crop < 200) ? 200 : retroh_crop;
+
+         /* Allow full PAL height with NTSC PAR */
+         if (defaulth > retroh && retroh_crop > retroh * (video_config & PUAE_VIDEO_DOUBLELINE) ? 2 : 1)
+            retroh = defaulth;
          break;
       default:
          retrow_crop = retrow;
@@ -8209,6 +8254,10 @@ static bool retro_update_av_info(void)
       change_timing = true;
    }
 
+   /* Offset centerings */
+   update_video_center_vertical();
+   update_video_center_horizontal();
+
    /* Fetch default av_info (not current!) */
    struct retro_system_av_info new_av_info;
    retro_get_system_av_info(&new_av_info);
@@ -8221,14 +8270,17 @@ static bool retro_update_av_info(void)
       new_av_info.geometry.aspect_ratio = retro_get_aspect_ratio(retrow_crop, retroh_crop, false);
 
       /* Ensure statusbar stays visible at the bottom */
-      int statusbar_position_offset = retroh - retroh_crop - opt_statusbar_position_offset;
-      if (opt_statusbar_position >= 0 && statusbar_position_offset >= opt_statusbar_position)
+      int statusbar_position_offset = retroh - retroh_crop - retroy_crop - opt_statusbar_position_offset;
+      if (opt_statusbar_position >= 0)
       {
          opt_statusbar_position = statusbar_position_offset;
 
          if (opt_statusbar_position < 0)
             opt_statusbar_position = 0;
       }
+      else
+         opt_statusbar_position = -retroy_crop + 1;
+
 #if 0
       printf("ztatusbar:%3d old:%3d offset:%3d, defaulth:%d retroz:%d\n", opt_statusbar_position, opt_statusbar_position_old, opt_statusbar_position_offset, defaulth, retroh_crop);
 #endif
@@ -8253,36 +8305,27 @@ static bool retro_update_av_info(void)
    if (change_timing || change_geometry)
       aspect_ratio = new_av_info.geometry.aspect_ratio;
 
-   /* If crop mode should be vertically centered automagically */
-   if (opt_vertical_offset_auto && (crop_id != 0 || retroh_crop != retroh))
-      update_video_center_vertical();
-   else
-      thisframe_y_adjust = minfirstline + opt_vertical_offset;
-
-   /* Horizontal centering needs to be done also after geometry change */
-   if (opt_horizontal_offset_auto)
-      update_video_center_horizontal();
-   else
-      visible_left_border = retro_max_diwlastword - retrow - (opt_horizontal_offset * width_multiplier);
+   retro_bmp_offset = (retrox_crop * (pix_bytes >> 1)) + (retroy_crop * (retrow << (pix_bytes >> 2)));
 
    /* Logging */
    if (av_log)
    {
       if (change_timing)
-         printf("  * Update av_info : %dx%d %0.4fHz, crop: %dx%d, aspect:%0.3f, video_config:%d\n", retrow, retroh, hz, retrow_crop, retroh_crop, aspect_ratio, video_config_geometry);
-      else if (change_geometry)
-         printf("  * Update geometry: %dx%d, crop: %dx%d, aspect:%0.3f, video_config:%d\n", retrow, retroh, retrow_crop, retroh_crop, aspect_ratio, video_config_geometry);
+         printf("  * Update av_info : %dx%d %0.4fHz, crop: %dx%d, aspect:%0.3f, video_config:%d offset:%dx%d\n",
+               retrow, retroh, hz, retrow_crop, retroh_crop, aspect_ratio, video_config_geometry, retrox_crop, retroy_crop);
       else
-         printf("  * Update center  : %dx%d, crop: %dx%d, aspect:%0.3f, video_config:%d\n", retrow, retroh, retrow_crop, retroh_crop, aspect_ratio, video_config_geometry);
+         printf("  * Update %s: %dx%d, crop: %dx%d, aspect:%0.3f, video_config:%d offset:%dx%d\n",
+               (change_geometry) ? "geometry" : "center  ",
+               retrow, retroh, retrow_crop, retroh_crop, aspect_ratio, video_config_geometry, retrox_crop, retroy_crop);
    }
 
-   /* Triggers check_prefs_changed_gfx() in vsync_handle_check() */
-   set_config_changed();
-
-   /* Changing any drawing/offset parameters requires
-    * a drawing reset - it is safest to just do this
-    * whenever retro_update_av_info() is called */
-   request_reset_drawing = true;
+   if (islace)
+   {
+      /* Reset horizontal hacks */
+      if (locked_video_horizontal)
+         log_cb(RETRO_LOG_INFO, "Horizontal centering hacks cleared.\n");
+      locked_video_horizontal = false;
+   }
 
    return true;
 }
@@ -8298,39 +8341,9 @@ void retro_run(void)
    if (request_reset_soft)
       retro_reset_soft();
 
-   /* Handle statusbar text, audio filter type & video geometry + resolution */
-   update_audiovideo();
-
-   /* AV info change is requested */
-   if (request_update_av_info)
-      retro_update_av_info();
-
    /* Poll inputs */
    input_poll_cb();
    retro_poll_event();
-
-   /* If any drawing parameters/offsets have been modified,
-    * must call reset_drawing() to ensure that the changes
-    * are 'registered' by center_image() in drawing.c
-    * > If we don't do this, the wrong parameters may be
-    *   used on the next frame, which can lead to out of
-    *   bounds video buffer access (memory corruption)
-    * > This check must come *after* horizontal/vertical
-    *   offset calculation, retro_update_av_info() and
-    *   retro_poll_event() */
-   if (request_reset_drawing)
-   {
-      request_reset_drawing = false;
-      reset_drawing();
-   }
-
-   /* Dynamic resolution changing requires a frame breather after reset_drawing() */
-   if (request_init_custom_timer > 0)
-   {
-      request_init_custom_timer--;
-      if (request_init_custom_timer == 0)
-         init_custom();
-   }
 
    /* 4.9.0 caused startup audio rate miscalculation without this hack.. (?!)
     * Rather this than doing `lof_display = lof_store;` in `VPOSW()` inside `lof_changing`
@@ -8372,6 +8385,36 @@ void retro_run(void)
    restart_pending = m68k_go(1, 1);
    retro_now += 1000000 / retro_refresh;
 
+   /* Handle statusbar text, audio filter type & video geometry + resolution */
+   update_audiovideo();
+
+   /* AV info change is requested */
+   if (request_update_av_info)
+      retro_update_av_info();
+
+   /* If any drawing parameters/offsets have been modified,
+    * must call reset_drawing() to ensure that the changes
+    * are 'registered' by center_image() in drawing.c
+    * > If we don't do this, the wrong parameters may be
+    *   used on the next frame, which can lead to out of
+    *   bounds video buffer access (memory corruption)
+    * > This check must come *after* horizontal/vertical
+    *   offset calculation, retro_update_av_info() and
+    *   retro_poll_event() */
+   if (request_reset_drawing)
+   {
+      request_reset_drawing = false;
+      reset_drawing();
+   }
+
+   /* Dynamic resolution changing requires a frame breather after reset_drawing() */
+   if (request_init_custom_timer > 0)
+   {
+      request_init_custom_timer--;
+      if (request_init_custom_timer == 0)
+         init_custom();
+   }
+
    /* Warning messages */
    if (retro_message)
    {
@@ -8404,18 +8447,13 @@ void retro_run(void)
    if (video_config & PUAE_VIDEO_PAL)
    {
       if (video_config & PUAE_VIDEO_DOUBLELINE)
-      {
-         draw_hline(0, 574, retrow_crop, 0, 0);
-         draw_hline(0, 575, retrow_crop, 0, 0);
-      }
+         draw_hline(0, 574, retrow, 2, 0);
       else
-      {
-         draw_hline(0, 287, retrow_crop, 0, 0);
-      }
+         draw_hline(0, 287, retrow, 1, 0);
    }
 
 upload:
-   video_cb(retro_bmp, retrow_crop, retroh_crop, retrow << (pix_bytes / 2));
+   video_cb(retro_bmp + retro_bmp_offset, retrow_crop, retroh_crop, retrow << (pix_bytes >> 1));
    upload_output_audio_buffer();
 }
 

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -270,6 +270,8 @@ extern unsigned short int retrow;
 extern unsigned short int retroh;
 extern unsigned short int retrow_crop;
 extern unsigned short int retroh_crop;
+extern unsigned short int retrox_crop;
+extern unsigned short int retroy_crop;
 extern unsigned short int video_config;
 extern unsigned short int video_config_geometry;
 

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -50,7 +50,6 @@ extern unsigned char width_multiplier;
 extern uint8_t libretro_frame_end;
 
 unsigned short int* pixbuf = NULL;
-extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
 extern char retro_temp_directory[RETRO_PATH_MAX];
 
 int retro_thisframe_first_drawn_line;
@@ -318,6 +317,7 @@ void print_statusbar(void)
    if (opt_statusbar & STATUSBAR_BASIC && !statusbar_message_timer)
       goto end;
 
+   int BOX_X                = retrox_crop;
    int BOX_Y                = 0;
    int BOX_WIDTH            = 0;
    int BOX_HEIGHT           = 11;
@@ -342,14 +342,14 @@ void print_statusbar(void)
    int FONT_COLOR           = (pix_bytes == 4) ? 0xffffff : 0xffff;;
    int FONT_SLOT            = 34 * FONT_WIDTH;
 
-   int TEXT_X               = 1 * FONT_WIDTH;
+   int TEXT_X               = 1 * FONT_WIDTH + retrox_crop;
    int TEXT_Y               = 0;
    int TEXT_LENGTH          = (video_config & PUAE_VIDEO_DOUBLELINE) ? 128 : 64;
 
    /* Statusbar location */
    /* Top */
    if (opt_statusbar_position < 0)
-      TEXT_Y = BOX_PADDING;
+      TEXT_Y = BOX_PADDING + retroy_crop;
    /* Bottom */
    else
       TEXT_Y = gfxvidinfo->drawbuffer.outheight - opt_statusbar_position - BOX_HEIGHT + BOX_PADDING;
@@ -546,7 +546,7 @@ void print_statusbar(void)
       JOY2_COLOR = joystick_color(jflag[1]);
 
    /* Statusbar output */
-   draw_fbox(0, BOX_Y, BOX_WIDTH, BOX_HEIGHT, 0, GRAPH_ALPHA_100);
+   draw_fbox(BOX_X, BOX_Y, BOX_WIDTH, BOX_HEIGHT, 0, GRAPH_ALPHA_100);
 
    if (statusbar_message_timer)
    {

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -43,7 +43,7 @@ static unsigned int mouse_speed[NORMAL_JPORTS] = {0};
 int arcadia_pad_enabled[NORMAL_JPORTS] = {0};
 
 extern bool request_update_av_info;
-extern void retro_reset_soft();
+extern bool request_reset_soft;
 extern bool retro_statusbar;
 extern long vkbd_mapping_active;
 extern unsigned char width_multiplier;
@@ -252,7 +252,7 @@ void emu_function(int function)
                (retro_mousemode) ? "Mouse Mode" : "Joystick Mode");
          break;
       case EMU_RESET:
-         retro_reset_soft();
+         request_reset_soft = true;
          /* Statusbar notification */
          statusbar_message_show(4, "%s", "Reset");
          break;

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -104,8 +104,8 @@ int retro_ui_get_pointer_state(uint8_t port, int *px, int *py, uint8_t *pb)
       *py = input_state_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y);
    }
 
-   *px = (int)((*px + 0x7fff) * retrow_crop / 0xffff);
-   *py = (int)((*py + 0x7fff) * retroh_crop / 0xffff);
+   *px = (int)((*px + 0x7fff) * retrow_crop / 0xffff + retrox_crop);
+   *py = (int)((*py + 0x7fff) * retroh_crop / 0xffff + retroy_crop);
 
    if (joyport_pointer_color > -1)
    {

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -407,9 +407,9 @@ void print_vkbd(void)
       XKEYSPACING        = 2;
       XOFFSET            = -1;
 
+      /* PUAE_VIDEO_HIRES_DOUBLELINE */
       if (video_config_geometry & PUAE_VIDEO_DOUBLELINE)
       {
-         /* PUAE_VIDEO_HIRES_DOUBLELINE */
          FONT_HEIGHT    *= 2;
          YKEYSPACING    *= 2;
          YPADDING       *= 2;
@@ -424,11 +424,13 @@ void print_vkbd(void)
       }
    }
 
+   XOFFSET      += retrox_crop;
+
    int XSIDE     = (320 * FONT_WIDTH) / VKBDX;
-   int YSIDE     = 21 * FONT_HEIGHT;
+   int YSIDE     = (172 * FONT_HEIGHT) / VKBDY;
 
    XPADDING      = retrow_crop - (XSIDE * VKBDX);
-   YPADDING      = retroh_crop - (YSIDE * VKBDY);
+   YPADDING      = retroh_crop + (retroy_crop * 2) - (YSIDE * VKBDY);
 
    int XBASEKEY  = (XPADDING > 0) ? (XPADDING / 2) : 0;
    int YBASEKEY  = (YPADDING > 0) ? (YPADDING / 2) : 0;
@@ -672,8 +674,10 @@ void print_vkbd(void)
 
    if (VKBDY_GAP_POS)
    {
+      unsigned lores_offset = (retrow_crop < 361 && retrow_crop % 2 == 0);
+
       draw_fbox(vkbd_x_min-FONT_WIDTH, YOFFSET+YBASEKEY+(VKBDY_GAP_POS * YSIDE)+FONT_HEIGHT,
-                vkbd_x_max-vkbd_x_min+FONT_WIDTH+XKEYSPACING+FONT_WIDTH, vkbd_y_gap_pad-FONT_HEIGHT,
+                vkbd_x_max-vkbd_x_min+(FONT_WIDTH * 2)+XKEYSPACING+((lores_offset) ? -XKEYSPACING : 0), vkbd_y_gap_pad-FONT_HEIGHT,
                 0, BRD_ALPHA);
 #if 0
       draw_fbox(XOFFSET+XBASEKEY+(VKBDX_GAP_POS * XSIDE)+vkbd_x_gap_pad, YOFFSET+YBASEKEY+(VKBDY_GAP_POS * YSIDE)+FONT_HEIGHT,
@@ -692,14 +696,14 @@ void print_vkbd(void)
       corner_y_min = 0;
       corner_y_max = vkbd_y_min - YKEYSPACING;
       draw_fbox(0, corner_y_min,
-                retrow_crop, corner_y_max,
+                retrow, corner_y_max,
                 0, BRD_ALPHA);
 
       /* Bottom */
       corner_y_min = vkbd_y_max + YKEYSPACING;
-      corner_y_max = retroh_crop - vkbd_y_max - YKEYSPACING;
+      corner_y_max = retroh - vkbd_y_max - YKEYSPACING;
       draw_fbox(0, corner_y_min,
-                retrow_crop, corner_y_max,
+                retrow, corner_y_max,
                 0, BRD_ALPHA);
 
       /* Left + Right */
@@ -709,7 +713,7 @@ void print_vkbd(void)
                 vkbd_x_min - XKEYSPACING, corner_y_max,
                 0, BRD_ALPHA);
       draw_fbox(vkbd_x_max + (XKEYSPACING * 2) + ((lores_offset) ? -XKEYSPACING : 0), corner_y_min,
-                retrow_crop - vkbd_x_max - (XKEYSPACING * (lores_offset ? 1 : 2)), corner_y_max,
+                retrow - vkbd_x_max - (XKEYSPACING * (lores_offset ? 1 : 2)), corner_y_max,
                 0, BRD_ALPHA);
    }
 
@@ -1078,8 +1082,8 @@ void input_vkbd(void)
 
    if (p_x != 0 && p_y != 0 && (p_x != last_pointer_x || p_y != last_pointer_y))
    {
-      int px = (int)((p_x + 0x7fff) * retrow_crop / 0xffff);
-      int py = (int)((p_y + 0x7fff) * retroh_crop / 0xffff);
+      int px = (int)((p_x + 0x7fff) * retrow_crop / 0xffff + retrox_crop);
+      int py = (int)((p_y + 0x7fff) * retroh_crop / 0xffff + retroy_crop);
 
       last_pointer_x = p_x;
       last_pointer_y = p_y;

--- a/sources/src/drawing.c
+++ b/sources/src/drawing.c
@@ -4121,13 +4121,13 @@ static void center_image (void)
 			visible_left_border = (vidinfo->drawbuffer.inxoffset - DISPLAY_LEFT_SHIFT) << currprefs.gfx_resolution;
 		}
 	}
+#endif /* __LIBRETRO__ */
 
 	if (visible_left_border > max_diwlastword - 32)
 		visible_left_border = max_diwlastword - 32;
 	if (visible_left_border < 0)
 		visible_left_border = 0;
 	visible_left_border &= ~((xshift (1, lores_shift)) - 1);
-#endif /* __LIBRETRO__ */
 
 	//write_log (_T("%d %d %d %d %d\n"), max_diwlastword, vidinfo->drawbuffer.inwidth, lores_shift, currprefs.gfx_resolution, visible_left_border);
 
@@ -4168,9 +4168,6 @@ static void center_image (void)
 
 		}
 	}
-#else
-	if (!thisframe_y_adjust)
-		thisframe_y_adjust = minfirstline;
 #endif /* __LIBRETRO__ */
 
 	/* Make sure the value makes sense */

--- a/sources/src/statusline.c
+++ b/sources/src/statusline.c
@@ -286,6 +286,8 @@ void draw_status_line_single(int monid, uae_u8 *buf, int bpp, int y, int totalwi
     else
         x_start = td_numbers_padx;
 
+    x_start += retrox_crop;
+
     int floppies = 1;
     if (gui_data.hd >= 0 || gui_data.cd >= 0 || gui_data.md >= 0)
     {


### PR DESCRIPTION
- Replace cropping and centering with video callback offset
  Closes #640
- Improve game specific centering and resolution switch (Super Skidmarks) hacks for less false positives
- Allow using NTSC pixel aspect while in full height PAL without cutting the image

Also:
- Fix audio filter type not updating properly after restart
- Mute empty floppy drive by default


The old 2021 core will get these too once the dust settles and no major issues are discovered.
