### PR TITLE
WHDLoad QuitKey improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,10 @@ Pre-installed WHDLoad LHA archives can be launched directly without any kind of 
 - Kickstarts will be copied automatically to the helper image
 - To update `WHDLoad:` simply delete the directory or the HDF
 
+- WHDLoad quit key is hardcoded to unused `$2B` = `AK_NUMBERSIGN` = `RETROK_HASH` which does not exist in modern keyboards.
+    - Keyboard shortcut: LCtrl + Backslash
+    - Virtual keyboard shortcut: Shifted RESET button
+
 #### Overrides at startup
 
 - **(Red)** Hold fire button for launch selector

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1224,7 +1224,7 @@ static void retro_set_core_options()
          "puae_use_whdload_nowritecache",
          "Media > WHDLoad NoWriteCache",
          "WHDLoad NoWriteCache",
-         "Write save data immediately or on WHDLoad quit. Write cache enabled runs the core a few frames after frontend quit in order to trigger WHDLoad quit and flush the cache.\nCore restart required.",
+         "Write cache requires running the core a few frames after closing content to trigger WHDLoad quit and flush cache to disk.\nQuitKey = '$2b' = '#' = 'LCtrl + Backslash'.\nCore restart required.",
          NULL,
          "media",
          {
@@ -6034,11 +6034,11 @@ static void whdload_quitkey(void)
    log_cb(RETRO_LOG_INFO, "WHDLoad QuitKey triggered..\n");
    libretro_runloop_active = false;
 
-   retro_key_down(RETROK_KP_MINUS);
+   retro_key_down(RETROK_HASH);
    for (i = 0; i < 2; i++)
       m68k_go(1, 1);
 
-   retro_key_up(RETROK_KP_MINUS);
+   retro_key_up(RETROK_HASH);
    for (i = 0; i < retro_refresh * 2; i++)
       m68k_go(1, 1);
 
@@ -6684,7 +6684,7 @@ static bool retro_create_config(void)
                {
                   bool whdload_prefs_changes  = false;
                   bool whdload_quitkey_set    = false;
-                  const char *whdload_quitkey = "$4a";
+                  const char *whdload_quitkey = "$2b"; /* AK_NUMBERSIGN = RETROK_HASH */
 
                   while (fgets(whdload_buf, sizeof(whdload_buf), whdload_prefs_fp))
                   {
@@ -6716,7 +6716,7 @@ static bool retro_create_config(void)
                      strlcat(whdload_buf_new, whdload_buf_row, sizeof(whdload_buf_new));
                   }
 
-                  /* retro_unload triggers QuitKey (Numpad -) and runs a few frames so that data gets saved */
+                  /* retro_unload triggers QuitKey (RETROK_HASH) and runs a few frames so that data gets saved */
                   if (!opt_use_whdload_nowritecache && !whdload_quitkey_set)
                   {
                      snprintf(whdload_buf_row, sizeof(whdload_buf_row), "QuitKey=%s\n", whdload_quitkey);

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -939,6 +939,24 @@ static void process_key(unsigned disable_keys)
          else if (!retro_key_event_state[i] && retro_key_state[i])
             retro_key_state[i] = 0;
       }
+      /* Special RETROK_HASH faker in LCtrl + Backslash = AK_NUMBERSIGN */
+      if (i == RETROK_BACKSLASH && (retro_key_state[RETROK_LCTRL] || retro_key_state[RETROK_HASH]))
+      {
+         if (retro_key_event_state[RETROK_BACKSLASH] && !retro_key_event_state[RETROK_HASH] && !retro_key_state[RETROK_HASH])
+         {
+            retro_key_down(RETROK_HASH);
+            retro_key_state[RETROK_HASH] = 1;
+            retro_key_event_state[RETROK_HASH] = 1;
+            retro_key_up(RETROK_BACKSLASH);
+            retro_key_state[RETROK_BACKSLASH] = 0;
+         }
+         else if (!retro_key_event_state[RETROK_BACKSLASH] && retro_key_event_state[RETROK_HASH] && retro_key_state[RETROK_HASH])
+         {
+            retro_key_up(RETROK_HASH);
+            retro_key_state[RETROK_HASH] = 0;
+            retro_key_event_state[RETROK_HASH] = 0;
+         }
+      }
       else if (keyboard_translation[i] != -1)
       {
          /* Override cursor keys if used as a RetroPad */

--- a/libretro/libretro-mapper.h
+++ b/libretro/libretro-mapper.h
@@ -119,6 +119,7 @@ static retro_keymap retro_keys[RETROK_LAST] =
    {JOYSTICK_RIGHT,     "JOYSTICK_RIGHT",      "Joystick Right"},
    {JOYSTICK_FIRE,      "JOYSTICK_FIRE",       "Joystick Fire"},
    {JOYSTICK_2ND_FIRE,  "JOYSTICK_2ND_FIRE",   "Joystick Fire 2"},
+   {RETROK_HASH,        "RETROK_HASH",         "WHDLoad QuitKey"},
    {RETROK_BACKSPACE,   "RETROK_BACKSPACE",    "Keyboard Backspace"},
    {RETROK_TAB,         "RETROK_TAB",          "Keyboard Tab"},
 /* {RETROK_CLEAR,       "RETROK_CLEAR",        "Keyboard Clear"}, */


### PR DESCRIPTION
- Moved hardcoded WHDLoad QuitKey from `RETROK_KP_MINUS` to `RETROK_HASH`
- Allowed pressing `RETROK_HASH` with `RETROK_LCTRL + RETROK_BACKSLASH`
- Added specific VKBD + RetroPad mapper button
