### PR TITLE
fix: Correct fseek error check in my_fsize

### DIFF
--- a/retrodep/fsdb_host.c
+++ b/retrodep/fsdb_host.c
@@ -428,7 +428,7 @@ uae_s64 my_fsize(struct my_openfile_s* mos) {
 #else
 	size_t size = 0;
 	int current = ftell(mos->fp);
-	if (fseek(mos->fp, 0, SEEK_END)) {
+	if (fseek(mos->fp, 0, SEEK_END) < 0) {
 		write_log("my_fsize: fseek on file '%s' failed\n", mos->path);
 		return -1;
 	}


### PR DESCRIPTION
## Description

This change treats fseek failure as `< 0` in file size check.

The libretro VFS API requires fskeek to return "the new position": https://github.com/libretro/libretro-common/blob/7040de62e/include/libretro.h#L2853

## Motivation and context

`my_fsize()` was treating non-zero seek results as failure, but the wrapped seek API may return the new position on success.

To fix this, we check for negative return values instead to avoid false "fseek failed" errors and restore WHDLoad startup script execution.

## How has this been tested?

To reproduce:

> The file is visible to the Amiga but something goes wrong when trying to run it. If I type type "cd c" then "dir" in the Amiga shell, the shell returns "dir: file is not executable" and this line is generated in the log:

> 2026-04-12 16:22:31.255 T:1679796    info <general>: AddOnLog: game.libretro.uae: my_fsize: fseek on file '/Users/user/Library/Application Support/Kodi/userdata/addon_data/game.libretro.uae/save/WHDLoad/C/Dir' failed

Testing in progress here: https://github.com/kodi-game/game.libretro.uae/issues/3