### PR TITLE
Fix zlib build with Xcode 16.3+ Apple toolchains

### DIFF
--- a/deps/libz/zutil.h
+++ b/deps/libz/zutil.h
@@ -128,7 +128,7 @@ extern char z_errmsg[10][21]; /* indexed by 2-zlib_error */
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #      include <unix.h> /* for fdopen */
 #    else
-#      ifndef fdopen
+#      if !defined(fdopen) && !defined(__APPLE__)
 #        define fdopen(fd,mode) NULL /* No fdopen() */
 #      endif
 #    endif


### PR DESCRIPTION
## Description

This PR fixes building zlib with Xcode 16.3+.

zutil.h's legacy fdopen fallback collides with the system declaration in recent Apple SDKs.

Guard the fallback on `__APPLE__` so Apple builds use the system fdopen().

## Motivation and context

The issue is reported with *Xcode 16.3 / Apple clang 17 / macOS 15.4 SDK* and *Xcode 16.4 / macOS 15.5 SDK*, while *Xcode 16.1 / Apple clang 16* is reported to work.

## How has this been tested?

Tested building https://github.com/kodi-game/game.libretro.uae, which builds this core.

On recent Apple software: macOS 26.3.1, Xcode 26.4.1, Clang 21.0.0.

Result: build succeeds.