### PR TITLE
check if reference is null, and check if struct member is null before…

### DIFF
--- a/retrodep/threaddep/thread.h
+++ b/retrodep/threaddep/thread.h
@@ -129,7 +129,9 @@ void uae_sem_init (uae_sem_t *sem, int pshared, unsigned int value);
 
 STATIC_INLINE void uae_sem_destroy (uae_sem_t *sem)
 {
-    sem_destroy (sem->sem);
+    if(sem && sem->sem) {
+        sem_destroy (sem->sem);
+    }
 }
 
 STATIC_INLINE void uae_sem_post (uae_sem_t *sem)


### PR DESCRIPTION
… calling sem_destroy


This seems to be at least a realistic enough fix for https://github.com/libretro/libretro-uae/issues/729#issuecomment-4469270823

at least this patch gets to a working game without removing filesys_cleanup or modifying anything in sysconfig. 